### PR TITLE
Fix inet_gethostbyname() behaviour and usage.

### DIFF
--- a/hal/src/photon/inet_hal.cpp
+++ b/hal/src/photon/inet_hal.cpp
@@ -31,7 +31,9 @@ int inet_gethostbyname(const char* hostname, uint16_t hostnameLen, HAL_IPAddress
     wiced_ip_address_t address;
     address.version = WICED_IPV4;
     wiced_result_t result = wiced_hostname_lookup (hostname, &address, 5000);
-    out_ip_addr->ipv4 = GET_IPV4_ADDRESS(address);
+    if (result == WICED_SUCCESS) {
+        out_ip_addr->ipv4 = GET_IPV4_ADDRESS(address);
+    }
     return -result;
 }
 

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -602,6 +602,7 @@ int Spark_Connect(void)
 
     bool ip_resolve_failed = false;
     IPAddress ip_addr;
+    int rv = -1;
 
     switch (server_addr.addr_type)
     {
@@ -622,13 +623,12 @@ int Spark_Connect(void)
             int attempts = 3;
             while (!ip_addr && 0 < --attempts)
             {
-                inet_gethostbyname(server_addr.domain, strnlen(server_addr.domain, 126), &ip_addr.raw(), NIF_DEFAULT, NULL);
+                rv = inet_gethostbyname(server_addr.domain, strnlen(server_addr.domain, 126), &ip_addr.raw(), NIF_DEFAULT, NULL);
                 HAL_Delay_Milliseconds(1);
             }
-            ip_resolve_failed = !ip_addr;
+            ip_resolve_failed = rv;
     }
 
-    int rv = -1;
     if (!ip_resolve_failed)
     {
         if (!ip_addr)

--- a/wiring/src/spark_wiring_tcpclient.cpp
+++ b/wiring/src/spark_wiring_tcpclient.cpp
@@ -58,7 +58,7 @@ int TCPClient::connect(const char* host, uint16_t port, network_interface_t nif)
       {
         IPAddress ip_addr;
 
-        if(inet_gethostbyname(host, strlen(host), ip_addr, nif, NULL) == 0)
+        if((rv = inet_gethostbyname(host, strlen(host), ip_addr, nif, NULL)) == 0)
         {
                 return connect(ip_addr, port, nif);
         }


### PR DESCRIPTION
Use return value directly in system_cloud.cpp, instead of inferring error
from an IP address of 0.0.0.0.
Stop writing garbage into ip address in photon/inet_hal.cpp when the underlying
wiced call failed.
Use and pass on inet_gethostbyname() return value in spark_wiring_tcpclient.cpp