### PR TITLE
Add missing SysTick_Disable prototype

### DIFF
--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h
@@ -64,6 +64,7 @@ typedef enum
 void Set_System(void);
 void NVIC_Configuration(void);
 void SysTick_Configuration(void);
+void SysTick_Disable(void);
 
 void IWDG_Reset_Enable(uint32_t msTimeout);
 


### PR DESCRIPTION
Running `make all PARTICLE_DEVELOP=1 PLATFORM=photon` from the firmware root folder fails with `implicit declaration of function 'SysTick_Disable'` in `bootloader/src/main.c`