### PR TITLE
added contribution link

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Unless stated elsewhere, file headers or otherwise, all files herein are license
 
 ### CONTRIBUTE
 
-Want to contribute to the Spark Core project? Follow [this link]() to find out how.
+Want to contribute to the Spark Core project? Follow [this link](http://spark.github.io/) to find out how.
 
 ### CONNECT
 


### PR DESCRIPTION
Was looking for details on contribution protocol and noticed a dead link - found what I was looking for on the project page so I linked there.