### PR TITLE
Feature/serial flash p1

### DIFF
--- a/hal/inc/hal_dynalib_peripherals.h
+++ b/hal/inc/hal_dynalib_peripherals.h
@@ -29,10 +29,12 @@
 #define	HAL_PERIPHERALS_DYNALIB_H
 
 #include "dynalib.h"
+#include "platform_config.h"    // for HAS_SERIAL_FLASH
 
 #ifdef DYNALIB_EXPORT
 #include "tone_hal.h"
 #include "servo_hal.h"
+#include "hw_config.h"
 #endif
 
 DYNALIB_BEGIN(hal_peripherals)
@@ -45,9 +47,16 @@ DYNALIB_FN(hal_peripherals,HAL_Servo_Attach)
 DYNALIB_FN(hal_peripherals,HAL_Servo_Detach)
 DYNALIB_FN(hal_peripherals,HAL_Servo_Write_Pulse_Width)
 DYNALIB_FN(hal_peripherals,HAL_Servo_Read_Pulse_Width)
-DYNALIB_FN(hal_peripherals,HAL_Servo_Read_Frequency)        
-                
-DYNALIB_END(hal_peripherals)        
-        
+DYNALIB_FN(hal_peripherals,HAL_Servo_Read_Frequency)
+
+#if defined(HAS_SERIAL_FLASH) && 0
+DYNALIB_FN(hal_peripherals,sFLASH_EraseSector)
+DYNALIB_FN(hal_peripherals,sFLASH_EraseBulk)
+DYNALIB_FN(hal_peripherals,sFLASH_WriteBuffer)
+DYNALIB_FN(hal_peripherals,sFLASH_ReadBuffer)
+DYNALIB_FN(hal_peripherals,sFLASH_ReadID)
+#endif
+DYNALIB_END(hal_peripherals)
+
 #endif	/* HAL_PERIPHERALS_DYNALIB_H */
 

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -197,7 +197,7 @@ void HAL_Core_Config(void)
     FLASH_WriteProtectMemory(FLASH_INTERNAL, CORE_FW_ADDRESS, USER_FIRMWARE_IMAGE_LOCATION - CORE_FW_ADDRESS, true);
 #endif
 
-#ifdef USE_SERIAL_FLASH
+#ifdef HAS_SERIAL_FLASH
     //Initialize Serial Flash
     sFLASH_Init();
 #else

--- a/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc/sst25vf_spi.h
+++ b/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc/sst25vf_spi.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 
 #define sFLASH_PAGESIZE					0x1000		/* 4096 bytes */
+#define sFLASH_PAGECOUNT                                512             /* 2MByte storage */
 
 
 #ifdef __cplusplus

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h
@@ -37,7 +37,7 @@
 #include "usb_hal.h"
 #include "platform_system_flags.h"
 #include "hw_ticks.h"
-#ifdef USE_SERIAL_FLASH
+#if defined(HAS_SERIAL_FLASH)
 #include "spi_flash.h"
 #endif
 
@@ -75,7 +75,7 @@ uint8_t BUTTON_GetState(Button_TypeDef Button);
 uint16_t BUTTON_GetDebouncedTime(Button_TypeDef Button);
 void BUTTON_ResetDebouncedState(Button_TypeDef Button);
 
-#ifdef USE_SERIAL_FLASH
+#ifdef HAS_SERIAL_FLASH
 /* Serial Flash Hardware related methods */
 void sFLASH_SPI_DeInit(void);
 void sFLASH_SPI_Init(void);

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
@@ -122,23 +122,23 @@
 //BM-14 and ELECTRON uses USB_OTG_FS peripheral
 #define USE_USB_OTG_FS
 //BM-14 has serial flash
-#if   PLATFORM_TEACUP_PIGTAIL_DEV == PLATFORM_ID || \
-      PLATFORM_TEACUP_PIGTAIL_PRODUCTION == PLATFORM_ID
-#define USE_SERIAL_FLASH
-#else
-#define FLASH_UPDATE_MODULES
-#endif
-//BM-14 bootloader with FLASH_UPDATE_MODULES enabled DOES NOT fit in < 16KB
-//#define FLASH_UPDATE_MODULES /* Please do not uncomment this at present */
 #elif   PLATFORM_PHOTON_DEV == PLATFORM_ID || \
         PLATFORM_PHOTON_PRODUCTION == PLATFORM_ID
 //BM-09 uses USB_OTG_HS peripheral
 #define USE_USB_OTG_HS
-//BM-09 bootloader with FLASH_UPDATE_MODULES enabled fits in < 16KB
-#define FLASH_UPDATE_MODULES
 #endif
 
-#ifdef USE_SERIAL_FLASH
+#if   PLATFORM_TEACUP_PIGTAIL_DEV == PLATFORM_ID || \
+      PLATFORM_TEACUP_PIGTAIL_PRODUCTION == PLATFORM_ID || \
+      PLATFORM_P1 == PLATFORM_ID
+	#define HAS_SERIAL_FLASH
+    #define sFLASH_PAGESIZE     0x1000 /* 4096 bytes sector size that needs to be erased */
+    #define sFLASH_PAGECOUNT    256    /* 1MByte storage */
+#endif
+
+#define FLASH_UPDATE_MODULES
+
+#ifdef HAS_SERIAL_FLASH
 //SPI FLASH Interface pins
 #define sFLASH_SPI                          SPI2
 #define sFLASH_SPI_CLK                      RCC_APB1Periph_SPI2

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/spi_flash.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/spi_flash.h
@@ -29,8 +29,6 @@
 
 #include <stdint.h>
 
-#define sFLASH_PAGESIZE     0x1000 /* 4096 bytes sector size that needs to be erased */
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_conf.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_conf.h
@@ -35,7 +35,7 @@
 #include "hw_config.h"
 
 /* Maximum number of supported media (Flash, sFlash & DCT) */
-#ifdef USE_SERIAL_FLASH
+#ifdef HAS_SERIAL_FLASH
 #define MAX_USED_MEDIA                  3
 #else
 #define MAX_USED_MEDIA                  2
@@ -46,7 +46,7 @@
 #define USB_MAX_STR_DESC_SIZ            255
 #define USB_SUPPORT_USER_STRING_DESC
 
-#define USBD_SELF_POWERED               
+#define USBD_SELF_POWERED
 
 /* USB DFU Class Layer Parameter */
 #define XFERSIZE                        4096   /* Max DFU Packet Size   = 16384 bytes */
@@ -54,7 +54,7 @@
 #define DFU_IN_EP                       0x80
 #define DFU_OUT_EP                      0x00
 
-/* Flash memory address from where user application will be loaded 
+/* Flash memory address from where user application will be loaded
    This address represents the DFU code protected against write and erase operations.*/
 #define APP_DEFAULT_ADD                 CORE_FW_ADDRESS
 

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
@@ -98,7 +98,7 @@ void Set_System(void)
 	 To reconfigure the default setting of SystemInit() function, refer to
 	 system_stm32f2xx.c file
      */
-
+    
     uint32_t* SCB_CCR = (uint32_t*)(0xE000ED14);
     *SCB_CCR |= SCB_CCR_DIV_0_TRP_Msk;
 
@@ -458,7 +458,7 @@ void BUTTON_ResetDebouncedState(Button_TypeDef Button)
     BUTTON_DEBOUNCED_TIME[Button] = 0;
 }
 
-#ifdef USE_SERIAL_FLASH
+#ifdef HAS_SERIAL_FLASH
 /**
  * @brief  DeInitializes the peripherals used by the SPI FLASH driver.
  * @param  None
@@ -601,24 +601,24 @@ void USB_Cable_Config (FunctionalState NewState)
 inline void Load_SystemFlags_Impl(platform_system_flags_t* flags)
 {
     const void* flags_store = dct_read_app_data(0);
-    memcpy(flags, flags_store, sizeof(platform_system_flags_t));
+    memcpy(flags, flags_store, sizeof(platform_system_flags_t));    
     flags->header[0] = 0xACC0;
     flags->header[1] = 0x1ADE;
 }
 
 inline void Save_SystemFlags_Impl(const platform_system_flags_t* flags)
 {
-    dct_write_app_data(flags, 0, sizeof(*flags));
+    dct_write_app_data(flags, 0, sizeof(*flags));        
 }
 
 platform_system_flags_t system_flags;
 
-void Load_SystemFlags()
+void Load_SystemFlags() 
 {
     Load_SystemFlags_Impl(&system_flags);
 }
 
-void Save_SystemFlags()
+void Save_SystemFlags() 
 {
     Save_SystemFlags_Impl(&system_flags);
 }
@@ -661,7 +661,7 @@ void BACKUP_Flash_Reset(void)
 
     Finish_Update();
 #else
-
+    
     //Not supported since there is no Backup copy of the firmware in Internal Flash
 #endif
 }
@@ -670,7 +670,7 @@ void OTA_Flash_Reset(void)
 {
     // todo - before attempting a copy, verify the integrity of the image (e.g. crc))
     // if that fails, abort the copy and leave the existing user firmware as is.
-
+    
 #ifdef USE_SERIAL_FLASH
 /*
     First take backup of the current application firmware to External Flash

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/sources.mk
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/sources.mk
@@ -20,6 +20,10 @@ endif
 ifeq ("$(PLATFORM_ID)","7")
 CSRC += $(TARGET_SPARK_SRC_PATH)/spi_flash.c
 endif
+ifeq ("$(PLATFORM_ID)","8")
+CSRC += $(TARGET_SPARK_SRC_PATH)/spi_flash.c
+endif
+
 
 # C++ source files included in this build.
 CPPSRC +=


### PR DESCRIPTION
enable external SPI flash on the P1. The serial flash code is not dynamically linked but statically linked from the "platform" module into application code as needed.

We can move it to the system-part2 later if needed.