### PR TITLE
servo trim

### DIFF
--- a/wiring/inc/spark_wiring_servo.h
+++ b/wiring/inc/spark_wiring_servo.h
@@ -180,13 +180,15 @@ public:
      */
     uint16_t readMicroseconds() const;
 
+    void setTrim(int trim);
+
 private:
     int16_t pin;
     uint16_t minPW;
     uint16_t maxPW;
     int16_t minAngle;
     int16_t maxAngle;
-
+    int trim;
     void resetFields(void);
 };
 

--- a/wiring/src/spark_wiring_servo.cpp
+++ b/wiring/src/spark_wiring_servo.cpp
@@ -88,12 +88,12 @@ bool Servo::detach()
 void Servo::write(int degrees)
 {
   degrees = constrain(degrees, this->minAngle, this->maxAngle);
-  this->writeMicroseconds(ANGLE_TO_US(degrees));
+  this->writeMicroseconds(ANGLE_TO_US(degrees)+trim);
 }
 
 int Servo::read() const
 {
-  int a = US_TO_ANGLE(this->readMicroseconds());
+  int a = US_TO_ANGLE(this->readMicroseconds()-trim);
   // map() round-trips in a weird way we mostly correct for here;
   // the round-trip is still sometimes off-by-one for write(1) and
   // write(179).
@@ -130,4 +130,5 @@ void Servo::resetFields(void)
   this->maxAngle = SERVO_DEFAULT_MAX_ANGLE;
   this->minPW = SERVO_DEFAULT_MIN_PW;
   this->maxPW = SERVO_DEFAULT_MAX_PW;
+  this->trim = 0;
 }


### PR DESCRIPTION
fix for #120 - provide a setTrim() method that users can minutely adjust the servo timing. Untested.