### PR TITLE
Added the a hook to EXTRA_CFLAGS in user/build.mk. 

### DIFF
--- a/user/build.mk
+++ b/user/build.mk
@@ -47,3 +47,5 @@ CPPFLAGS += -std=gnu++11
 
 BUILTINS_EXCLUDE = malloc free realloc
 CFLAGS += $(addprefix -fno-builtin-,$(BUILTINS_EXCLUDE))
+
+CFLAGS += $(EXTRA_CFLAGS)


### PR DESCRIPTION
This allows the user code to be built with extra CFLAGS.  The user just has to set the shell variable EXTRA_CFLAGS and they will get added.

Something like:

export EXTRA_CFLAGS="flags"; make APP=userapp