### PR TITLE
Fix return type for NO_CLOUD version of SyncTime()

### DIFF
--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -100,7 +100,7 @@ public:
 
     bool syncTime(void)
     {
-        return CLOUD_FN(spark_protocol_send_time_request(sp()),(void)0);
+        return CLOUD_FN(spark_protocol_send_time_request(sp()), false);
     }
 
     static void sleep(long seconds) __attribute__ ((deprecated("Please use System.sleep() instead.")))


### PR DESCRIPTION
When the boolean return type was added to SyncTime, the SPARK_NO_CLOUD variant of the 
 CLOUD_FN macro in the syncTime function wasn't updated from void.

Compiling with SPARK_NO_CLOUD enabled throws an error.