### PR TITLE
Change preprocessor macro functions to static inline

### DIFF
--- a/inc/spark_wiring.h
+++ b/inc/spark_wiring.h
@@ -40,31 +40,6 @@
 #include "spark_wiring_random.h"
 
 /*
-* Basic variables
-*/
-
-#if !defined(min)
-#   define min(a,b)                ((a)<(b)?(a):(b))
-#endif
-#if !defined(max)
-#   define max(a,b)                ((a)>(b)?(a):(b))
-#endif
-#if !defined(constrain)
-#   define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
-#endif
-#if !defined(round)
-#   define round(x)                ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
-#endif
-
-#define HIGH 0x1
-#define LOW 0x0
-
-#define boolean bool
-
-//#define NULL ((void *)0)
-#define NONE ((uint8_t)0xFF)
-
-/*
 * Pin mapping. Borrowed from Wiring
 */
 

--- a/inc/spark_wiring_constants.h
+++ b/inc/spark_wiring_constants.h
@@ -27,22 +27,25 @@
 #ifndef SPARK_WIRING_CONSTANTS_H
 #define	SPARK_WIRING_CONSTANTS_H
 
+#include <type_traits>
 
 /*
 * Basic variables
 */
 
-template <typename T>
+template <typename T, typename U>
 static inline
-T max (T a, T b) { return ((a)>(b)?(a):(b)); }
+typename std::common_type<T, U>::type
+max (T a, U b) { return ((a)>(b)?(a):(b)); }
 
-template <typename T>
+template <typename T, typename U>
 static inline
-T min (T a, T b) { return ((a)<(b)?(a):(b)); }
+typename std::common_type<T, U>::type
+min (T a, U b) { return static_cast<typename std::common_type<T, U>::type>((a)<(b)?(a):(b)); }
 
-template <typename T>
+template <typename T, typename U, typename V>
 static inline
-T constrain (T amt, T low, T high) { return ((amt)<(low)?(low):((amt)>(high)?(high):(amt))); }
+T constrain (T amt, U low, V high) { return ((amt)<(low)?(low):((amt)>(high)?(high):(amt))); }
 
 template <typename T>
 static inline

--- a/inc/spark_wiring_constants.h
+++ b/inc/spark_wiring_constants.h
@@ -1,6 +1,6 @@
 /**
  ******************************************************************************
- * @file    spark_wiring.h
+ * @file    spark_wiring_constants.h
  * @author  Matthew McGowan
  * @version V1.0.0
  * @date    13-March-2013
@@ -50,7 +50,6 @@
 
 #define boolean bool
 
-//#define NULL ((void *)0)
 #define NONE ((uint8_t)0xFF)
 
 

--- a/inc/spark_wiring_constants.h
+++ b/inc/spark_wiring_constants.h
@@ -32,18 +32,21 @@
 * Basic variables
 */
 
-#if !defined(min)
-#   define min(a,b)                ((a)<(b)?(a):(b))
-#endif
-#if !defined(max)
-#   define max(a,b)                ((a)>(b)?(a):(b))
-#endif
-#if !defined(constrain)
-#   define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
-#endif
-#if !defined(round)
-#   define round(x)                ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
-#endif
+template <typename T>
+static inline
+T max (T a, T b) { return ((a)>(b)?(a):(b)); }
+
+template <typename T>
+static inline
+T min (T a, T b) { return ((a)<(b)?(a):(b)); }
+
+template <typename T>
+static inline
+T constrain (T amt, T low, T high) { return ((amt)<(low)?(low):((amt)>(high)?(high):(amt))); }
+
+template <typename T>
+static inline
+T round (T x) { return ((x)>=0?(long)((x)+0.5):(long)((x)-0.5)); }
 
 #define HIGH 0x1
 #define LOW 0x0


### PR DESCRIPTION
- will now respect namespace scoping
-- will not overwrite user defined functions
-- will allow users to use ::user::max() and ::max() as necessary
- will provide type safety