### PR TITLE
Adding possibility for callback value registration with Spark::function

### DIFF
--- a/inc/spark_utilities.h
+++ b/inc/spark_utilities.h
@@ -107,6 +107,7 @@ class SparkClass {
 public:
 	static void variable(const char *varKey, void *userVar, Spark_Data_TypeDef userVarType);
 	static void function(const char *funcKey, int (*pFunc)(String paramString));
+	static void function(const char *funcKey, int (*pFunc)(String paramString, void* pv), void* pv);
 	static void publish(const char *eventName);
 	static void publish(const char *eventName, const char *eventData);
 	static void publish(const char *eventName, const char *eventData, int ttl);

--- a/inc/spark_utilities.h
+++ b/inc/spark_utilities.h
@@ -107,7 +107,7 @@ class SparkClass {
 public:
 	static void variable(const char *varKey, void *userVar, Spark_Data_TypeDef userVarType);
 	static void function(const char *funcKey, int (*pFunc)(String paramString));
-	static void function(const char *funcKey, int (*pFunc)(String paramString, void* pv), void* pv);
+	static void function(const char *funcKey, int (*pFuncPv)(String paramString, void* pv), void* pv);
 	static void publish(const char *eventName);
 	static void publish(const char *eventName, const char *eventData);
 	static void publish(const char *eventName, const char *eventData, int ttl);
@@ -129,7 +129,7 @@ public:
 	static bool connected(void);
 	static void connect(void);
 	static void disconnect(void);
-        static void process(void);
+	static void process(void);
 	static String deviceID(void);
 	static void syncTime(void);
 };

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -66,7 +66,7 @@ struct User_Func_Lookup_Table_t
 	char userFuncKey[USER_FUNC_KEY_LENGTH];
 	char userFuncArg[USER_FUNC_ARG_LENGTH];
 	int userFuncRet;
-  void* userFuncPv;
+	void* userFuncPv;
 	bool userFuncSchedule;
 } User_Func_Lookup_Table[USER_FUNC_MAX_COUNT];
 
@@ -222,7 +222,7 @@ void SparkClass::variable(const char *varKey, void *userVar, Spark_Data_TypeDef 
 }
 
 void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString)) {
-    function(funcKey, (int (*)(String, void*))pFunc, NULL);
+	function(funcKey, (int (*)(String, void*))pFunc, NULL);
 }
 
 void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString, void* pv), void* pv)
@@ -230,7 +230,7 @@ void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString, 
 	if(User_Func_Count == USER_FUNC_MAX_COUNT || pFunc == NULL || funcKey == NULL)
 		return;
 	
-    for(int i = 0; i < User_Func_Count; i++)
+	for(int i = 0; i < User_Func_Count; i++)
 	{
 		if(
 			User_Func_Lookup_Table[i].pUserFuncPv == pFunc &&

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -62,12 +62,12 @@ struct User_Var_Lookup_Table_t
 
 struct User_Func_Lookup_Table_t
 {
-  int (*pUserFunc)(String userArg);
-  int (*pUserFuncPv)(String userArg, void* pv);
+	int (*pUserFunc)(String userArg);
+	int (*pUserFuncPv)(String userArg, void* pv);
 	char userFuncKey[USER_FUNC_KEY_LENGTH];
 	char userFuncArg[USER_FUNC_ARG_LENGTH];
 	int userFuncRet;
-  void* userFuncPv;
+	void* userFuncPv;
 	bool userFuncSchedule;
 } User_Func_Lookup_Table[USER_FUNC_MAX_COUNT];
 
@@ -239,8 +239,8 @@ void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString))
 		}
 
 		User_Func_Lookup_Table[User_Func_Count].pUserFunc = pFunc;
-    User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = NULL;
-    
+		User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = NULL;
+
 		memset(User_Func_Lookup_Table[User_Func_Count].userFuncArg, 0, USER_FUNC_ARG_LENGTH);
 		memset(User_Func_Lookup_Table[User_Func_Count].userFuncKey, 0, USER_FUNC_KEY_LENGTH);
 		memcpy(User_Func_Lookup_Table[User_Func_Count].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH);
@@ -251,29 +251,29 @@ void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString))
 
 void SparkClass::function(const char *funcKey, int (*pFuncPv)(String paramString, void* pv), void* pv)
 {
-  int i = 0;
-  if(NULL != pFuncPv && funcKey != NULL)
-  {
-    if(User_Func_Count == USER_FUNC_MAX_COUNT)
-      return;
-    for(i = 0; i < User_Func_Count; i++)
-    {
-      if(User_Func_Lookup_Table[i].pUserFuncPv == pFuncPv && User_Func_Lookup_Table[i].userFuncPv == pv && (0 == strncmp(User_Func_Lookup_Table[i].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH)))
-      {
-        return;
-      }
-    }
+	int i = 0;
+	if(NULL != pFuncPv && funcKey != NULL)
+	{
+		if(User_Func_Count == USER_FUNC_MAX_COUNT)
+			return;
+		for(i = 0; i < User_Func_Count; i++)
+		{
+			if(User_Func_Lookup_Table[i].pUserFuncPv == pFuncPv && User_Func_Lookup_Table[i].userFuncPv == pv && (0 == strncmp(User_Func_Lookup_Table[i].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH)))
+			{
+				return;
+			}
+		}
 
-    User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = pFuncPv;
-    User_Func_Lookup_Table[User_Func_Count].pUserFunc = NULL;
-    User_Func_Lookup_Table[User_Func_Count].userFuncPv = pv;
+		User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = pFuncPv;
+		User_Func_Lookup_Table[User_Func_Count].pUserFunc = NULL;
+		User_Func_Lookup_Table[User_Func_Count].userFuncPv = pv;
 
-    memset(User_Func_Lookup_Table[User_Func_Count].userFuncArg, 0, USER_FUNC_ARG_LENGTH);
-    memset(User_Func_Lookup_Table[User_Func_Count].userFuncKey, 0, USER_FUNC_KEY_LENGTH);
-    memcpy(User_Func_Lookup_Table[User_Func_Count].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH);
-    User_Func_Lookup_Table[User_Func_Count].userFuncSchedule = false;
-    User_Func_Count++;
-  }
+		memset(User_Func_Lookup_Table[User_Func_Count].userFuncArg, 0, USER_FUNC_ARG_LENGTH);
+		memset(User_Func_Lookup_Table[User_Func_Count].userFuncKey, 0, USER_FUNC_KEY_LENGTH);
+		memcpy(User_Func_Lookup_Table[User_Func_Count].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH);
+		User_Func_Lookup_Table[User_Func_Count].userFuncSchedule = false;
+		User_Func_Count++;
+	}
 }
 
 void SparkClass::publish(const char *eventName)
@@ -1025,12 +1025,12 @@ int userFuncSchedule(const char *funcKey, const char *paramString)
 			User_Func_Lookup_Table[i].userFuncSchedule = true;
 			//return User_Func_Lookup_Table[i].pUserFunc(User_Func_Lookup_Table[i].userFuncArg);
 			if (User_Func_Lookup_Table[i].pUserFuncPv != NULL)
-      {
-        return User_Func_Lookup_Table[i].pUserFuncPv(pString, User_Func_Lookup_Table[i].userFuncPv);
-      } else
-      {
-        return User_Func_Lookup_Table[i].pUserFunc(pString);
-      }
+			{
+				return User_Func_Lookup_Table[i].pUserFuncPv(pString, User_Func_Lookup_Table[i].userFuncPv);
+			} else
+			{
+				return User_Func_Lookup_Table[i].pUserFunc(pString);
+			}
 		}
 	}
 	return -1;

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -62,12 +62,11 @@ struct User_Var_Lookup_Table_t
 
 struct User_Func_Lookup_Table_t
 {
-	int (*pUserFunc)(String userArg);
 	int (*pUserFuncPv)(String userArg, void* pv);
 	char userFuncKey[USER_FUNC_KEY_LENGTH];
 	char userFuncArg[USER_FUNC_ARG_LENGTH];
 	int userFuncRet;
-	void* userFuncPv;
+  void* userFuncPv;
 	bool userFuncSchedule;
 } User_Func_Lookup_Table[USER_FUNC_MAX_COUNT];
 
@@ -222,58 +221,33 @@ void SparkClass::variable(const char *varKey, void *userVar, Spark_Data_TypeDef 
   }
 }
 
-void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString))
-{
-	int i = 0;
-	if(NULL != pFunc && NULL != funcKey)
-	{
-		if(User_Func_Count == USER_FUNC_MAX_COUNT)
-			return;
-
-		for(i = 0; i < User_Func_Count; i++)
-		{
-			if(User_Func_Lookup_Table[i].pUserFunc == pFunc && (0 == strncmp(User_Func_Lookup_Table[i].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH)))
-			{
-				return;
-			}
-		}
-
-		User_Func_Lookup_Table[User_Func_Count].pUserFunc = pFunc;
-		User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = NULL;
-
-		memset(User_Func_Lookup_Table[User_Func_Count].userFuncArg, 0, USER_FUNC_ARG_LENGTH);
-		memset(User_Func_Lookup_Table[User_Func_Count].userFuncKey, 0, USER_FUNC_KEY_LENGTH);
-		memcpy(User_Func_Lookup_Table[User_Func_Count].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH);
-		User_Func_Lookup_Table[User_Func_Count].userFuncSchedule = false;
-		User_Func_Count++;
-	}
+void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString)) {
+    function(funcKey, (int (*)(String, void*))pFunc, NULL);
 }
 
-void SparkClass::function(const char *funcKey, int (*pFuncPv)(String paramString, void* pv), void* pv)
+void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString, void* pv), void* pv)
 {
-	int i = 0;
-	if(NULL != pFuncPv && funcKey != NULL)
+	if(User_Func_Count == USER_FUNC_MAX_COUNT || pFunc == NULL || funcKey == NULL)
+		return;
+	
+    for(int i = 0; i < User_Func_Count; i++)
 	{
-		if(User_Func_Count == USER_FUNC_MAX_COUNT)
+		if(
+			User_Func_Lookup_Table[i].pUserFuncPv == pFunc &&
+			User_Func_Lookup_Table[i].userFuncPv == pv &&
+			!strncmp(User_Func_Lookup_Table[i].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH)
+		)
 			return;
-		for(i = 0; i < User_Func_Count; i++)
-		{
-			if(User_Func_Lookup_Table[i].pUserFuncPv == pFuncPv && User_Func_Lookup_Table[i].userFuncPv == pv && (0 == strncmp(User_Func_Lookup_Table[i].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH)))
-			{
-				return;
-			}
-		}
-
-		User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = pFuncPv;
-		User_Func_Lookup_Table[User_Func_Count].pUserFunc = NULL;
-		User_Func_Lookup_Table[User_Func_Count].userFuncPv = pv;
-
-		memset(User_Func_Lookup_Table[User_Func_Count].userFuncArg, 0, USER_FUNC_ARG_LENGTH);
-		memset(User_Func_Lookup_Table[User_Func_Count].userFuncKey, 0, USER_FUNC_KEY_LENGTH);
-		memcpy(User_Func_Lookup_Table[User_Func_Count].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH);
-		User_Func_Lookup_Table[User_Func_Count].userFuncSchedule = false;
-		User_Func_Count++;
 	}
+
+	User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = pFunc;
+	User_Func_Lookup_Table[User_Func_Count].userFuncPv = pv;
+
+	memset(User_Func_Lookup_Table[User_Func_Count].userFuncArg, 0, USER_FUNC_ARG_LENGTH);
+	memset(User_Func_Lookup_Table[User_Func_Count].userFuncKey, 0, USER_FUNC_KEY_LENGTH);
+	memcpy(User_Func_Lookup_Table[User_Func_Count].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH);
+	User_Func_Lookup_Table[User_Func_Count].userFuncSchedule = false;
+	User_Func_Count++;
 }
 
 void SparkClass::publish(const char *eventName)
@@ -1024,13 +998,8 @@ int userFuncSchedule(const char *funcKey, const char *paramString)
 			memcpy(User_Func_Lookup_Table[i].userFuncArg, paramString, paramLength);
 			User_Func_Lookup_Table[i].userFuncSchedule = true;
 			//return User_Func_Lookup_Table[i].pUserFunc(User_Func_Lookup_Table[i].userFuncArg);
-			if (User_Func_Lookup_Table[i].pUserFuncPv != NULL)
-			{
-				return User_Func_Lookup_Table[i].pUserFuncPv(pString, User_Func_Lookup_Table[i].userFuncPv);
-			} else
-			{
-				return User_Func_Lookup_Table[i].pUserFunc(pString);
-			}
+
+			return User_Func_Lookup_Table[i].pUserFuncPv(pString, User_Func_Lookup_Table[i].userFuncPv);
 		}
 	}
 	return -1;

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -230,7 +230,7 @@ void SparkClass::function(const char *funcKey, int (*pFuncPv)(String paramString
 	if(User_Func_Count == USER_FUNC_MAX_COUNT || pFuncPv == NULL || funcKey == NULL)
 		return;
 	
-	for(byte i = 0; i < User_Func_Count; i++)
+	for(int i = 0; i < User_Func_Count; i++)
 	{
 		if(
 			User_Func_Lookup_Table[i].pUserFuncPv == pFuncPv &&

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -230,7 +230,7 @@ void SparkClass::function(const char *funcKey, int (*pFuncPv)(String paramString
 	if(User_Func_Count == USER_FUNC_MAX_COUNT || pFuncPv == NULL || funcKey == NULL)
 		return;
 	
-	for(int i = 0; i < User_Func_Count; i++)
+	for(byte i = 0; i < User_Func_Count; i++)
 	{
 		if(
 			User_Func_Lookup_Table[i].pUserFuncPv == pFuncPv &&

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -225,22 +225,22 @@ void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString))
 	function(funcKey, (int (*)(String, void*))pFunc, NULL);
 }
 
-void SparkClass::function(const char *funcKey, int (*pFunc)(String paramString, void* pv), void* pv)
+void SparkClass::function(const char *funcKey, int (*pFuncPv)(String paramString, void* pv), void* pv)
 {
-	if(User_Func_Count == USER_FUNC_MAX_COUNT || pFunc == NULL || funcKey == NULL)
+	if(User_Func_Count == USER_FUNC_MAX_COUNT || pFuncPv == NULL || funcKey == NULL)
 		return;
 	
 	for(int i = 0; i < User_Func_Count; i++)
 	{
 		if(
-			User_Func_Lookup_Table[i].pUserFuncPv == pFunc &&
+			User_Func_Lookup_Table[i].pUserFuncPv == pFuncPv &&
 			User_Func_Lookup_Table[i].userFuncPv == pv &&
 			!strncmp(User_Func_Lookup_Table[i].userFuncKey, funcKey, USER_FUNC_KEY_LENGTH)
 		)
 			return;
 	}
 
-	User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = pFunc;
+	User_Func_Lookup_Table[User_Func_Count].pUserFuncPv = pFuncPv;
 	User_Func_Lookup_Table[User_Func_Count].userFuncPv = pv;
 
 	memset(User_Func_Lookup_Table[User_Func_Count].userFuncArg, 0, USER_FUNC_ARG_LENGTH);


### PR DESCRIPTION
...allowing implementations of function calls to class members, should resolve #313

Allows following pattern as mentioned by @m-mcgowan on this thread: http://community.spark.io/t/how-to-point-spark-function-to-a-class-function/6986/4

```cpp
class MyClass {
   static int callback(String arg, void* pv) {
       return ((MyClass*)pv)->handle(arg);
   }

   virtual int handle(String arg) {
       return 42;
   }
}

MyClass my_class;
Spark.function("myfunc", MyClass::callback, &my_class);
```