### PR TITLE
Warn people not to use the current open source firmware on Photons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Spark Core Firmware [![Backlog](https://badge.waffle.io/spark/firmware.png?label=backlog&title=backlog)](https://waffle.io/spark/firmware) [![Build Status](https://travis-ci.org/spark/firmware.svg)](https://travis-ci.org/spark/firmware)
+# Spark Core Firmware [![Build Status](https://travis-ci.org/spark/firmware.svg)](https://travis-ci.org/spark/firmware)
 
 This is the main source code repository of the Spark Core firmware libraries.
+
+*Photon users:* This firmware library is _not_ yet updated for the Photon; following these instructions with the Photon will not work. DO NOT program your Photon with this firmware. We are waiting for legal approval from Broadcom on some open source libraries, at which point we will be publishing the open source firmware for the Photon; we hope that will be available in the next couple of weeks.
 
 This firmware depends on two other libraries: the [Spark Common Library](http://www.github.com/spark/core-common-lib) and the [Spark Communication Library](http://www.github.com/spark/core-communication-lib)
 


### PR DESCRIPTION
Hey @m-mcgowan - not sure if this warning is 100% accurate, but I figured we should get something in here so that people don't try to use this firmware repo with the Photon. Let me know if this looks right to you.