### PR TITLE
Fix RTC issue on Electron - override RTC alarm interrupt handler

### DIFF
--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -76,11 +76,11 @@ IDX[x] = added IRQ handler
 19 [ ] RTC_WKUP_IRQHandler               // RTC Wakeup through the EXTI line
 20 [ ] FLASH_IRQHandler                  // FLASH
 21 [ ] RCC_IRQHandler                    // RCC
-22 [ ] EXTI0_IRQHandler                  // EXTI Line0
-23 [ ] EXTI1_IRQHandler                  // EXTI Line1
-24 [ ] EXTI2_IRQHandler                  // EXTI Line2
-25 [ ] EXTI3_IRQHandler                  // EXTI Line3
-26 [ ] EXTI4_IRQHandler                  // EXTI Line4
+22 [x] EXTI0_IRQHandler                  // EXTI Line0
+23 [x] EXTI1_IRQHandler                  // EXTI Line1
+24 [x] EXTI2_IRQHandler                  // EXTI Line2
+25 [x] EXTI3_IRQHandler                  // EXTI Line3
+26 [x] EXTI4_IRQHandler                  // EXTI Line4
 27 [ ] DMA1_Stream0_IRQHandler           // DMA1 Stream 0
 28 [ ] DMA1_Stream1_IRQHandler           // DMA1 Stream 1
 29 [ ] DMA1_Stream2_IRQHandler           // DMA1 Stream 2
@@ -110,8 +110,8 @@ IDX[x] = added IRQ handler
 53 [x] USART1_IRQHandler                 // USART1
 54 [x] USART2_IRQHandler                 // USART2
 55 [x] USART3_IRQHandler                 // USART3
-56 [ ] EXTI15_10_IRQHandler              // External Line[15:10]s
-57 [ ] RTC_Alarm_IRQHandler              // RTC Alarm (A and B) through EXTI Line
+56 [x] EXTI15_10_IRQHandler              // External Line[15:10]s
+57 [x] RTC_Alarm_IRQHandler              // RTC Alarm (A and B) through EXTI Line
 58 [x] OTG_FS_WKUP_IRQHandler            // USB OTG FS Wakeup through EXTI line
 59 [x] TIM8_BRK_TIM12_IRQHandler         // TIM8 Break and TIM12
 60 [x] TIM8_UP_TIM13_IRQHandler          // TIM8 Update and TIM13
@@ -183,6 +183,7 @@ const unsigned USART1_IRQHandler_Idx                = 53;
 const unsigned USART2_IRQHandler_Idx                = 54;
 const unsigned USART3_IRQHandler_Idx                = 55;
 const unsigned EXTI15_10_IRQHandler_Idx             = 56;
+const unsigned RTC_Alarm_IRQHandler_Idx             = 57;
 const unsigned OTG_FS_WKUP_IRQHandler_Idx           = 58;
 const unsigned TIM8_BRK_TIM12_IRQHandler_Idx        = 59;
 const unsigned TIM8_UP_TIM13_IRQHandler_Idx         = 60;
@@ -284,6 +285,7 @@ void HAL_Core_Setup_override_interrupts(void)
     isrs[I2C3_ER_IRQHandler_Idx]            = (uint32_t)I2C3_ER_irq;
     isrs[DMA1_Stream7_IRQHandler_Idx]       = (uint32_t)DMA1_Stream7_irq;
     isrs[DMA2_Stream5_IRQHandler_Idx]       = (uint32_t)DMA2_Stream5_irq;
+    isrs[RTC_Alarm_IRQHandler_Idx]          = (uint32_t)RTC_Alarm_irq;
     SCB->VTOR = (unsigned long)isrs;
 }
 

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -210,10 +210,8 @@ void HAL_Core_Config(void)
 #endif
 
     HAL_Core_Config_systick_configuration();
-#if PLATFORM_ID!=PLATFORM_ELECTRON_PRODUCTION
-    // ELECTRON TODO: re-instate this when working
+
     HAL_RTC_Configuration();
-#endif
 
     HAL_RNG_Configuration();
 

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.h
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.h
@@ -84,6 +84,7 @@ void EXTI3_IRQHandler(void);
 void EXTI4_IRQHandler(void);
 void EXTI9_5_IRQHandler(void);
 void EXTI15_10_IRQHandler(void);
+void RTC_Alarm_irq(void);
 
 
 // etc... all ISRs ending _irq()). These are named after the values they had in WICED


### PR DESCRIPTION
@technobly @mohitbhoite @towynlin @brandoaire The RTC on electron works now after overriding the RTC alarm interrupt handler. So it's not an issue with the crystals or the loading caps as we concluded earlier