### PR TITLE
Added EXTRA_CFLAGS to the build make file

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -138,6 +138,8 @@ else
 CFLAGS += -DRELEASE_BUILD
 endif
 
+CFLAGS += $(EXTRA_CFLAGS)
+
 # C++ specific flags
 CPPFLAGS += -fno-rtti -fno-exceptions
 


### PR DESCRIPTION
This allows extra CFLAGS to be added when the make command is called.  Much of what I want integrate into your firmware for my project requires certain constants to be set in the CFLAGS when they are compiled.  This will make that easy for me to accomplish.