### PR TITLE
Mode button debounce time reset automatically

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,8 +247,6 @@ void Timing_Decrement(void)
 #ifdef SPARK_WLAN_ENABLE
 	if(!WLAN_SMART_CONFIG_START && BUTTON_GetDebouncedTime(BUTTON1) >= 3000)
 	{
-		BUTTON_ResetDebouncedState(BUTTON1);
-
 		if(!SPARK_WLAN_SLEEP)
 		{
 
@@ -257,8 +255,6 @@ void Timing_Decrement(void)
 	}
 	else if(BUTTON_GetDebouncedTime(BUTTON1) >= 7000)
 	{
-		BUTTON_ResetDebouncedState(BUTTON1);
-
 		WLAN_DELETE_PROFILES = 1;
 	}
 

--- a/src/stm32_it.cpp
+++ b/src/stm32_it.cpp
@@ -317,8 +317,6 @@ void EXTI2_IRQHandler(void)
 		/* Clear the EXTI line pending bit */
 		EXTI_ClearITPendingBit(EXTI_Line2);//BUTTON1_EXTI_LINE
 
-		BUTTON_DEBOUNCED_TIME[BUTTON1] = 0x00;
-
 		/* Disable BUTTON1 Interrupt */
 		BUTTON_EXTI_Config(BUTTON1, DISABLE);
 
@@ -482,10 +480,14 @@ void TIM1_CC_IRQHandler(void)
 
 		if (BUTTON_GetState(BUTTON1) == BUTTON1_PRESSED)
 		{
+			/* Accumulate debounce time when BUTTON1 is pressed */
 			BUTTON_DEBOUNCED_TIME[BUTTON1] += BUTTON_DEBOUNCE_INTERVAL;
 		}
 		else
 		{
+			/* Reset debounce time when BUTTON1 is released */
+			BUTTON_DEBOUNCED_TIME[BUTTON1] = 0x00;
+
 			/* Disable TIM1 CC4 Interrupt */
 			TIM_ITConfig(TIM1, TIM_IT_CC4, DISABLE);
 


### PR DESCRIPTION
This change cleans up some code, and makes it easier to use the Mode button in user code.  Sample application:

```cpp
#include "application.h"
bool ModeBtnPressed();

void setup() {
  Spark.disconnect(); // Disconnect from the Cloud on startup
}

void loop() {
  if(ModeBtnPressed()) {
    RGB.control(true);
    for(uint8_t x=0; x<2; x++) { // Ready the Hyperdrive!
      RGB.color(255,0,0); //red
      delay(100);
      RGB.color(255,100,0); //orange
      delay(100);
      RGB.color(255,255,0); //yellow
      delay(100);
      RGB.color(0,255,0); //green
      delay(100);
      RGB.color(0,255,255); //cyan
      delay(100);
      RGB.color(0,0,255); //blue
      delay(100);
      RGB.color(255,0,255); //magenta
      delay(100);
      RGB.color(255,255,255); //white
      delay(100);
    }
    RGB.control(false);
    Spark.connect(); // Engage Hyperdrive!
  }
}

bool ModeBtnPressed() {
  if(BUTTON_GetDebouncedTime(BUTTON1) > 100) {
    return 1;
  }
  return 0;
}
```

Before this, we had to use code like this to protect against blocking the Smart Config:

```cpp
#include "application.h"
bool ModeBtnPressed();
uint32_t startTime = 0;

void setup() {
    startTime = millis(); // capture the time that our app starts
    Spark.disconnect();
}

void loop() {
    if(ModeBtnPressed()) {
        RGB.control(true);
        for(uint8_t x=0; x<2; x++) { // Ready the Hyperdrive!
            RGB.color(255,0,0); //red
            delay(100);
            RGB.color(255,100,0); //orange
            delay(100);
            RGB.color(255,255,0); //yellow
            delay(100);
            RGB.color(0,255,0); //green
            delay(100);
            RGB.color(0,255,255); //cyan
            delay(100);
            RGB.color(0,0,255); //blue
            delay(100);
            RGB.color(255,0,255); //magenta
            delay(100);
            RGB.color(255,255,255); //white
            delay(100);
        }
        RGB.control(false);
        Spark.connect(); // Engage Hyperdrive!
    }
}

bool ModeBtnPressed() {
    if(millis() - startTime > 10000) { // wait at least 10s for smart config hooks
        if(BUTTON_GetDebouncedTime(BUTTON1) > 100) {
            BUTTON_ResetDebouncedState(BUTTON1);
            return 1;
        }
    }
    return 0;
}
```