### PR TITLE
Time.timeStr() formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `Particle.function`, `Particle.subscribe` and `attachInterrupt` can take a C++ method and instance pointer. [#534](https://github.com/spark/firmware/pull/534) Thanks to @monkbroc!
 - `UDP.setBuffer` to set the buffer a UDP instance uses for `read`/`write`. [#224](https://github.com/spark/firmware/pull/224) and [#452](https://github.com/spark/firmware/pull/452)
 - `WiFi.setCredentials()` can take a Cipher type to allow full specification of an AP's credentials. [#574](https://github.com/spark/firmware/pull/574)
+- Configurable format in `Time.timeStr()`, including ISO 8601. [#455](https://github.com/spark/firmware/issues/455)
 
 ### BUGFIXES
 

--- a/user/tests/wiring/api/time.cpp
+++ b/user/tests/wiring/api/time.cpp
@@ -1,0 +1,17 @@
+
+#include "testapi.h"
+
+test(time_format)
+{
+    time_format_t format;
+    API_COMPILE(Time.timeStr());
+    API_COMPILE(Time.timeStr(1234));
+    API_COMPILE(Time.timeStr(TIME_FORMAT_DEFAULT));
+    API_COMPILE(Time.timeStr(TIME_FORMAT_ISO8601_FULL));
+    API_COMPILE(Time.timeStr(1234, TIME_FORMAT_ISO8601_FULL));
+    API_COMPILE(Time.setFormat(TIME_FORMAT_ISO8601_FULL));
+    API_COMPILE((void)(format=Time.getFormat()));
+
+    API_COMPILE(Time.format(1234, "abcd"))
+
+}

--- a/user/tests/wiring/no_fixture/time.cpp
+++ b/user/tests/wiring/no_fixture/time.cpp
@@ -58,14 +58,13 @@ test(TIME_ChangingTimeZoneWorksImmediately) {
     Time.zone(4);
     int newHour = Time.hour();
     assertMoreOrEqual(4, (newHour-currentHour)%12);
-
+    Time.zone(0);
 }
 
 test(TIME_Format) {
 
     Time.zone(-5);
     time_t t = 1024*1024*1024;
-
     assertEqual(Time.timeStr(t).c_str(),(const char*)"Sat Jan 10 08:37:04 2004");
     assertEqual(Time.timeStr(t, TIME_FORMAT_DEFAULT).c_str(), (const char*)("Sat Jan 10 08:37:04 2004"));
     assertEqual(Time.timeStr(t, TIME_FORMAT_ISO8601_FULL).c_str(), (const char*)"2004-01-10T08:37:04-05:00");
@@ -73,6 +72,14 @@ test(TIME_Format) {
     assertEqual(Time.timeStr(t).c_str(), (const char*)("2004-01-10T08:37:04-05:00"));
     Time.zone(0);
     assertEqual(Time.timeStr(t).c_str(), (const char*)("2004-01-10T13:37:04Z"));
+    Time.setFormat(TIME_FORMAT_DEFAULT);
+}
 
-
+test(TIME_concatenate) {
+    // addresses reports of timeStr() not being concatenatable
+    time_t t = 1024*1024*1024;
+    assertEqual(Time.timeStr(t,TIME_FORMAT_DEFAULT).c_str(),(const char*)"Sat Jan 10 13:37:04 2004");
+    String s = Time.timeStr(t,TIME_FORMAT_DEFAULT);
+    s += "abcd";
+    assertEqual(s.c_str(), (const char*)"Sat Jan 10 13:37:04 2004abcd");
 }

--- a/user/tests/wiring/no_fixture/time.cpp
+++ b/user/tests/wiring/no_fixture/time.cpp
@@ -60,3 +60,19 @@ test(TIME_ChangingTimeZoneWorksImmediately) {
     assertMoreOrEqual(4, (newHour-currentHour)%12);
 
 }
+
+test(TIME_Format) {
+
+    Time.zone(-5);
+    time_t t = 1024*1024*1024;
+
+    assertEqual(Time.timeStr(t).c_str(),(const char*)"Sat Jan 10 08:37:04 2004");
+    assertEqual(Time.timeStr(t, TIME_FORMAT_DEFAULT).c_str(), (const char*)("Sat Jan 10 08:37:04 2004"));
+    assertEqual(Time.timeStr(t, TIME_FORMAT_ISO8601_FULL).c_str(), (const char*)"2004-01-10T08:37:04-05:00");
+    Time.setFormat(TIME_FORMAT_ISO8601_FULL);
+    assertEqual(Time.timeStr(t).c_str(), (const char*)("2004-01-10T08:37:04-05:00"));
+    Time.zone(0);
+    assertEqual(Time.timeStr(t).c_str(), (const char*)("2004-01-10T13:37:04Z"));
+
+
+}

--- a/wiring/inc/spark_wiring_time.h
+++ b/wiring/inc/spark_wiring_time.h
@@ -29,6 +29,12 @@
 #include "spark_wiring_string.h"
 #include <time.h>
 
+enum time_format_t
+{
+    TIME_FORMAT_DEFAULT = 0,
+    TIME_FORMAT_ISO8601_FULL = 1
+};
+
 class TimeClass {
 public:
 	// Arduino time and date functions
@@ -55,8 +61,39 @@ public:
 	static time_t  now();              			// return the current time as seconds since Jan 1 1970
 	static void    zone(float GMT_Offset);		// set the time zone (+/-) offset from GMT
 	static void    setTime(time_t t);			// set the given time as unix/rtc time
-	static String  timeStr();			// returns string representation for the current time
-	static String  timeStr(time_t t);			// returns string representation for the given time
+
+
+        /* return string representation of the current time */
+        inline String timeStr()
+        {
+                return timeStr(now(), format_spec);
+        }
+
+        inline String timeStr(time_format_t format_spec)
+        {
+                return timeStr(now(), format_spec);
+        }
+
+        /* return string representation for the given time */
+        inline String timeStr(time_t t)
+        {
+            return timeStr(t, format_spec);
+        }
+
+        static String timeStr(time_t t, time_format_t format_spec);
+
+        static String format(time_t t, const char* format_spec);
+
+        void setFormat(time_format_t format) {
+            this->format_spec = format;
+        }
+
+        time_format_t getFormat() const { return format_spec; }
+
+private:
+    static time_format_t format_spec;
+    static String timeFormatImpl(tm* calendar_time, const char* format, int time_zone);
+
 };
 
 extern TimeClass Time;	//eg. usage: Time.day();

--- a/wiring/src/spark_wiring_time.cpp
+++ b/wiring/src/spark_wiring_time.cpp
@@ -287,9 +287,10 @@ String TimeClass::timeFormatImpl(tm* calendar_time, const char* format, int time
 {
     if (!format)
     {
-	String calendar_time_string = String(asctime(calendar_time));
-        calendar_time_string[calendar_time_string.length()-1] = 0;
-	return calendar_time_string;
+        char* ascstr = asctime(calendar_time);
+        int len = strlen(ascstr);
+        ascstr[len-1] = 0; // remove final newline
+	return String(ascstr);
     }
     else
     {

--- a/wiring/src/spark_wiring_time.cpp
+++ b/wiring/src/spark_wiring_time.cpp
@@ -25,6 +25,15 @@
 
 #include "spark_wiring_time.h"
 #include "rtc_hal.h"
+#include "stdio.h"
+
+// these follow the same order as the time_format_t constants
+static const char* time_formats[] = {
+    NULL,                                       // DEFAULT - means use asctime()
+    "%FT%T",                                   // ISO8601_FULL
+    "%Y-%m-%dT%H:%M:%S%z"
+                                        //
+};
 
 /* The calendar "tm" structure from the standard libray "time.h" has the following definition: */
 //struct tm
@@ -99,6 +108,8 @@ static void Refresh_UnixTime_Cache(time_t unix_time)
             unix_time_cache = unix_time;
     }
 }
+
+time_format_t TimeClass::format_spec = TIME_FORMAT_DEFAULT;
 
 /* current hour */
 int TimeClass::hour()
@@ -255,21 +266,44 @@ void TimeClass::setTime(time_t t)
     HAL_RTC_Set_UnixTime(t);
 }
 
-/* return string representation of the current time */
-String TimeClass::timeStr()
+/* return string representation for the given time */
+String TimeClass::timeStr(time_t t, time_format_t format)
 {
-	return timeStr(now());
+	t += time_zone_cache;
+	tm* calendar_time = localtime(&t);
+
+        const char* format_string = time_formats[format];
+        return timeFormatImpl(calendar_time, format_string, time_zone_cache);
 }
 
-/* return string representation for the given time */
-String TimeClass::timeStr(time_t t)
+String TimeClass::format(time_t t, const char* format_spec)
 {
-	struct tm *calendar_time;
-	t += time_zone_cache;
-	calendar_time = localtime(&t);
+    t += time_zone_cache;
+    tm* calendar_time = localtime(&t);
+    return timeFormatImpl(calendar_time, format_spec, time_zone_cache);
+}
+
+String TimeClass::timeFormatImpl(tm* calendar_time, const char* format, int time_zone)
+{
+    if (!format)
+    {
 	String calendar_time_string = String(asctime(calendar_time));
-    calendar_time_string[calendar_time_string.length()-1] = 0;
+        calendar_time_string[calendar_time_string.length()-1] = 0;
 	return calendar_time_string;
+    }
+    else
+    {
+        char buf[50];
+        strftime(buf, 50, format, calendar_time);
+        char* e = buf+strlen(buf);
+        // while we are not using stdlib for managing the timezone, we have to do this manually
+        if (!time_zone)
+            strcpy(e, "Z");
+        else {
+            snprintf(e, sizeof(buf)-(e-buf), "%+03d:%02u", time_zone/3600, time_zone%3600);
+        }
+        return String(buf);
+    }
 }
 
 TimeClass Time;


### PR DESCRIPTION
#455 - configurable format to Time.timeStr(), and a generic time formatter `Time.format(time_t, format_spec)` based on `strftime()`.  Complete with API and unit tests.


Here's the new APIs:

```c++
String s = Time.timeStr();
// as before - outputs time like
// Sat Jan 10 13:37:04 2004


String s = Time.timeStr(TIME_FORMAT_ISO8601_FULL);
// Current time formatted ISO8601,  no time zone configured
// 2004-01-10T13:37:04Z

// can also specify the time to convert
time_t beer_oclock = Time.now()+1234;
String s = Time.timeStr(beer_oclock, TIME_FORMAT_ISO8601_FULL);

// configure timezone
Time.zone(-5);
String s = Time.timeStr(TIME_FORMAT_ISO8601_FULL);
// current time formated in ISO8601, includes time zone
// 2004-01-10T08:37:04-05:00

// If not provided, the format is TIME_FORMAT_DEFAULT 
// (the format used by Time.timeStr() in prior versions.)
// the format to use when none specified can be managed using these APIs

Time.setFormat(format);
Time.getFormat();

// So

// set the default format
Time.setFormat(TIME_FORMAT_ISO8601_FULL);
String s = Time.timeStr();
// prints the current time in iso 8601 format, e.g.. 2004-01-10T08:37:04-05:00

// finally a new API based on [strftime](http://www.cplusplus.com/reference/ctime/strftime/)
String s = Time.format(Time.now(), "It's %I:%M%p.")
// s == It's 12:45pm

```




```

