### PR TITLE
Adding support for custom serial bit parity

### DIFF
--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -50,8 +50,6 @@ typedef enum HAL_USART_Serial {
 /* Exported constants --------------------------------------------------------*/
 
 /* Exported macros -----------------------------------------------------------*/
-// IS_USART_CONFIG_VALID (return true for 8 data bit, no flow control, any parity, any stop byte configurations
-#define IS_USART_CONFIG_VALID(CONFIG) ( ((CONFIG>>2) != 0b11) && ((CONFIG>>4)==0b11) && ((CONFIG >> 6)==0b00) )
 
 /* Exported functions --------------------------------------------------------*/
 

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -50,6 +50,8 @@ typedef enum HAL_USART_Serial {
 /* Exported constants --------------------------------------------------------*/
 
 /* Exported macros -----------------------------------------------------------*/
+// IS_USART_CONFIG_VALID (return true for 8 data bit, no flow control, any parity, any stop byte configurations
+#define IS_USART_CONFIG_VALID(CONFIG) ( ((CONFIG>>2) != 0b11) && ((CONFIG>>4)==0b11) && ((CONFIG >> 6)==0b00) )
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -58,7 +60,7 @@ extern "C" {
 #endif
 
 void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer);
-void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud);
+void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud, uint8_t config);
 void HAL_USART_End(HAL_USART_Serial serial);
 uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data);
 int32_t HAL_USART_Available_Data(HAL_USART_Serial serial);

--- a/hal/src/core-v1/usart_hal.c
+++ b/hal/src/core-v1/usart_hal.c
@@ -122,8 +122,14 @@ void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer
   usartMap[serial]->usart_transmitting = false;
 }
 
-void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud)
+void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud, uint8_t config)
 {
+  // check to see if USART configuration is valid, if not, exit
+  if (!IS_USART_CONFIG_VALID(config)) {
+    usartMap[serial]->usart_enabled = false;
+    return;
+  }
+
   // AFIO clock enable
   RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
 
@@ -149,20 +155,42 @@ void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud)
   // Remap USARTn to alternate pins EG. USART1 to pins TX/PB6, RX/PB7
   GPIO_PinRemapConfig(usartMap[serial]->usart_pin_remap, ENABLE);
 
-  // USART default configuration
-  // USART configured as follow:
-  // - BaudRate = (set baudRate as 9600 baud)
-  // - Word Length = 8 Bits
-  // - One Stop Bit
-  // - No parity
-  // - Hardware flow control disabled (RTS and CTS signals)
-  // - Receive and transmit enabled
+  // USART configuration
   USART_InitStructure.USART_BaudRate = baud;
-  USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-  USART_InitStructure.USART_StopBits = USART_StopBits_1;
-  USART_InitStructure.USART_Parity = USART_Parity_No;
   USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
   USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
+  
+  // stop bits
+  switch (config & 0b00000011) {
+    case 0: // 1 stop bit
+      USART_InitStructure.USART_StopBits = USART_StopBits_1;
+      break;
+    case 1: // 2 stop bits
+      USART_InitStructure.USART_StopBits = USART_StopBits_2;
+      break;
+    case 2: // 0.5 stop bits
+      USART_InitStructure.USART_StopBits = USART_StopBits_0_5;
+      break;
+    case 3: // 1.5 stop bits
+      USART_InitStructure.USART_StopBits = USART_StopBits_1_5;
+      break;
+  }
+  
+  // parity configuration (impacts word length)
+  switch ((config & 0b00001100) >> 2) {
+    case 0: // none
+      USART_InitStructure.USART_Parity = USART_Parity_No;
+      USART_InitStructure.USART_WordLength = USART_WordLength_8b;
+      break;
+    case 1: // even
+      USART_InitStructure.USART_Parity = USART_Parity_Even;
+      USART_InitStructure.USART_WordLength = USART_WordLength_9b;
+      break;
+    case 2: // odd
+      USART_InitStructure.USART_Parity = USART_Parity_Odd;
+      USART_InitStructure.USART_WordLength = USART_WordLength_9b;
+      break;    
+  }
 
   // Configure USART
   USART_Init(usartMap[serial]->usart_peripheral, &USART_InitStructure);

--- a/hal/src/core-v1/usart_hal.c
+++ b/hal/src/core-v1/usart_hal.c
@@ -39,6 +39,8 @@ typedef enum USART_Num_Def {
 #define GPIO_Remap_None 0
 
 /* Private macro -------------------------------------------------------------*/
+// IS_USART_CONFIG_VALID(config) - returns true for 8 data bit, no flow control, any parity, any stop byte configurations
+#define IS_USART_CONFIG_VALID(CONFIG) ( ((CONFIG>>2) != 0b11) && ((CONFIG>>4)==0b11) && ((CONFIG >> 6)==0b00) )
 
 /* Private variables ---------------------------------------------------------*/
 typedef struct STM32_USART_Info {

--- a/hal/src/core-v1/usart_hal.c
+++ b/hal/src/core-v1/usart_hal.c
@@ -39,8 +39,8 @@ typedef enum USART_Num_Def {
 #define GPIO_Remap_None 0
 
 /* Private macro -------------------------------------------------------------*/
-// IS_USART_CONFIG_VALID(config) - returns true for 8 data bit, no flow control, any parity, any stop byte configurations
-#define IS_USART_CONFIG_VALID(CONFIG) ( ((CONFIG>>2) != 0b11) && ((CONFIG>>4)==0b11) && ((CONFIG >> 6)==0b00) )
+// IS_USART_CONFIG_VALID(config) - returns true for 8 data bit, any flow control, any parity, any stop byte configurations
+#define IS_USART_CONFIG_VALID(CONFIG) ( (((CONFIG & 0b00001100)>>2) != 0b11) && (((CONFIG & 0b00110000)>>4)==0b11) )
 
 /* Private variables ---------------------------------------------------------*/
 typedef struct STM32_USART_Info {

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -32,36 +32,48 @@
 
 /* serial configurations (some HW implementations may not support specific formats)
  * packet is configured as a collection of 2-bit flags for simple translation
- * bits 1(LSB)-2: stop bits [0b00=1 stop bit, 0b01=2 stop bits, 0b10=0.5 stop bits, 0b11 = 1.5 stop bits]
- * bits 3-4: parity [0b00=none, 0b01=even, 0b10=odd]
- * bits 5-6: data bits [0b00=5, 0b01=6, 0b10=7, 0b11=8]
- * bits 7-8(MSB): hardware flow control [0b00=none, 0b01=RTS, 0b10=CTS, 0b11=RTS+CTS]
- * Hardware implementation should include a macro to check for 
+ * bits 1-2: stop bits [0b00 = 1 stop bit, 0b01 = 2 stop bits, 0b10 = 0.5 stop bits, 0b11 = 1.5 stop bits]
+ * bits 3-4: parity [0b00 = none, 0b01 = even, 0b10 = odd]
+ * bits 5-6: data bits [0b00 = 5, 0b01 = 6, 0b10 = 7, 0b11 = 8]
+ * bits 7-8(MSB): hardware flow control [0b00 = none, 0b01 = RTS, 0b10 = CTS, 0b11 = RTS+CTS]
  */
-#define SERIAL_5N1 0b00000000
-#define SERIAL_6N1 0b00010000
-#define SERIAL_7N1 0b00100000
+ 
+/* Full list of standard serial configurations from Arduino
+  #define SERIAL_5N1 0b00000000
+  #define SERIAL_6N1 0b00010000
+  #define SERIAL_7N1 0b00100000
+  #define SERIAL_8N1 0b00110000
+  #define SERIAL_5N2 0b00000001
+  #define SERIAL_6N2 0b00010001
+  #define SERIAL_7N2 0b00100001
+  #define SERIAL_8N2 0b00110001
+  #define SERIAL_5E1 0b00000100
+  #define SERIAL_6E1 0b00010100
+  #define SERIAL_7E1 0b00100100
+  #define SERIAL_8E1 0b00110100
+  #define SERIAL_5E2 0b00000101
+  #define SERIAL_6E2 0b00010101
+  #define SERIAL_7E2 0b00100101
+  #define SERIAL_8E2 0b00110101
+  #define SERIAL_5O1 0b00001000
+  #define SERIAL_6O1 0b00011000
+  #define SERIAL_7O1 0b00101000
+  #define SERIAL_8O1 0b00111000
+  #define SERIAL_5O2 0b00001001
+  #define SERIAL_6O2 0b00011001
+  #define SERIAL_7O2 0b00101001
+  #define SERIAL_8O2 0b00111001
+*/
+
+// Enabled serial modes for the Spark Core (PLATFORM_ID: 0)
+#if defined(PLATFORM_ID) && (PLATFORM_ID == 0)
 #define SERIAL_8N1 0b00110000
-#define SERIAL_5N2 0b00000001
-#define SERIAL_6N2 0b00010001
-#define SERIAL_7N2 0b00100001
 #define SERIAL_8N2 0b00110001
-#define SERIAL_5E1 0b00000100
-#define SERIAL_6E1 0b00010100
-#define SERIAL_7E1 0b00100100
 #define SERIAL_8E1 0b00110100
-#define SERIAL_5E2 0b00000101
-#define SERIAL_6E2 0b00010101
-#define SERIAL_7E2 0b00100101
 #define SERIAL_8E2 0b00110101
-#define SERIAL_5O1 0b00001000
-#define SERIAL_6O1 0b00011000
-#define SERIAL_7O1 0b00101000
 #define SERIAL_8O1 0b00111000
-#define SERIAL_5O2 0b00001001
-#define SERIAL_6O2 0b00011001
-#define SERIAL_7O2 0b00101001
 #define SERIAL_8O2 0b00111001
+#endif
 
 class USARTSerial : public Stream
 {

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -30,6 +30,39 @@
 #include "spark_wiring_stream.h"
 #include "usart_hal.h"
 
+/* serial configurations (some HW implementations may not support specific formats)
+ * packet is configured as a collection of 2-bit flags for simple translation
+ * bits 1(LSB)-2: stop bits [0b00=1 stop bit, 0b01=2 stop bits, 0b10=0.5 stop bits, 0b11 = 1.5 stop bits]
+ * bits 3-4: parity [0b00=none, 0b01=even, 0b10=odd]
+ * bits 5-6: data bits [0b00=5, 0b01=6, 0b10=7, 0b11=8]
+ * bits 7-8(MSB): hardware flow control [0b00=none, 0b01=RTS, 0b10=CTS, 0b11=RTS+CTS]
+ * Hardware implementation should include a macro to check for 
+ */
+#define SERIAL_5N1 0b00000000
+#define SERIAL_6N1 0b00010000
+#define SERIAL_7N1 0b00100000
+#define SERIAL_8N1 0b00110000
+#define SERIAL_5N2 0b00000001
+#define SERIAL_6N2 0b00010001
+#define SERIAL_7N2 0b00100001
+#define SERIAL_8N2 0b00110001
+#define SERIAL_5E1 0b00000100
+#define SERIAL_6E1 0b00010100
+#define SERIAL_7E1 0b00100100
+#define SERIAL_8E1 0b00110100
+#define SERIAL_5E2 0b00000101
+#define SERIAL_6E2 0b00010101
+#define SERIAL_7E2 0b00100101
+#define SERIAL_8E2 0b00110101
+#define SERIAL_5O1 0b00001000
+#define SERIAL_6O1 0b00011000
+#define SERIAL_7O1 0b00101000
+#define SERIAL_8O1 0b00111000
+#define SERIAL_5O2 0b00001001
+#define SERIAL_6O2 0b00011001
+#define SERIAL_7O2 0b00101001
+#define SERIAL_8O2 0b00111001
+
 class USARTSerial : public Stream
 {
 private:

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -39,13 +39,12 @@ USARTSerial::USARTSerial(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_B
 
 void USARTSerial::begin(unsigned long baud)
 {
-  HAL_USART_Begin(_serial, baud);
+  begin(baud, SERIAL_8N1);
 }
 
-// TODO
-void USARTSerial::begin(unsigned long baud, byte config)
+void USARTSerial::begin(unsigned long baud, uint8_t config)
 {
-
+  HAL_USART_Begin(_serial, baud, config);
 }
 
 void USARTSerial::end()


### PR DESCRIPTION
Updates to the HAL branch to add support for other serial modes enabled on the STM32F103 based on discussions in the online forum: http://community.spark.io/t/custom-serial-bit-parity-with-spark-core-e-g-serial-8n2/10675.

Syntax follows the Arduino standard. For example, if you wanted communicate with a device requiring 8 data bits, 2 stop bits, and even parity @ 9600baud on Serial1, you would initialize as follows:

     Serial1.begin(9600, SERIAL_8E2);

Define statements are included for the most common 8 data bit serial modes (none/even/odd parity and 1/2 stop bits). The code will throw a compile error if the user tries to compile with a predefined configuration that isn't supported/defined for the device (e.g. SERIAL_5N1 on the Spark Core). However, the code will fail silently if a user manually enters an unsupported serial configuration (e.g. `0b00000000` = `SERIAL_5N1`). 

The STM32 also supports some more advanced features, such as flow control (currently disabled in `hal/src/core-v1/usart_hal.c`, though potentially supported if the pinouts are exposed). The full set of features can be found here: `platform/MCU/STM32F1xx/STM32_StdPeriph_Driver/inc`.