### PR TITLE
Shifted #defines for DEBUG to the correct file

### DIFF
--- a/hal/inc/wlan_hal.h
+++ b/hal/inc/wlan_hal.h
@@ -31,6 +31,9 @@
 #include "debug.h"
 #include "socket_hal.h"
 
+//#define DEBUG_WIFI    // Define to show all the flags in debug output
+//#define DEBUG_WAN_WD  // Define to show all SW WD activity in debug output
+
 #ifdef	__cplusplus
 extern "C" {
 #endif

--- a/wiring/src/spark_wlan.cpp
+++ b/wiring/src/spark_wlan.cpp
@@ -39,10 +39,6 @@ WLanConfig ip_config;
 
 uint32_t wlan_watchdog;
 
-//#define DEBUG_WIFI    // Define to show all the flags in debug output
-//#define DEBUG_WAN_WD  // Define to show all SW WD activity in debug output
-
-
 volatile uint8_t WLAN_DISCONNECT;
 volatile uint8_t WLAN_MANUAL_CONNECT = 0; //For Manual connection, set this to 1
 volatile uint8_t WLAN_DELETE_PROFILES;


### PR DESCRIPTION
After the HAL refactoring, this 2 debug statement is residing in the old file and when uncommented, does not printout the corresponding debug messages.