### PR TITLE
fix for #362. 

### DIFF
--- a/wiring/src/spark_utilities.cpp
+++ b/wiring/src/spark_utilities.cpp
@@ -524,7 +524,7 @@ int Spark_Receive(unsigned char *buf, uint32_t buflen)
 
 void begin_flash_file(int flashType, uint32_t sFlashAddress, uint32_t fileSize) 
 {
-  RGB.control(true);
+  RGB.control(false);
   RGB.color(RGB_COLOR_MAGENTA);
   SPARK_FLASH_UPDATE = flashType;
   TimingFlashUpdateTimeout = 0;


### PR DESCRIPTION
`RGB.control()` was being called (to return control of the RGB led to the system) but called with the wrong value! :-)