### PR TITLE
C++11 and attach interrupts using lambdas

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -48,10 +48,12 @@ SRC_PATH = $(PROJECT_DIR)
 # ensure defined
 USRSRC += ""
 
+# The entire firmware is gnu+11 safe
+CPPFLAGS += -std=gnu++11
+
 # determine where user sources are, relative to project root
 ifdef APP
 USRSRC = applications/$(APP)/
-CPPFLAGS += -std=gnu++11
 
 ifndef TARGET
 TARGET ?= $(notdir $(APP))
@@ -61,7 +63,6 @@ endif
 
 ifdef TEST
 USRSRC = tests/$(TEST)/
-CPPFLAGS += -std=gnu++11
 ifndef TARGET
 TARGET ?= $(notdir $(TEST))
 TARGETDIR ?= $(USRSRC)
@@ -254,7 +255,6 @@ $(BUILD_PATH)%.o : $(SRC_PATH)%.cpp
 
 # Other Targets
 clean:
-	
 	$(RM) $(ALLOBJ) $(ALLDEPS) $(TARGETDIR)$(TARGET).elf $(TARGETDIR)$(TARGET).bin $(TARGETDIR)$(TARGET).hex $(TARGETDIR)$(TARGET).map
 	$(RMDIR) $(BUILD_PATH)
 	@echo

--- a/build/makefile
+++ b/build/makefile
@@ -63,12 +63,16 @@ endif
 
 ifdef TEST
 USRSRC = tests/$(TEST)/
+CPPFLAGS += -fexceptions
 ifndef TARGET
 TARGET ?= $(notdir $(TEST))
 TARGETDIR ?= $(USRSRC)
 endif
 include $(PROJECT_DIR)tests/tests.mk
 -include $(PROJECT_DIR)$(USRSRC)test.mk
+else
+# We only want exceptions for a TEST build which uses them in catch
+CPPFLAGS += -fno-exceptions
 endif
 
 # user sources specified, so override application.cpp and pull in files from 
@@ -140,7 +144,7 @@ CFLAGS += -DRELEASE_BUILD
 endif
 
 # C++ specific flags
-CPPFLAGS += -fno-rtti -fno-exceptions
+CPPFLAGS += -fno-rtti
 
 # Linker flags
 LDFLAGS += -T$(PROJECT_DIR)linker/linker_stm32f10x_md_dfu.ld -nostartfiles -Xlinker --gc-sections 

--- a/inc/application.h
+++ b/inc/application.h
@@ -45,4 +45,14 @@
 #include "spark_wiring_tone.h"
 #include "spark_wiring_eeprom.h"
 
+// min/max/round defines are no longer used in the firmware main
+// namespace but are provided for use in applications for back
+// compatibility. If applications or libraries want to use a clean
+// C++ namespace then #define SPARK_APP_USES_CLEAN_NAMESPACE
+#ifndef SPARK_APP_USES_CLEAN_NAMESPACE
+using std::min;
+using std::max;
+#include <math.h>
+#endif
+
 #endif /* APPLICATION_H_ */

--- a/inc/spark_wiring.h
+++ b/inc/spark_wiring.h
@@ -40,31 +40,6 @@
 #include "spark_wiring_random.h"
 
 /*
-* Basic variables
-*/
-
-#if !defined(min)
-#   define min(a,b)                ((a)<(b)?(a):(b))
-#endif
-#if !defined(max)
-#   define max(a,b)                ((a)>(b)?(a):(b))
-#endif
-#if !defined(constrain)
-#   define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
-#endif
-#if !defined(round)
-#   define round(x)                ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
-#endif
-
-#define HIGH 0x1
-#define LOW 0x0
-
-#define boolean bool
-
-//#define NULL ((void *)0)
-#define NONE ((uint8_t)0xFF)
-
-/*
 * Pin mapping. Borrowed from Wiring
 */
 

--- a/inc/spark_wiring_constants.h
+++ b/inc/spark_wiring_constants.h
@@ -31,19 +31,14 @@
 /*
 * Basic variables
 */
-
-#if !defined(min)
-#   define min(a,b)                ((a)<(b)?(a):(b))
-#endif
-#if !defined(max)
-#   define max(a,b)                ((a)>(b)?(a):(b))
-#endif
+// for: isnan, isinf, round
+#include <cmath>
+// for: min max
+#include <algorithm>
 #if !defined(constrain)
 #   define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #endif
-#if !defined(round)
-#   define round(x)                ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
-#endif
+/* #endif */
 
 #define HIGH 0x1
 #define LOW 0x0

--- a/inc/spark_wiring_interrupts.h
+++ b/inc/spark_wiring_interrupts.h
@@ -28,6 +28,7 @@
 #ifndef __SPARK_WIRING_INTERRUPTS_H
 #define __SPARK_WIRING_INTERRUPTS_H
 
+#include <functional>
 #include "spark_wiring.h"
 
 /*
@@ -40,7 +41,7 @@ typedef enum InterruptMode {
   FALLING
 } InterruptMode;
 
-typedef void (*voidFuncPtr)(void);
+typedef  std::function<void()> voidFuncPtr;
 
 void attachInterrupt(uint16_t pin, voidFuncPtr handler, InterruptMode mode);
 void detachInterrupt(uint16_t pin);

--- a/src/spark_wiring_interrupts.cpp
+++ b/src/spark_wiring_interrupts.cpp
@@ -51,7 +51,7 @@ extern STM32_Pin_Info PIN_MAP[TOTAL_PINS];
 
 // Create a structure for user ISR function pointers
  typedef struct exti_channel {
-    void (*handler)();
+    voidFuncPtr handler;
 } exti_channel;
 
 //Array to hold user ISR function pointers

--- a/src/spark_wiring_print.cpp
+++ b/src/spark_wiring_print.cpp
@@ -206,8 +206,8 @@ size_t Print::printFloat(double number, uint8_t digits)
 { 
   size_t n = 0;
   
-  if (isnan(number)) return print("nan");
-  if (isinf(number)) return print("inf");
+  if (std::isnan(number)) return print("nan");
+  if (std::isinf(number)) return print("inf");
   if (number > 4294967040.0) return print ("ovf");  // constant determined empirically
   if (number <-4294967040.0) return print ("ovf");  // constant determined empirically
   

--- a/tests/unit/std_functions.cpp
+++ b/tests/unit/std_functions.cpp
@@ -1,0 +1,15 @@
+#include "catch.hpp"
+
+#include "application.h"
+
+TEST_CASE("Can use min() in main namespace in an application") {
+    REQUIRE(min(10, 5)==5);
+}
+
+TEST_CASE("Can use max() in main namespace in an application") {
+    REQUIRE(min(10.0, 5.0)==10.0);
+}
+
+TEST_CASE("Can use round() in main namespace in an application") {
+    REQUIRE(round(10.7)==11);
+}


### PR DESCRIPTION
I wanted to support multiple instances of a class in a library which uses attachInterrupt

I can now do:
    auto mylambda = [&]() {this->touchSense();} ;
    attachInterrupt(m_sensorPin, mylambda , RISING);

Standard function pointers still work.

I needed some cleanups to allow the entire library to build using gnu++11 and some minimal tidy up to allow <functional> to be #included.