### PR TITLE
Patch to enable half duplex mode in Serial1

### DIFF
--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -68,6 +68,7 @@ int32_t HAL_USART_Read_Data(HAL_USART_Serial serial);
 int32_t HAL_USART_Peek_Data(HAL_USART_Serial serial);
 void HAL_USART_Flush_Data(HAL_USART_Serial serial);
 bool HAL_USART_Is_Enabled(HAL_USART_Serial serial);
+void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable);
 
 #ifdef __cplusplus
 }

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -302,6 +302,11 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
   return usartMap[serial]->usart_enabled;
 }
 
+void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
+{
+    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, ENABLE); //Enable ? ENABLE : DISABLE);
+}
+
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2
 // WARNING: This function MUST remain reentrance compliant -- no local static variables etc.
 static void HAL_USART_Handler(HAL_USART_Serial serial)

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -304,7 +304,7 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
 
 void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 {
-    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, ENABLE); //Enable ? ENABLE : DISABLE);
+    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, Enable ? ENABLE : DISABLE);
 }
 
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -305,7 +305,7 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
 
 void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 {
-    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, ENABLE); //Enable ? ENABLE : DISABLE);
+    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, Enable ? ENABLE : DISABLE);
 }
 
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -303,6 +303,11 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
 	return usartMap[serial]->usart_enabled;
 }
 
+void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
+{
+    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, ENABLE); //Enable ? ENABLE : DISABLE);
+}
+
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2
 // WARNING: This function MUST remain reentrance compliant -- no local static variables etc.
 static void HAL_USART_Handler(HAL_USART_Serial serial)

--- a/hal/src/template/usart_hal.c
+++ b/hal/src/template/usart_hal.c
@@ -65,3 +65,9 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
 {
     return false;
 }
+
+void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
+{
+}
+
+

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -28,6 +28,13 @@ test(api_wiring_interrupt) {
 
 }
 
+test(api_wiring_usartserial) {
+
+    API_COMPILE(Serial1.halfduplex(true));
+    API_COMPILE(Serial1.halfduplex(false));
+
+}
+
 void TIM3_callback()
 {
 }

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -39,6 +39,7 @@ public:
   virtual ~USARTSerial() {};
   void begin(unsigned long);
   void begin(unsigned long, uint8_t);
+  void halfduplex(bool);
   void end();
 
   virtual int available(void);

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -34,11 +34,10 @@ USARTSerial::USARTSerial(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_B
   _serial = serial;
   HAL_USART_Init(serial, rx_buffer, tx_buffer);
 }
-void USARTSerial::beginonewire(unsigned long baud)
+
+void USARTSerial::halfduplex(bool Enable)
 {
-    USARTSerial::begin(baud);
-//    pinMode(usartMap->usart_tx_pin, AF_OUTPUT_DRAIN);
-    USART_HalfDuplexCmd(usartMap->usart_peripheral, ENABLE);
+    HAL_USART_Half_Duplex(_serial, Enable);
 }
 
 // Public Methods //////////////////////////////////////////////////////////////

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -34,6 +34,12 @@ USARTSerial::USARTSerial(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_B
   _serial = serial;
   HAL_USART_Init(serial, rx_buffer, tx_buffer);
 }
+void USARTSerial::beginonewire(unsigned long baud)
+{
+    USARTSerial::begin(baud);
+//    pinMode(usartMap->usart_tx_pin, AF_OUTPUT_DRAIN);
+    USART_HalfDuplexCmd(usartMap->usart_peripheral, ENABLE);
+}
 
 // Public Methods //////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This patch will allow user code to enable half-duplex mode in Serial1.  I have not tried it with Serial2.  The patch works great on my Core.  I have yet to try it on a Photon, because I have not received them yet.  I will be trying it when I receive one.

Setting the serial port to half duplex enables the one-wire on the hardware.  Both TX and RX use the TX pin.

Thanks!