### PR TITLE
Feature/wakeup wifi in all modes

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -162,11 +162,8 @@ extern "C" void HAL_SysTick_Handler(void)
  *******************************************************************************/
 extern "C" void HAL_RTCAlarm_Handler(void)
 {
-    if(system_mode() == AUTOMATIC)
-    {
-  /* Wake up from Spark.sleep mode(SLEEP_MODE_WLAN) */
-  SPARK_WLAN_SLEEP = 0;
-}
+    /* Wake up from Spark.sleep mode(SLEEP_MODE_WLAN) */
+    SPARK_WLAN_SLEEP = 0;
 }
 
 void manage_safe_mode()


### PR DESCRIPTION
This wakes up wifi regardless of the mode, so that wifi is automatically enabled on wakeup from sleep in SEMI_AUTOMATIC/MANUAL modes.

One problem I see with this:
- if the wifi module was off beforehand, it will now be switched on. The previous wifi state (OFF,ON,CONNECTED) should be saved so that it can be restored to this state on wakeup.

