### PR TITLE
Compile error for Core and SPARK_CLOUD=n and syncTime; CLOUD_FN returns void not false

### DIFF
--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -100,7 +100,7 @@ public:
 
     bool syncTime(void)
     {
-        return CLOUD_FN(spark_protocol_send_time_request(sp()),(void)0);
+        return CLOUD_FN(spark_protocol_send_time_request(sp()), false);
     }
 
     static void sleep(long seconds) __attribute__ ((deprecated("Please use System.sleep() instead.")))


### PR DESCRIPTION
During compile for a Core with SPARK_CLOUD=n showed the following error message:

In file included from ../wiring/inc/spark_wiring.h:45:0,
                 from ../../oinkbrew_firmware/oinkbrew/HttpClient.cpp:3:
../wiring/inc/spark_wiring_cloud.h: In member function 'bool CloudClass::syncTime()':
../wiring/inc/spark_wiring_cloud.h:35:25: error: void value not ignored as it ought to be
 #define CLOUD_FN(x,y) (y)
                         ^
../wiring/inc/spark_wiring_cloud.h:103:16: note: in expansion of macro 'CLOUD_FN'
         return CLOUD_FN(spark_protocol_send_time_request(sp()),(void)0);
