### PR TITLE
Add C++ handlers and handler_data to subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - `Spark.connected()` et al. is now `Particle.connected()`. The former `Spark` library is still available but is deprecated.
  - `System.freeMemory()` API to determine the amount of available RAM.
  - `STARTUP()` macro to define blocks of code that execute at startup.
+ - `Particle.function`, `Particle.subscribe` and `attachInterrupt` can take a C++ method and instance pointer. [#534](https://github.com/spark/firmware/pull/534) Thanks to @monkbroc!
 
 ### ENHANCEMENTS
  - Retrieve the LED brightness via `RGB.brightness()`

--- a/communication/src/events.h
+++ b/communication/src/events.h
@@ -43,11 +43,13 @@ namespace SubscriptionScope {
 }
 
 typedef void (*EventHandler)(const char *event_name, const char *data);
+typedef void (*EventHandlerWithData)(void *handler_data, const char *event_name, const char *data);
 
 struct FilteringEventHandler
 {
   char filter[64];
   EventHandler handler;
+  void *handler_data;
   SubscriptionScope::Enum scope;
   char device_id[13];
 };

--- a/communication/src/spark_protocol.cpp
+++ b/communication/src/spark_protocol.cpp
@@ -674,12 +674,14 @@ void SparkProtocol::remove_event_handlers(const char* event_name)
 }
 
 bool SparkProtocol::event_handler_exists(const char *event_name, EventHandler handler,
-    SubscriptionScope::Enum scope, const char* id)
+    void *handler_data, SubscriptionScope::Enum scope, const char* id)
 {
   const int NUM_HANDLERS = sizeof(event_handlers) / sizeof(FilteringEventHandler);
   for (int i = 0; i < NUM_HANDLERS; i++)
   {
-      if (event_handlers[i].handler==handler && event_handlers[i].scope==scope) {
+      if (event_handlers[i].handler==handler &&
+          event_handlers[i].handler_data==handler_data &&
+          event_handlers[i].scope==scope) {
         const size_t MAX_FILTER_LEN = sizeof(event_handlers[i].filter);
         const size_t FILTER_LEN = strnlen(event_name, MAX_FILTER_LEN);
         if (!strncmp(event_handlers[i].filter, event_name, FILTER_LEN)) {
@@ -698,7 +700,7 @@ bool SparkProtocol::event_handler_exists(const char *event_name, EventHandler ha
 bool SparkProtocol::add_event_handler(const char *event_name, EventHandler handler,
     void *handler_data, SubscriptionScope::Enum scope, const char* id)
 {
-    if (event_handler_exists(event_name, handler, scope, id))
+    if (event_handler_exists(event_name, handler, handler_data, scope, id))
         return true;
 
   const int NUM_HANDLERS = sizeof(event_handlers) / sizeof(FilteringEventHandler);

--- a/communication/src/spark_protocol.h
+++ b/communication/src/spark_protocol.h
@@ -123,7 +123,7 @@ class SparkProtocol
                         void *handler_data, SubscriptionScope::Enum scope,
                         const char* device_id);
     bool event_handler_exists(const char *event_name, EventHandler handler,
-        SubscriptionScope::Enum scope, const char* id);
+        void *handler_data, SubscriptionScope::Enum scope, const char* id);
     void remove_event_handlers(const char* event_name);
     void send_subscriptions();
     bool send_subscription(const char *event_name, const char *device_id);

--- a/communication/src/spark_protocol.h
+++ b/communication/src/spark_protocol.h
@@ -120,7 +120,8 @@ class SparkProtocol
     bool send_event(const char *event_name, const char *data,
                     int ttl, EventType::Enum event_type);
     bool add_event_handler(const char *event_name, EventHandler handler,
-                        SubscriptionScope::Enum scope, const char* device_id);
+                        void *handler_data, SubscriptionScope::Enum scope,
+                        const char* device_id);
     bool event_handler_exists(const char *event_name, EventHandler handler,
         SubscriptionScope::Enum scope, const char* id);
     void remove_event_handlers(const char* event_name);

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -69,8 +69,8 @@ bool spark_protocol_send_subscription_scope(SparkProtocol* protocol, const char 
 }
 
 bool spark_protocol_add_event_handler(SparkProtocol* protocol, const char *event_name,
-    EventHandler handler, SubscriptionScope::Enum scope, const char* device_id, void* reserved) {
-    return protocol->add_event_handler(event_name, handler, scope, device_id);
+    EventHandler handler, SubscriptionScope::Enum scope, const char* device_id, void* handler_data) {
+    return protocol->add_event_handler(event_name, handler, handler_data, scope, device_id);
 }
 
 bool spark_protocol_send_time_request(SparkProtocol* protocol, void* reserved) {

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -115,7 +115,7 @@ bool spark_protocol_send_event(SparkProtocol* protocol, const char *event_name, 
                 int ttl, EventType::Enum event_type, void* reserved);
 bool spark_protocol_send_subscription_device(SparkProtocol* protocol, const char *event_name, const char *device_id, void* reserved=NULL);
 bool spark_protocol_send_subscription_scope(SparkProtocol* protocol, const char *event_name, SubscriptionScope::Enum scope, void* reserved=NULL);
-bool spark_protocol_add_event_handler(SparkProtocol* protocol, const char *event_name, EventHandler handler, SubscriptionScope::Enum scope, const char* id, void* reserved=NULL);
+bool spark_protocol_add_event_handler(SparkProtocol* protocol, const char *event_name, EventHandler handler, SubscriptionScope::Enum scope, const char* id, void* handler_data=NULL);
 bool spark_protocol_send_time_request(SparkProtocol* protocol, void* reserved=NULL);
 void spark_protocol_send_subscriptions(SparkProtocol* protocol, void* reserved=NULL);
 void spark_protocol_remove_event_handlers(SparkProtocol* protocol, const char *event_name, void* reserved=NULL);

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -112,11 +112,11 @@ SubscriptionScope::Enum convert(Spark_Subscription_Scope_TypeDef subscription_ty
     return(subscription_type==MY_DEVICES) ? SubscriptionScope::MY_DEVICES : SubscriptionScope::FIREHOSE;
 }
 
-bool spark_subscribe(const char *eventName, EventHandler handler, void* data,
+bool spark_subscribe(const char *eventName, EventHandler handler, void* handler_data,
         Spark_Subscription_Scope_TypeDef scope, const char* deviceID, void* reserved)
 {
     auto event_scope = convert(scope);
-    bool success = spark_protocol_add_event_handler(sp, eventName, handler, event_scope, deviceID, NULL);
+    bool success = spark_protocol_add_event_handler(sp, eventName, handler, event_scope, deviceID, handler_data);
     if (success && spark_connected())
     {
         if (deviceID)

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -43,6 +43,12 @@ test(api_spark_variable) {
 test(api_spark_function) {
     int (*handler)(String) = NULL;
     API_COMPILE(Particle.function("name", handler));
+
+    class MyClass {
+      public:
+        int handler(String arg) { return 0; }
+    } myObj;
+    API_COMPILE(Particle.function("name", &MyClass::handler, &myObj));
 }
 
 test(api_spark_publish) {
@@ -102,6 +108,17 @@ test(api_spark_subscribe) {
     API_COMPILE(Particle.subscribe(String("name"), handler, MY_DEVICES));
 
     API_COMPILE(Particle.subscribe(String("name"), handler, "1234"));
+
+    class MyClass {
+      public:
+        void handler(const char *event_name, const char *data) { }
+    } myObj;
+
+    API_COMPILE(Particle.subscribe("name", &MyClass::handler, &myObj));
+
+    API_COMPILE(Particle.subscribe("name", &MyClass::handler, &myObj, MY_DEVICES));
+
+    API_COMPILE(Particle.subscribe("name", &MyClass::handler, &myObj, "1234"));
 
 }
 

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -32,6 +32,13 @@ test(api_wiring_interrupt) {
     API_COMPILE(attachInterrupt(D0, D0_callback, RISING));
     API_COMPILE(detachInterrupt(D0));
 
+    class MyClass {
+      public:
+        void handler() { }
+    } myObj;
+
+    API_COMPILE(attachInterrupt(D0, &MyClass::handler, &myObj, RISING));
+
 }
 
 test(api_wiring_usartserial) {

--- a/user/tests/wiring/cloud/cloud.cpp
+++ b/user/tests/wiring/cloud/cloud.cpp
@@ -173,10 +173,15 @@ test(Spark_Second_Event_Handler_Not_Matched) {
 class Subscriber {
   public:
     void subscribe() {
-      Particle.subscribe("test/event3", &Subscriber::handler, this);
+      assertTrue(Particle.subscribe("test/event3", &Subscriber::handler, this));
+      // To make sure calling subscribe with a different handler is not a no op
+      assertTrue(Particle.subscribe("test/event3", &Subscriber::handler2, this));
       receivedCount = 0;
     }
     void handler(const char *eventName, const char *data) {
+      receivedCount++;
+    }
+    void handler2(const char *eventName, const char *data) {
       receivedCount++;
     }
     int receivedCount;
@@ -197,5 +202,5 @@ test(Subscribe_With_Object) {
     while ((millis()-start)<30000 && !subscriber.receivedCount)
         idle();
 
-    assertEqual(subscriber.receivedCount, 1);
+    assertEqual(subscriber.receivedCount, 2);
 }

--- a/user/tests/wiring/cloud/cloud.cpp
+++ b/user/tests/wiring/cloud/cloud.cpp
@@ -169,3 +169,33 @@ test(Spark_Second_Event_Handler_Not_Matched) {
 
     assertEqual(not_connected_handler_count, 1);
 }
+
+class Subscriber {
+  public:
+    void subscribe() {
+      Particle.subscribe("test/event3", &Subscriber::handler, this);
+      receivedCount = 0;
+    }
+    void handler(const char *eventName, const char *data) {
+      receivedCount++;
+    }
+    int receivedCount;
+} subscriber;
+
+test(Subscribe_With_Object) {
+    disconnect();
+    Particle.unsubscribe();
+    connect();
+
+    subscriber.subscribe();
+
+    String deviceID = Spark.deviceID();
+    Particle.publish("test/event3");
+
+    // now wait for published event to be received
+    long start = millis();
+    while ((millis()-start)<30000 && !subscriber.receivedCount)
+        idle();
+
+    assertEqual(subscriber.receivedCount, 1);
+}

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -31,6 +31,7 @@
 #include <functional>
 
 typedef std::function<user_function_int_str_t> user_std_function_int_str_t;
+typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 
 #ifdef SPARK_NO_CLOUD
 #define CLOUD_FN(x,y) (y)
@@ -69,6 +70,12 @@ public:
 #endif
     }
 
+    template <typename T>
+    static void function(const char *funcKey, int (T::*func)(String), T *instance) {
+      using namespace std::placeholders;
+      function(funcKey, std::bind(func, instance, _1));
+    }
+
     bool publish(const char *eventName, Spark_Event_TypeDef eventType=PUBLIC)
     {
         return CLOUD_FN(spark_send_event(eventName, NULL, 60, eventType, NULL), false);
@@ -92,6 +99,30 @@ public:
     bool subscribe(const char *eventName, EventHandler handler, const char *deviceID)
     {
         return CLOUD_FN(spark_subscribe(eventName, handler, NULL, MY_DEVICES, deviceID, NULL), false);
+    }
+
+    bool subscribe(const char *eventName, wiring_event_handler_t handler, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES)
+    {
+        return subscribe_wiring(eventName, handler, scope);
+    }
+
+    bool subscribe(const char *eventName, wiring_event_handler_t handler, const char *deviceID)
+    {
+        return subscribe_wiring(eventName, handler, MY_DEVICES, deviceID);
+    }
+
+    template <typename T>
+    bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES)
+    {
+        using namespace std::placeholders;
+        return subscribe(eventName, std::bind(handler, instance, _1, _2), scope);
+    }
+
+    template <typename T>
+    bool subscribe(const char *eventName, void (T::*handler)(const char *, const char *), T *instance, const char *deviceID)
+    {
+        using namespace std::placeholders;
+        return subscribe(eventName, std::bind(handler, instance, _1, _2), deviceID);
     }
 
     void unsubscribe()
@@ -123,7 +154,26 @@ private:
     static int call_raw_user_function(void* data, const char* param, void* reserved);
     static int call_std_user_function(void* data, const char* param, void* reserved);
 
+    static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
+
     SparkProtocol* sp() { return spark_protocol_instance(); }
+
+    bool subscribe_wiring(const char *eventName, wiring_event_handler_t handler, Spark_Subscription_Scope_TypeDef scope, const char *deviceID = NULL)
+    {
+#ifdef SPARK_NO_CLOUD
+        return false;
+#else
+        bool success = false;
+        if (handler) // if the call-wrapper has wrapped a callable object
+        {
+            auto wrapper = new wiring_event_handler_t(handler);
+            if (wrapper) {
+                success = spark_subscribe(eventName, (EventHandler)call_wiring_event_handler, wrapper, scope, deviceID, NULL);
+            }
+        }
+        return success;
+#endif
+    }
 };
 
 

--- a/wiring/inc/spark_wiring_interrupts.h
+++ b/wiring/inc/spark_wiring_interrupts.h
@@ -40,6 +40,11 @@ typedef void (*raw_interrupt_handler_t)(void);
  */
 bool attachInterrupt(uint16_t pin, wiring_interrupt_handler_t handler, InterruptMode mode);
 bool attachInterrupt(uint16_t pin, raw_interrupt_handler_t handler, InterruptMode mode);
+template <typename T>
+bool attachInterrupt(uint16_t pin, void (T::*handler)(), T *instance, InterruptMode mode) {
+    using namespace std::placeholders;
+    return attachInterrupt(pin, std::bind(handler, instance), mode);
+}
 void detachInterrupt(uint16_t pin);
 void interrupts(void);
 void noInterrupts(void);

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -15,6 +15,12 @@ int CloudClass::call_std_user_function(void* data, const char* param, void* rese
     return (*fn)(String(param));
 }
 
+void CloudClass::call_wiring_event_handler(const void* handler_data, const char *event_name, const char *data)
+{
+    wiring_event_handler_t* fn = (wiring_event_handler_t*)(handler_data);
+    (*fn)(event_name, data);
+}
+
 bool CloudClass::register_function(cloud_function_t fn, void* data, const char* funcKey)
 {
     cloud_function_descriptor desc;


### PR DESCRIPTION
Spark.function, Spark.subscribe and attachInterrupt can now take a pointer to a member and an instance to easily attach a callback to a C++ object as shown in the tests.

subscribe was missing lambda support and `spark_subscribe` did not save the data pointer to be passed to the `EventHandler` callback so I implemented the following solution to add lambda support:
* Don't change the signature of any dynalib method
* Save the handler data pointer in `FilteringEventHandler`
* If the data pointer is non-null, call the handler with the extra data pointer (3 arguments)
* If the data pointer is null, call the handler with 2 arguments

The idea is that this should be compatible with previous user code and HAL versions.

Compile and device tests pass (I didn't know how to add tests for attachInterrupt and Spark.function since those were not tested previously).

Note: This needs #533 for the tests to compile.