### PR TITLE
Fix for Time.zone issue.

### DIFF
--- a/wiring/src/spark_wiring_time.cpp
+++ b/wiring/src/spark_wiring_time.cpp
@@ -158,11 +158,8 @@ static void Set_CalendarTime(struct tm calendar_time)
 /* Refresh Unix/RTC time cache */
 static void Refresh_UnixTime_Cache(time_t unix_time)
 {
-	if(unix_time != unix_time_cache)
-	{
 		calendar_time_cache = Convert_UnixTime_To_CalendarTime(unix_time);
 		unix_time_cache = unix_time;
-	}
 }
 
 /* current hour */

--- a/wiring/src/spark_wiring_time.cpp
+++ b/wiring/src/spark_wiring_time.cpp
@@ -127,7 +127,7 @@ static time_t Convert_CalendarTime_To_UnixTime(struct tm calendar_time)
 static time_t Get_UnixTime(void)
 {
 	time_t unix_time = (time_t)HAL_RTC_Get_Counter();
-	return unix_time += time_zone_cache;
+	return unix_time;
 }
 
 /* Get converted Calendar time */
@@ -311,7 +311,7 @@ void TimeClass::zone(float GMT_Offset)
 	{
 		return;
 	}
-	time_zone_cache = GMT_Offset * 1800;
+	time_zone_cache = GMT_Offset * 3600;
 }
 
 /* set the given time as unix/rtc time */

--- a/wiring/src/spark_wiring_time.cpp
+++ b/wiring/src/spark_wiring_time.cpp
@@ -127,7 +127,7 @@ static time_t Convert_CalendarTime_To_UnixTime(struct tm calendar_time)
 static time_t Get_UnixTime(void)
 {
 	time_t unix_time = (time_t)HAL_RTC_Get_Counter();
-	return unix_time;
+	return unix_time += time_zone_cache;
 }
 
 /* Get converted Calendar time */
@@ -311,7 +311,7 @@ void TimeClass::zone(float GMT_Offset)
 	{
 		return;
 	}
-	time_zone_cache = GMT_Offset * 3600;
+	time_zone_cache = GMT_Offset * 1800;
 }
 
 /* set the given time as unix/rtc time */


### PR DESCRIPTION
This will fix https://github.com/spark/firmware/issues/280 for:

1.) Changed `Get_UnixTime` to factory in the **time_zone_cache** parameter

2.) Change the `Time.zone()` formula to multiple GMT_offset by 1800 instead 0f 3600 as tests showed that the original increase/decrease 2 hours per UTC

Sample code for test verification is here: https://gist.github.com/kennethlimcp/fe25df7bc1619654ff76