### PR TITLE
Switch to latest branch before attempting to build

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -33,7 +33,11 @@ Open up a terminal window, navigate to your destination directory and type the f
 Make sure you have downloaded and installed all the required dependencies as mentioned [previously](dependencies.md#1-download-and-install-dependencies).
 Note, if you've downloaded or cloned these previously, you'll want to `git pull` or redownload all of them before proceeding.
 
-Open up a terminal window, navigate to the `modules` folder under firmware
+Open up a terminal window, and switch branch to 'latest'
+
+    git checkout latest
+
+Navigate to the `modules` folder under firmware
 (i.e. `cd firmware/modules`) and type:
 
     make clean all PLATFORM=photon -s program-dfu


### PR DESCRIPTION
Can't build in develop branch
```
➜  modules git:(develop) make clean all PLATFORM=photon -s program-dfu
clean all program-dfu
../../../build/checks.mk:5: *** Please note the develop branch contains untested, unreleased code. We recommend using the 'latest' branch which contains the latest released firmware code. To build the develop branch, please see the the build documentation at https://github.com/spark/firmware/blob/develop/docs/build.md#building-the-develop-branch.  Stop.
make: *** [/Users/anuj/code/spark/firmware/modules/photon/system-part1/makefile] Error 2
```