### PR TITLE
valid JSON output for pretty printing tools like JSON.stringify(DATA,null,4)

### DIFF
--- a/system/src/wifi_credentials_reader.cpp
+++ b/system/src/wifi_credentials_reader.cpp
@@ -209,8 +209,9 @@ void WiFiCredentialsReader::handle(char c)
     else if ('s' == c)
     {
         StreamAppender appender(serial);
+        print("{");
         system_module_info(append_instance, &appender);
-        print("\r\n");
+        print("}\r\n");
     }
 
 }


### PR DESCRIPTION
When connecting to the device in Listening mode via serial, and receiving 's', this super small change makes the Describe Message output as valid JSON ready for copy/pasting into pretty print tools online or code like `JSON.stringify(DATA,null,4)`

@emilyrose just wanted to double check with you if this is needed for the CLI at all, and if so it would require some refactoring on your end most likely.