### PR TITLE
Printout mac address in listening mode

### DIFF
--- a/hal/inc/wlan_hal.h
+++ b/hal/inc/wlan_hal.h
@@ -31,6 +31,9 @@
 #include "debug.h"
 #include "socket_hal.h"
 
+//#define DEBUG_WIFI    // Define to show all the flags in debug output
+//#define DEBUG_WAN_WD  // Define to show all SW WD activity in debug output
+
 #ifdef	__cplusplus
 extern "C" {
 #endif

--- a/wiring/src/wifi_credentials_reader.cpp
+++ b/wiring/src/wifi_credentials_reader.cpp
@@ -27,6 +27,8 @@
 #include "delay_hal.h"
 #include "spark_utilities.h"
 
+using namespace spark;
+
 WiFiCredentialsReader::WiFiCredentialsReader(ConnectCallback connect_callback)
 {
   this->connect_callback = connect_callback;

--- a/wiring/src/wifi_credentials_reader.cpp
+++ b/wiring/src/wifi_credentials_reader.cpp
@@ -80,6 +80,21 @@ void WiFiCredentialsReader::read(void)
         String id = Spark.deviceID();
         print(id.c_str());
         print("\r\n");
+
+        byte mac[6];
+        WiFi.macAddress(mac);
+        print("MAC: ");
+        serial.print(mac[5],HEX);
+        print(":");
+        serial.print(mac[4],HEX);
+        print(":");
+        serial.print(mac[3],HEX);
+        print(":");
+        serial.print(mac[2],HEX);
+        print(":");
+        serial.print(mac[1],HEX);
+        print(":");
+        serial.print(mac[0],HEX);
     }
     else if ('f' == c)
     {


### PR DESCRIPTION
This will help new users get the mac address simply via Listening mode "i". 

Community issue: https://community.spark.io/t/getting-mac-address-of-unconnected-core/8473