### PR TITLE
set IWDG_SYSTEM_RESET to 0

### DIFF
--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -103,7 +103,7 @@ void HAL_Core_Config(void)
 	if (RCC_GetFlagStatus(RCC_FLAG_IWDGRST) != RESET)
 	{
 		/* IWDGRST flag set */
-		IWDG_SYSTEM_RESET = 1;
+		IWDG_SYSTEM_RESET = 0;
 
 		/* Clear reset flags */
 		RCC_ClearFlag();


### PR DESCRIPTION
- currently not used even in the new core bootloader
- prevents breathing white state when using SEMI_AUTO/MANUAL with latest firmware
- fixes https://github.com/spark/firmware-private/issues/99