### PR TITLE
Fix PINMAP for BTN. Was pointing to LED4

### DIFF
--- a/src/spark_wiring.cpp
+++ b/src/spark_wiring.cpp
@@ -75,7 +75,7 @@ STM32_Pin_Info PIN_MAP[TOTAL_PINS] =
   { GPIOB, GPIO_Pin_1, ADC_Channel_9, TIM3, TIM_Channel_4, (PinMode)NONE, 0, 0 },
   { GPIOA, GPIO_Pin_3, ADC_Channel_3, TIM2, TIM_Channel_4, (PinMode)NONE, 0, 0 },
   { GPIOA, GPIO_Pin_2, ADC_Channel_2, TIM2, TIM_Channel_3, (PinMode)NONE, 0, 0 },
-  { GPIOA, GPIO_Pin_10, NONE, NULL, NONE, (PinMode)NONE, 0, 0 }
+  { GPIOB, GPIO_Pin_2, NONE, NULL, NONE, (PinMode)NONE, 0, 0 }
 };
 
 /*


### PR DESCRIPTION
Updated STM32_Pin_Info PIN_MAP[TOTAL_PINS] to have the proper info for the 20th Pin which has been defined as BTN. 

Previously was LED4 according to the schematic and local debugging.