### PR TITLE
Add a change handler to the RGB class

### DIFF
--- a/services/inc/rgbled.h
+++ b/services/inc/rgbled.h
@@ -57,7 +57,7 @@ bool LED_RGB_IsOverRidden(void);
  */
 typedef void (*led_update_handler_fn)(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);
 
-void set_rgb_led_change_handler(led_update_handler_fn fn, void* data);
+void LED_RGB_SetChangeHandler(led_update_handler_fn fn, void* data);
 
 
 #ifdef __cplusplus

--- a/services/inc/services_dynalib.h
+++ b/services/inc/services_dynalib.h
@@ -45,6 +45,7 @@ DYNALIB_FN(services,panic_)
 DYNALIB_FN(services, jsmn_init)
 DYNALIB_FN(services, jsmn_parse)
 DYNALIB_FN(services, log_print_)
+DYNALIB_FN(services,LED_RGB_SetChangeHandler)
 DYNALIB_END(services)
 
 

--- a/services/src/rgbled.c
+++ b/services/src/rgbled.c
@@ -61,6 +61,11 @@ uint8_t Get_LED_Brightness()
 static void* data;
 static led_update_handler_fn handler;
 
+void LED_RGB_SetChangeHandler(led_update_handler_fn fn, void* fn_data) {
+  handler = fn;
+  data = fn_data;
+}
+
 uint8_t asRGBComponent(uint16_t ccr) {
     return (uint8_t)((ccr<<8)/Get_RGB_LED_Max_Value());
 }
@@ -140,7 +145,7 @@ void LED_Off(Led_TypeDef Led)
         break;
 
     case LED_RGB:
-        Set_RGB_LED_Values(0,0,0);
+        Set_RGB_LED_Color(0);
         led_fade_step = 0;
         led_fade_direction = 1; /* next fade is rising. */
         break;
@@ -175,7 +180,7 @@ void LED_Toggle(Led_TypeDef Led)
         color = LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor;
         Get_RGB_LED_Values(rgb);
         if (rgb[0] | rgb[1] | rgb[2])
-            Set_RGB_LED_Values(0,0,0);
+            Set_RGB_LED_Color(0);
         else
             Set_RGB_LED_Color(color);        
         break;

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -54,6 +54,15 @@ test(api_wiring_system_interrupt) {
 }
 #endif
 
+void externalLEDHandler(uint8_t r, uint8_t g, uint8_t b) {
+}
+
+class ExternalLed {
+  public:
+    void handler(uint8_t r, uint8_t g, uint8_t b) {
+    }
+} externalLed;
+
 test(api_rgb) {
     bool flag; uint8_t value;
     API_COMPILE(RGB.brightness(50));
@@ -63,5 +72,6 @@ test(api_rgb) {
     API_COMPILE(RGB.color(255,255,255));
     API_COMPILE(RGB.color(RGB_COLOR_WHITE));
     API_COMPILE(flag=RGB.brightness());
-
+    API_COMPILE(RGB.onChange(externalLEDHandler));
+    API_COMPILE(RGB.onChange(&ExternalLed::handler, &externalLed));
 }

--- a/user/tests/wiring/no_fixture/led.cpp
+++ b/user/tests/wiring/no_fixture/led.cpp
@@ -171,3 +171,29 @@ test(LED_BrightnessIsPersisted) {
     
     assertLEDColorIs(ledAdjust(255,128),ledAdjust(255,128),0);
 }
+
+uint8_t rgbUser[3];
+void userLEDChangeHandler(uint8_t r, uint8_t g, uint8_t b) {
+    rgbUser[0] = r;
+    rgbUser[1] = g;
+    rgbUser[2] = b;
+}
+
+void assertChangeHandlerCalledWith(uint8_t r, uint8_t g, uint8_t b) {
+    assertEqual(rgbUser[0], r);
+    assertEqual(rgbUser[1], g);
+    assertEqual(rgbUser[2], b);
+}
+
+test(LED_ChangeHandlerCalled) {
+    // given
+    RGB.onChange(userLEDChangeHandler);
+
+    // when
+    RGB.control(true);
+    RGB.brightness(255);
+    RGB.color(10, 20, 30);
+
+    // then
+    assertChangeHandlerCalledWith(ledAdjust(10),ledAdjust(20),ledAdjust(30));
+}

--- a/wiring/inc/spark_wiring_rgb.h
+++ b/wiring/inc/spark_wiring_rgb.h
@@ -21,7 +21,11 @@
  */
 
 #include <stdint.h>
+#include <functional>
 #include "rgbled.h"
+
+typedef void (raw_rgb_change_handler_t)(uint8_t, uint8_t, uint8_t);
+typedef std::function<raw_rgb_change_handler_t> wiring_rgb_change_handler_t;
 
 class RGBClass {
 private:
@@ -33,9 +37,16 @@ public:
 	static void color(uint32_t rgb);
 	static void brightness(uint8_t, bool update=true);
 
-        static uint8_t brightness() {
-            return Get_LED_Brightness();
-        }
+	static uint8_t brightness() {
+		return Get_LED_Brightness();
+	}
+
+	static void onChange(wiring_rgb_change_handler_t handler);
+	static void onChange(raw_rgb_change_handler_t *handler);
+
+private:
+	static void call_raw_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);
+	static void call_std_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);
 };
 
 extern RGBClass RGB;

--- a/wiring/inc/spark_wiring_rgb.h
+++ b/wiring/inc/spark_wiring_rgb.h
@@ -44,6 +44,12 @@ public:
 	static void onChange(wiring_rgb_change_handler_t handler);
 	static void onChange(raw_rgb_change_handler_t *handler);
 
+    template <typename T>
+    static void onChange(void (T::*handler)(uint8_t, uint8_t, uint8_t), T *instance) {
+      using namespace std::placeholders;
+      onChange(std::bind(handler, instance, _1, _2, _3));
+    }
+
 private:
 	static void call_raw_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);
 	static void call_std_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);

--- a/wiring/src/spark_wiring_rgb.cpp
+++ b/wiring/src/spark_wiring_rgb.cpp
@@ -61,4 +61,27 @@ void RGBClass::brightness(uint8_t brightness, bool update)
         LED_On(LED_RGB);
 }
 
+void RGBClass::onChange(wiring_rgb_change_handler_t handler) {
+  if(handler) {
+    auto wrapper = new wiring_rgb_change_handler_t(handler);
+    if(wrapper) {
+      LED_RGB_SetChangeHandler(call_std_change_handler, wrapper);
+    }
+  }
+}
 
+void RGBClass::onChange(raw_rgb_change_handler_t *handler) {
+  LED_RGB_SetChangeHandler(call_raw_change_handler, (void *)handler);
+}
+
+void RGBClass::call_raw_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved)
+{
+    auto fn = (raw_rgb_change_handler_t*)(data);
+    (*fn)(r, g, b);
+}
+
+void RGBClass::call_std_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved)
+{
+    auto fn = (wiring_rgb_change_handler_t*)(data);
+    (*fn)(r, g, b);
+}


### PR DESCRIPTION
A user can easily implement an external RGB LED by registering a change handler with `RGB.onChange` and doing `analogWrite` to another set of pins inside the change andler.

Multiple community topics show this is wanted.
http://community.particle.io/t/mirroring-on-board-rgb-led-to-external-led/13724/2
http://community.particle.io/t/best-way-to-implement-an-outboard-bright-rgb-led/12063/2

How to use:

```
// Needed to catch the initial cloud connection blinks
SYSTEM_MODE(SEMI_AUTOMATIC);

void externalLEDHandler(uint8_t r, uint8_t g, uint8_t b) {
  // reproduce green to an external LED to get a pretty good idea if the cloud is connected
  analogWrite(D0, g);
}

void setup()
{
  pinMode(D0, OUTPUT);
  RGB.onChange(&externalLEDHandler);
  Spark.connect();
}
```

Note: `Set_RGB_LED_Values(0,0,0);` was changed to `Set_RGB_LED_Color(0);` otherwise the handler is not called when the LED is toggled during the initial cloud connected.