### PR TITLE
Add #define for ADC resolution

### DIFF
--- a/inc/spark_wiring.h
+++ b/inc/spark_wiring.h
@@ -126,6 +126,7 @@
 
 #define ADC1_DR_ADDRESS		((uint32_t)0x4001244C)
 #define ADC_DMA_BUFFERSIZE	10
+#define ADC_MAX_VALUE	4095
 #define ADC_SAMPLING_TIME	ADC_SampleTime_7Cycles5	//Allowed values: 1.5, 7.5 and 13.5 for "Dual slow interleaved mode"
 
 #define TIM_PWM_FREQ 500 //500Hz


### PR DESCRIPTION
Now I can programmatically determine voltage when you decide to change to a 10-bit ADC.
`3.3V * (analogRead(A0) / ADC_MAX_VALUE)`
-- or --
If you want to implement [analogReadResolution()](http://arduino.cc/en/Reference/AnalogReadResolution)
`#define ADC_RESOLUTION_BITS 12`
`3.3V * (analogRead(A0) / ((1 << ADC_RESOLUTION_BITS) - 1))`