### PR TITLE
SPI.setClockSpeed/setClockDividerReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## v0.4.5
 
 ### FEATURES
+ - `SPI.setClockDividerReference`, `SPI.setClockSpeed` to set clock speed in a more portable manner. [#454]https://github.com/spark/firmware/issues/454
 
 - `WiFi.scan` function to retrieve details of local access points. [#567](https://github.com/spark/firmware/pull/567)
 - `UDP.sendPacket`/`UDP.receivePacket` to send/receive a packet directly to an application-supplied buffer. [#452](https://github.com/spark/firmware/pull/452)

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -135,6 +135,19 @@ uint32_t HAL_Core_Runtime_Info(runtime_info_t* info, void* reserved);
 
 extern void app_setup_and_loop();
 
+typedef enum HAL_SystemClock
+{
+    SYSTEMCLOCK_PRIMARY,
+    SYSTEMCLOCK_SPI
+} HAL_SystemClock;
+
+/**
+ * Retrieves the
+ * @param reserved
+ * @return
+ */
+unsigned HAL_Core_System_Clock(HAL_SystemClock clock, void* reserved);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/hal_dynalib_core.h
+++ b/hal/inc/hal_dynalib_core.h
@@ -56,7 +56,7 @@ DYNALIB_FN(hal_core,HAL_Bootloader_Get_Flag)
 DYNALIB_FN(hal_core,HAL_Bootloader_Lock)
 DYNALIB_FN(hal_core,HAL_Core_System_Reset_FlagSet)
 DYNALIB_FN(hal_core,HAL_Core_Runtime_Info)
-
+DYNALIB_FN(hal_core,HAL_Core_System_Clock)
 DYNALIB_END(hal_core)
 
 

--- a/hal/inc/hal_dynalib_core.h
+++ b/hal/inc/hal_dynalib_core.h
@@ -56,7 +56,6 @@ DYNALIB_FN(hal_core,HAL_Bootloader_Get_Flag)
 DYNALIB_FN(hal_core,HAL_Bootloader_Lock)
 DYNALIB_FN(hal_core,HAL_Core_System_Reset_FlagSet)
 DYNALIB_FN(hal_core,HAL_Core_Runtime_Info)
-DYNALIB_FN(hal_core,HAL_Core_System_Clock)
 DYNALIB_END(hal_core)
 
 

--- a/hal/inc/hal_dynalib_spi.h
+++ b/hal/inc/hal_dynalib_spi.h
@@ -40,6 +40,7 @@ DYNALIB_FN(hal_spi,HAL_SPI_Send_Receive_Data)
 DYNALIB_FN(hal_spi,HAL_SPI_Is_Enabled_Old)
 DYNALIB_FN(hal_spi,HAL_SPI_Init)
 DYNALIB_FN(hal_spi,HAL_SPI_Is_Enabled)
+DYNALIB_FN(Hal_spi,HAL_SPI_Info)
 DYNALIB_END(hal_spi)
 
 

--- a/hal/inc/spi_hal.h
+++ b/hal/inc/spi_hal.h
@@ -64,6 +64,13 @@ typedef void (*HAL_SPI_DMA_UserCallback)(void);
 extern "C" {
 #endif
 
+typedef struct hal_spi_info_t {
+    uint16_t size;
+
+    uint32_t system_clock;      // the clock speed that is divided when setting a divider
+
+} hal_spi_info_t;
+
 void HAL_SPI_Init(HAL_SPI_Interface spi);
 void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin);
 void HAL_SPI_End(HAL_SPI_Interface spi);
@@ -74,6 +81,7 @@ uint16_t HAL_SPI_Send_Receive_Data(HAL_SPI_Interface spi, uint16_t data);
 void HAL_SPI_DMA_Transfer(HAL_SPI_Interface spi, void* tx_buffer, void* rx_buffer, uint32_t length, HAL_SPI_DMA_UserCallback userCallback);
 bool HAL_SPI_Is_Enabled_Old();
 bool HAL_SPI_Is_Enabled(HAL_SPI_Interface spi);
+void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -382,3 +382,8 @@ uint32_t HAL_Core_Runtime_Info(runtime_info_t* info, void* reserved)
     info->freeheap = freeheap();
     return 0;
 }
+
+unsigned HAL_Core_System_Clock(HAL_SystemClock clock, void* reserved)
+{
+    return SystemCoreClock;
+}

--- a/hal/src/core/spi_hal.c
+++ b/hal/src/core/spi_hal.c
@@ -187,3 +187,8 @@ bool HAL_SPI_Is_Enabled(HAL_SPI_Interface spi)
 {
   return SPI_Enabled;
 }
+
+void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved)
+{
+    info->system_clock = 36000000;
+}

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -261,3 +261,8 @@ uint16_t HAL_Bootloader_Get_Flag(BootloaderFlag flag)
 void HAL_Core_Enter_Bootloader(bool persist)
 {
 }
+
+unsigned HAL_Core_System_Clock(HAL_SystemClock clock, void* reserved)
+{
+    return 1;
+}

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -823,3 +823,7 @@ bool HAL_Core_System_Reset_FlagSet(RESET_TypeDef resetType)
     return false;
 }
 
+unsigned HAL_Core_System_Clock(HAL_SystemClock clock, void* reserved)
+{
+    return SystemCoreClock;
+}

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -398,3 +398,8 @@ void DMA2_Stream5_irq(void)
 {
     HAL_SPI_TX_DMA_Stream_InterruptHandler(HAL_SPI_INTERFACE1);
 }
+
+void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved)
+{
+    info->system_clock = spi==HAL_SPI_INTERFACE1 ? 60000000 : 30000000;
+}

--- a/hal/src/template/core_hal.c
+++ b/hal/src/template/core_hal.c
@@ -113,6 +113,13 @@ void HAL_Bootloader_Lock(bool lock)
 {
 }
 
+
+unsigned HAL_Core_System_Clock(HAL_SystemClock clock, void* reserved)
+{
+    return 1;
+}
+
+
 int main() 
 {
     while(1);

--- a/hal/src/template/spi_hal.c
+++ b/hal/src/template/spi_hal.c
@@ -63,3 +63,7 @@ bool HAL_SPI_Is_Enabled(HAL_SPI_Interface spi)
 void HAL_SPI_DMA_Transfer(HAL_SPI_Interface spi, void* tx_buffer, void* rx_buffer, uint32_t length, HAL_SPI_DMA_UserCallback userCallback)
 {
 }
+
+void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved)
+{
+}

--- a/user/tests/wiring/api/peripherals.cpp
+++ b/user/tests/wiring/api/peripherals.cpp
@@ -1,0 +1,32 @@
+
+#include "testapi.h"
+#include "spark_wiring_spi.h"
+
+test(SPI_clock)
+{
+    API_COMPILE(SPI.setClockDivider(SPI_CLOCK_DIV2));
+    API_COMPILE(SPI.setClockDivider(SPI_CLOCK_DIV256));
+    API_COMPILE(SPI.setClockSpeed(100, MHZ));
+    API_COMPILE(SPI.setClockSpeed(100, KHZ));
+    API_COMPILE(SPI.setClockSpeed(ARDUINO));
+    API_COMPILE(SPI.setClockSpeed(ARDUINO/4));
+    API_COMPILE(SPI.setClockDividerReference(ARDUINO));
+}
+
+#if Wiring_SPI1
+test(SPI1_begin)
+{
+    API_COMPILE(SPI1.begin());
+}
+
+test(SPI1_clock)
+{
+    API_COMPILE(SPI1.setClockDivider(SPI_CLOCK_DIV2));
+    API_COMPILE(SPI1.setClockDivider(SPI_CLOCK_DIV256));
+    API_COMPILE(SPI1.setClockSpeed(100, MHZ));
+    API_COMPILE(SPI1.setClockSpeed(100, KHZ));
+    API_COMPILE(SPI1.setClockSpeed(ARDUINO));
+    API_COMPILE(SPI1.setClockSpeed(ARDUINO/4));
+    API_COMPILE(SPI1.setClockDividerReference(ARDUINO));
+}
+#endif

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -33,9 +33,26 @@
 
 typedef void (*wiring_spi_dma_transfercomplete_callback_t)(void);
 
+enum FrequencyScale
+{
+    HZ = 1,
+    KHZ = HZ*1000,
+    MHZ = KHZ*1000,
+    SYSTEM = 0,         // represents the system clock speed
+    ARDUINO = 16*MHZ,
+    CORE = 72*MHZ,
+    PHOTON = 120*MHZ
+};
+
 class SPIClass {
 private:
   HAL_SPI_Interface _spi;
+
+  /**
+   * Set the divider reference clock.
+   * The default is the system clock.
+   */
+  unsigned dividerReference;
 
 public:
   SPIClass(HAL_SPI_Interface spi);
@@ -47,7 +64,36 @@ public:
 
   void setBitOrder(uint8_t);
   void setDataMode(uint8_t);
-  void setClockDivider(uint8_t);
+
+  /**
+   * Sets the clock speed that the divider is relative to. This does not change
+   * the assigned clock speed until the next call to {@link #setClockDivider}
+   * @param value   The clock speed reference value
+   * @param scale   The clock speed reference scalar
+   *
+   * E.g.
+   *
+   * setClockDividerReference(ARDUINO);
+   * setClockDividerReference(16, MHZ);
+   *
+   * @see #setClockDivider
+   */
+  void setClockDividerReference(unsigned value, unsigned scale=HZ);
+
+  /**
+   * Sets the clock speed as a divider relative to the clock divider reference.
+   * @param divider SPI_CLOCK_DIVx where x is a power of 2 from 2 to 256.
+   */
+  void setClockDivider(uint8_t divider);
+
+  /**
+   * Sets the absolute clock speed. This will select the clock divider that is no greater than
+   * {@code value*scale}.
+   * @param value
+   * @param scale
+   * @return the actual clock speed set.
+   */
+  unsigned setClockSpeed(unsigned value, unsigned scale=HZ);
 
   byte transfer(byte _data);
   void transfer(void* tx_buffer, void* rx_buffer, size_t length, wiring_spi_dma_transfercomplete_callback_t user_callback);

--- a/wiring/src/spark_wiring_spi.cpp
+++ b/wiring/src/spark_wiring_spi.cpp
@@ -129,7 +129,11 @@ unsigned SPIClass::setClockSpeed(unsigned value, unsigned value_scale)
 {
     // actual speed is the system clock divided by some scalar
     unsigned targetSpeed = value*value_scale;
-    unsigned clock = HAL_Core_System_Clock(SYSTEMCLOCK_SPI, NULL);
+    hal_spi_info_t info;
+    memset(&info, 0, sizeof(info));
+    info.size = sizeof(info);
+    HAL_SPI_Info(_spi, &info, NULL);
+    unsigned clock = info.system_clock;
     uint8_t scale = 0;
     while (clock > targetSpeed) {
         clock >>= 1;


### PR DESCRIPTION
`SPI.setClockSpeed`, `SPI.setClockDividerReference` for more portable SPI clock speeds.

Examples:

Set the clock divider reference for arduino compatibility
```
SPI.setClockDividerReference(ARDUINO);
SPI.setClockDivider(SPI_CLOCK_DIV4);
```

Set an absolute clock speed (or the highest supported speed without going over)
```
unsigned acutalSpeed = SPI.setClockSpeed(20, MHZ);
```

