### PR TITLE
Implementation as discussed for issue #347.

### DIFF
--- a/main/src/main.cpp
+++ b/main/src/main.cpp
@@ -212,7 +212,7 @@ void app_setup_and_loop(void)
     while (1)
     {
         DECLARE_SYS_HEALTH(ENTERED_WLAN_Loop);
-        SPARK_WLAN_Loop();
+        Spark_Idle();
 
         static uint8_t SPARK_WIRING_APPLICATION = 0;
         if(SPARK_WLAN_SLEEP || !SPARK_CLOUD_CONNECT || SPARK_CLOUD_CONNECTED || SPARK_WIRING_APPLICATION)

--- a/main/tests/core-v1/testapp1/cloud.cpp
+++ b/main/tests/core-v1/testapp1/cloud.cpp
@@ -4,7 +4,7 @@
 
 test(Spark_Publish_Silently_Fails_When_Not_Connected) {
     Spark.disconnect();
-    SPARK_WLAN_Loop();    
+    Spark.process();    
     Spark.publish("hello", "world", 60, PRIVATE);
 }
 

--- a/main/tests/libraries/unit-test/SparkParty.cpp
+++ b/main/tests/libraries/unit-test/SparkParty.cpp
@@ -85,7 +85,7 @@ void unit_test_setup()
     // store circular buffer at end of external flash.
     log = Flashee::Devices::createCircularBuffer((store.pageCount()-pages)*pageSize, store.length());
     // direct output to Serial and to the circular buffer
-    tee = new PrintTee(*Test::out, *new CircularBufferPrint(*log, Spark_Idle));
+    tee = new PrintTee(*Test::out, *new CircularBufferPrint(*log, Spark.process));
     Test::out = tee;
 #else
     Test::out = &Serial;

--- a/main/tests/libraries/unit-test/SparkParty.cpp
+++ b/main/tests/libraries/unit-test/SparkParty.cpp
@@ -85,7 +85,7 @@ void unit_test_setup()
     // store circular buffer at end of external flash.
     log = Flashee::Devices::createCircularBuffer((store.pageCount()-pages)*pageSize, store.length());
     // direct output to Serial and to the circular buffer
-    tee = new PrintTee(*Test::out, *new CircularBufferPrint(*log, SPARK_WLAN_Loop));
+    tee = new PrintTee(*Test::out, *new CircularBufferPrint(*log, Spark_Idle));
     Test::out = tee;
 #else
     Test::out = &Serial;

--- a/wiring/inc/spark_utilities.h
+++ b/wiring/inc/spark_utilities.h
@@ -164,7 +164,7 @@ bool Spark_Communication_Loop(void);
 void Multicast_Presence_Announcement(void);
 void Spark_Signal(bool on);
 void Spark_SetTime(unsigned long dateTime);
-
+void Spark_Process_Events();
 void Spark_Prepare_To_Save_File(uint32_t sFlashAddress, uint32_t fileSize);
 void Spark_Prepare_For_Firmware_Update(void);
 void Spark_Finish_Firmware_Update(void);

--- a/wiring/inc/spark_wlan.h
+++ b/wiring/inc/spark_wlan.h
@@ -32,19 +32,21 @@
 
 extern "C" {
 
-//void Set_NetApp_Timeout(void);
-//void Clear_NetApp_Dhcp(void);
-//void Start_Smart_Config(void);
-
-/* WLAN Application related callbacks passed to wlan_init */
-//void WLAN_Async_Callback(long lEventType, char *data, unsigned char length);
-//char *WLAN_Firmware_Patch(unsigned long *length);
-//char *WLAN_Driver_Patch(unsigned long *length);
-//char *WLAN_BootLoader_Patch(unsigned long *length);
-
 uint32_t SPARK_WLAN_SetNetWatchDog(uint32_t timeOutInuS);
 void SPARK_WLAN_Setup(void (*presence_announcement_callback)(void));
-void SPARK_WLAN_Loop(void);
+
+/**
+ * Run background processing. This function should be called as often as possible by user code.
+ * @param force_events when true, runs cloud event pump in addition to maintaining the wifi and cloud connection.
+ */
+void Spark_Idle(bool force_events=false);
+
+/**
+ * The old method 
+ */
+void SPARK_WLAN_Loop(void) __attribute__ ((deprecated));
+inline void SPARK_WLAN_Loop(void) { Spark_Idle(); }
+
 void SPARK_WLAN_SmartConfigProcess();
 
 /* Spark Cloud APIs */

--- a/wiring/inc/spark_wlan.h
+++ b/wiring/inc/spark_wlan.h
@@ -44,7 +44,7 @@ void Spark_Idle(bool force_events=false);
 /**
  * The old method 
  */
-void SPARK_WLAN_Loop(void) __attribute__ ((deprecated));
+void SPARK_WLAN_Loop(void) __attribute__ ((deprecated("Please use Spark.process() instead.")));
 inline void SPARK_WLAN_Loop(void) { Spark_Idle(); }
 
 void SPARK_WLAN_SmartConfigProcess();

--- a/wiring/src/spark_utilities.cpp
+++ b/wiring/src/spark_utilities.cpp
@@ -445,6 +445,12 @@ void SparkClass::disconnect(void)
 
 void SparkClass::process(void)
 {
+    // run the background processing loop, and specifically also pump cloud events
+    Spark_Idle(true);
+}
+
+void Spark_Process_Events()
+{
     if (SPARK_CLOUD_SOCKETED && !Spark_Communication_Loop())
     {
         SPARK_FLASH_UPDATE = 0;

--- a/wiring/src/spark_wiring.cpp
+++ b/wiring/src/spark_wiring.cpp
@@ -248,18 +248,18 @@ void delay(unsigned long ms)
       break;
     }
 
-    if (SPARK_WLAN_SLEEP)
+    if (SPARK_WLAN_SLEEP || System.mode()==MANUAL || (System.mode()==SEMI_AUTOMATIC && !Spark.connected()))
     {
-      //Do not yield for SPARK_WLAN_Loop()
+      //Do not yield for Spark_Idle()
     }
     else if ((elapsed_millis >= spark_loop_elapsed_millis) || (spark_loop_total_millis >= SPARK_LOOP_DELAY_MILLIS))
     {
       spark_loop_elapsed_millis = elapsed_millis + SPARK_LOOP_DELAY_MILLIS;
-      //spark_loop_total_millis is reset to 0 in SPARK_WLAN_Loop()
+      //spark_loop_total_millis is reset to 0 in Spark_Idle()
       do
       {
         //Run once if the above condition passes
-        SPARK_WLAN_Loop();
+        Spark_Idle();
       }
       while (SPARK_FLASH_UPDATE);//loop during OTA update
     }

--- a/wiring/src/spark_wiring_wifi.cpp
+++ b/wiring/src/spark_wiring_wifi.cpp
@@ -159,7 +159,7 @@ the same way.
 
             if(!SPARK_WLAN_SLEEP)//if Spark.sleep() is not called
             {
-                // Reset remaining state variables in SPARK_WLAN_Loop()
+                // Reset remaining state variables in Spark_Idle()
                 SPARK_WLAN_SLEEP = 1;
 
                 // Do not automatically connect to the cloud

--- a/wiring/src/spark_wlan.cpp
+++ b/wiring/src/spark_wlan.cpp
@@ -181,7 +181,7 @@ void SPARK_WLAN_Setup(void (*presence_announcement_callback)(void))
     Spark_Protocol_Init();
 }
 
-void SPARK_WLAN_Loop(void)
+void Spark_Idle(bool force_events/*=false*/)
 {
   static int cfod_count = 0;
   HAL_Notify_WDT();
@@ -193,7 +193,7 @@ void SPARK_WLAN_Loop(void)
   {
     if (SPARK_WLAN_STARTED)
     {
-      DEBUG("Resetting CC3000!");
+      DEBUG("Resetting WLAN!");
       CLR_WLAN_WD();
       WLAN_CONNECTED = 0;
       WLAN_DHCP = 0;
@@ -373,9 +373,9 @@ void SPARK_WLAN_Loop(void)
       }
     }
 
-    if(SPARK_FLASH_UPDATE || System.mode() != MANUAL)
+    if(SPARK_FLASH_UPDATE || force_events || System.mode() != MANUAL)
     {
-      Spark.process();
+      Spark_Process_Events();
     }
   }
 }

--- a/wiring/src/spark_wlan.cpp
+++ b/wiring/src/spark_wlan.cpp
@@ -181,146 +181,134 @@ void SPARK_WLAN_Setup(void (*presence_announcement_callback)(void))
     Spark_Protocol_Init();
 }
 
-void Spark_Idle(bool force_events/*=false*/)
+static int cfod_count = 0;
+
+/**
+ * Reset or initialize the network connection as required.
+ */
+void manage_network_connection()
 {
-  static int cfod_count = 0;
-  HAL_Notify_WDT();
-
-  ON_EVENT_DELTA();
-  spark_loop_total_millis = 0;
-
-  if (SPARK_WLAN_RESET || SPARK_WLAN_SLEEP || WLAN_WD_TO())
-  {
-    if (SPARK_WLAN_STARTED)
+    if (SPARK_WLAN_RESET || SPARK_WLAN_SLEEP || WLAN_WD_TO())
     {
-      DEBUG("Resetting WLAN!");
-      CLR_WLAN_WD();
-      WLAN_CONNECTED = 0;
-      WLAN_DHCP = 0;
-      SPARK_WLAN_RESET = 0;
-      SPARK_WLAN_STARTED = 0;
-      SPARK_CLOUD_SOCKETED = 0;
-      SPARK_CLOUD_CONNECTED = 0;
-      SPARK_FLASH_UPDATE = 0;
-      Spark_Error_Count = 0;
-      cfod_count = 0;
+        if (SPARK_WLAN_STARTED)
+        {
+            DEBUG("Resetting WLAN!");
+            CLR_WLAN_WD();
+            WLAN_CONNECTED = 0;
+            WLAN_DHCP = 0;
+            SPARK_WLAN_RESET = 0;
+            SPARK_WLAN_STARTED = 0;
+            SPARK_CLOUD_SOCKETED = 0;
+            SPARK_CLOUD_CONNECTED = 0;
+            SPARK_FLASH_UPDATE = 0;
+            Spark_Error_Count = 0;
+            cfod_count = 0;
 
-      WiFi.off();
+            WiFi.off();
+        }
     }
-  }
-  else
-  {
-    if (!SPARK_WLAN_STARTED)
+    else
     {
-      if (!WLAN_MANUAL_CONNECT && !WLAN_DISCONNECT)
-      {
-        ARM_WLAN_WD(CONNECT_TO_ADDRESS_MAX);
-      }
-      WiFi.connect();
+        if (!SPARK_WLAN_STARTED)
+        {
+            if (!WLAN_MANUAL_CONNECT && !WLAN_DISCONNECT)
+            {
+                ARM_WLAN_WD(CONNECT_TO_ADDRESS_MAX);
+            }
+            WiFi.connect();
+        }
+    }    
+}
+
+void manage_smart_config() 
+{
+    if (WLAN_SMART_CONFIG_START)
+    {
+        Start_Smart_Config();
     }
-  }
+    else if (WLAN_MANUAL_CONNECT && !WLAN_DHCP)
+    {
+        CLR_WLAN_WD();
+        WiFi.disconnect();
+        wlan_manual_connect();
+        WLAN_MANUAL_CONNECT = 0;
+    }
 
-  if (WLAN_SMART_CONFIG_START)
-  {
-    Start_Smart_Config();
-  }
-  else if (WLAN_MANUAL_CONNECT && !WLAN_DHCP)
-  {
-    CLR_WLAN_WD();
-    WiFi.disconnect();
-    wlan_manual_connect();
-    WLAN_MANUAL_CONNECT = 0;
-  }
-
-  // Complete Smart Config Process:
-  // 1. if smart config is done
-  // 2. CC3000 established AP connection
-  // 3. DHCP IP is configured
-  // then send mDNS packet to stop external SmartConfig application
+    // Complete Smart Config Process:
+    // 1. if smart config is done
+    // 2. CC3000 established AP connection
+    // 3. DHCP IP is configured
+    // then send mDNS packet to stop external SmartConfig application
     if ((WLAN_SMART_CONFIG_STOP == 1) && (WLAN_DHCP == 1) && (WLAN_CONNECTED == 1))
     {
         wlan_smart_config_cleanup();
         WLAN_SMART_CONFIG_STOP = 0;
-    }
+    }    
+}
 
-  if (WLAN_DHCP && !SPARK_WLAN_SLEEP)
-  {
-    if (ip_config.aucIP[0] == 0)
+void manage_ip_config()
+{
+    if (WLAN_DHCP && !SPARK_WLAN_SLEEP)
     {
-      HAL_Delay_Milliseconds(100);
-      wlan_fetch_ipconfig(&ip_config);
+        if (ip_config.aucIP[0] == 0)
+        {
+            HAL_Delay_Milliseconds(100);
+            wlan_fetch_ipconfig(&ip_config);
+        }
     }
-  }
-  else if (ip_config.aucIP[0] != 0)
-  {
-    memset(&ip_config, 0, sizeof(ip_config));
-  }
+    else if (ip_config.aucIP[0] != 0)
+    {
+        memset(&ip_config, 0, sizeof(ip_config));
+    }    
+}
 
-  if (SPARK_CLOUD_CONNECT == 0)
-  {
+void disconnect_cloud()
+{
     if (SPARK_CLOUD_SOCKETED || SPARK_CLOUD_CONNECTED)
     {
-      Spark_Disconnect();
+        Spark_Disconnect();
 
-      SPARK_FLASH_UPDATE = 0;
-      SPARK_CLOUD_CONNECTED = 0;
-      SPARK_CLOUD_SOCKETED = 0;
+        SPARK_FLASH_UPDATE = 0;
+        SPARK_CLOUD_CONNECTED = 0;
+        SPARK_CLOUD_SOCKETED = 0;
 
-      if(!WLAN_DISCONNECT)
-      {
-        LED_SetRGBColor(RGB_COLOR_GREEN);
-        LED_On(LED_RGB);
-      }
+        if(!WLAN_DISCONNECT)
+        {
+            LED_SetRGBColor(RGB_COLOR_GREEN);
+            LED_On(LED_RGB);
+        }
+    }    
+}
+
+void handle_cloud_errors()
+{
+    LED_SetRGBColor(RGB_COLOR_RED);
+
+    while (Spark_Error_Count != 0)
+    {
+      LED_On(LED_RGB);
+      HAL_Delay_Milliseconds(500);
+      LED_Off(LED_RGB);
+      HAL_Delay_Milliseconds(500);
+      Spark_Error_Count--;
     }
 
-    return;
-  }
+    // TODO Send the Error Count to Cloud: NVMEM_Spark_File_Data[ERROR_COUNT_FILE_OFFSET]
 
-  if (WLAN_DHCP && !SPARK_WLAN_SLEEP && !SPARK_CLOUD_SOCKETED)
-  {
-    if (Spark_Error_Count)
+    // Reset Error Count
+    wlan_clear_error_count();    
+}
+
+void handle_cfod()
+{
+    if ((cfod_count += RESET_ON_CFOD) == MAX_FAILED_CONNECTS)
     {
-      LED_SetRGBColor(RGB_COLOR_RED);
-
-      while (Spark_Error_Count != 0)
-      {
-        LED_On(LED_RGB);
-        HAL_Delay_Milliseconds(500);
-        LED_Off(LED_RGB);
-        HAL_Delay_Milliseconds(500);
-        Spark_Error_Count--;
-      }
-
-      // TODO Send the Error Count to Cloud: NVMEM_Spark_File_Data[ERROR_COUNT_FILE_OFFSET]
-
-      // Reset Error Count
-      wlan_clear_error_count();
+      SPARK_WLAN_RESET = RESET_ON_CFOD;
+      ERROR("Resetting CC3000 due to %d failed connect attempts", MAX_FAILED_CONNECTS);
     }
 
-    SPARK_LED_FADE = 0;
-    LED_SetRGBColor(RGB_COLOR_CYAN);
-    LED_On(LED_RGB);
-
-    if (Spark_Connect() >= 0)
+    if (Internet_Test() < 0)
     {
-      cfod_count  = 0;
-      SPARK_CLOUD_SOCKETED = 1;
-    }
-    else
-    {
-      if (SPARK_WLAN_RESET)
-      {
-        return;
-      }
-
-      if ((cfod_count += RESET_ON_CFOD) == MAX_FAILED_CONNECTS)
-      {
-        SPARK_WLAN_RESET = RESET_ON_CFOD;
-        ERROR("Resetting CC3000 due to %d failed connect attempts", MAX_FAILED_CONNECTS);
-      }
-
-      if (Internet_Test() < 0)
-      {
         // No Internet Connection
         if ((cfod_count += RESET_ON_CFOD) == MAX_FAILED_CONNECTS)
         {
@@ -329,55 +317,116 @@ void Spark_Idle(bool force_events/*=false*/)
         }
 
         Spark_Error_Count = 2;
-      }
-      else
-      {
+    }
+    else
+    {
         // Cloud not Reachable
         Spark_Error_Count = 3;
-      }
+    }    
+}
 
-      wlan_set_error_count(Spark_Error_Count);
-      SPARK_CLOUD_SOCKETED = 0;
-    }
-  }
+/**
+ * Establishes a socket connection to the cloud if not already present.
+ * - handles previous connection errors by flashing the LED
+ * - attempts to open a socket to the cloud
+ * - handles the CFOD
+ * 
+ * On return, SPARK_CLOUD_SOCKETED is set to true if the socket connection was successful.
+ */
 
-  if (SPARK_CLOUD_SOCKETED)
-  {
-    if (!SPARK_CLOUD_CONNECTED)
-    {
-      int err = Spark_Handshake();
+void establish_cloud_connection()
+{
+    if (WLAN_DHCP && !SPARK_WLAN_SLEEP && !SPARK_CLOUD_SOCKETED)
+    {    
+        if (Spark_Error_Count)
+            handle_cloud_errors();
 
-      if (err)
-      {
-        if (0 > err)
-        {
-          // Wrong key error, red
-          LED_SetRGBColor(RGB_COLOR_RED);
-        }
-        else if (1 == err)
-        {
-          // RSA decryption error, orange
-          LED_SetRGBColor(RGB_COLOR_ORANGE);
-        }
-        else if (2 == err)
-        {
-          // RSA signature verification error, magenta
-          LED_SetRGBColor(RGB_COLOR_MAGENTA);
-        }
-
+        SPARK_LED_FADE = 0;
+        LED_SetRGBColor(RGB_COLOR_CYAN);
         LED_On(LED_RGB);
-      }
-      else
-      {
-        SPARK_CLOUD_CONNECTED = 1;
-      }
-    }
 
-    if(SPARK_FLASH_UPDATE || force_events || System.mode() != MANUAL)
+        if (Spark_Connect() >= 0)
+        {
+            cfod_count  = 0;
+            SPARK_CLOUD_SOCKETED = 1;
+        }
+        else
+        {
+            SPARK_CLOUD_SOCKETED = 0;
+            if (!SPARK_WLAN_RESET)
+                handle_cfod();
+            wlan_set_error_count(Spark_Error_Count);
+        }
+    }    
+}
+
+/**
+ * Manages the handshake and cloud events when the cloud has a socket connected.
+ * @param force_events
+ */
+void handle_cloud_connection(bool force_events)
+{
+    if (SPARK_CLOUD_SOCKETED)
     {
-      Spark_Process_Events();
+        if (!SPARK_CLOUD_CONNECTED)
+        {
+            int err = Spark_Handshake();
+            if (err)
+            {
+                if (0 > err)
+                {
+                    // Wrong key error, red
+                    LED_SetRGBColor(RGB_COLOR_RED);
+                }
+                else if (1 == err)
+                {
+                    // RSA decryption error, orange
+                    LED_SetRGBColor(RGB_COLOR_ORANGE);
+                }
+                else if (2 == err)
+                {
+                    // RSA signature verification error, magenta
+                    LED_SetRGBColor(RGB_COLOR_MAGENTA);
+                }
+
+                LED_On(LED_RGB);
+            }
+            else
+            {
+                SPARK_CLOUD_CONNECTED = 1;
+            }
+        }
+
+        if(SPARK_FLASH_UPDATE || force_events || System.mode() != MANUAL)
+        {
+            Spark_Process_Events();
+        }
     }
-  }
+}
+
+void Spark_Idle(bool force_events/*=false*/)
+{  
+    HAL_Notify_WDT();
+
+    ON_EVENT_DELTA();
+    spark_loop_total_millis = 0;
+
+    manage_network_connection();
+
+    manage_smart_config();
+
+    manage_ip_config();
+
+    if (SPARK_CLOUD_CONNECT == 0)
+    {
+        disconnect_cloud();        
+    }
+    else // cloud connection is wanted
+    {
+        establish_cloud_connection();
+
+        handle_cloud_connection(force_events);
+    }
 }
 
 void HAL_WLAN_notify_simple_config_done() 


### PR DESCRIPTION
- `Spark.publish()` now runs the full background processing - this is wifi/clout connection management, plus pumping cloud events
- `SPARK_WLAN_Loop()` renamed to `Spark_Idle()`. The old function name is still available, but deprecated.
- `delay()` does not run the background loop when in manual mode, nor when in semi automatic mode and not connected. The rationale being that in manual mode, users are given full control over cloud processing, while in semi-automatic mode, the promise is to maintain the cloud connection once it is established.
