### PR TITLE
Print.printf/printfln

### DIFF
--- a/user/tests/unit/print.cpp
+++ b/user/tests/unit/print.cpp
@@ -1,0 +1,58 @@
+
+#include "catch.hpp"
+#include "spark_wiring_print.h"
+
+
+class BufferPrint : public Print
+{
+    String value;
+
+public:
+    size_t write(uint8_t c)
+    {
+        value += (char)c;
+        return 1;
+    }
+
+    const String& result()
+    {
+        return value;
+    }
+};
+
+
+SCENARIO("Print.printf() with a small string", "[print]")
+{
+    BufferPrint print;
+    print.printf("abcd %d", 10);
+    REQUIRE(String("abcd 10") == print.result());
+}
+
+SCENARIO("Print.printfln() with a small string", "[print]")
+{
+    BufferPrint print;
+    print.printfln("abcd %d", 10);
+    REQUIRE(String("abcd 10\r\n") == print.result());
+}
+
+
+SCENARIO("Print.printf() with a 19-char string", "[print]")
+{
+    BufferPrint print;
+    print.printf("abcdabcdabcdabcd %d", 10);
+    REQUIRE(String("abcdabcdabcdabcd 10") == print.result());
+}
+
+SCENARIO("Print.printf() with a 20-char string", "[print]")
+{
+    BufferPrint print;
+    print.printf("abcdabcdabcdabcd %d", 100);
+    REQUIRE(String("abcdabcdabcdabcd 100") == print.result());
+}
+
+SCENARIO("Print.printf() with a a > 20 char string", "[print]")
+{
+    BufferPrint print;
+    print.printf("abcdabcdabcdabcd %d xyzxyzxyzxyzxyzxyzxyzxyz", 100);
+    REQUIRE(String("abcdabcdabcdabcd 100 xyzxyzxyzxyzxyzxyzxyzxyz") == print.result());
+}

--- a/wiring/inc/spark_wiring_print.h
+++ b/wiring/inc/spark_wiring_print.h
@@ -49,6 +49,8 @@ class Print
     size_t printFloat(double, uint8_t);
   protected:
     void setWriteError(int err = 1) { write_error = err; }
+    size_t printf_impl(bool newline, const char* format, ...);
+
   public:
     Print() : write_error(0) {}
     virtual ~Print() {}
@@ -83,6 +85,21 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    size_t printfln(const char* format, ...);
+
+    template <typename... Args>
+    inline size_t printf(const char* format, Args... args)
+    {
+        return this->printf_impl(false, format, args...);
+    }
+
+    template <typename... Args>
+    inline size_t printfln(const char* format, Args... args)
+    {
+        return this->printf_impl(true, format, args...);
+    }
+
 };
 
 #endif

--- a/wiring/src/spark_wiring_print.cpp
+++ b/wiring/src/spark_wiring_print.cpp
@@ -25,6 +25,8 @@
  */
 
 #include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
 #include "spark_wiring_print.h"
 #include "spark_wiring_string.h"
 #include "spark_wiring_stream.h"
@@ -240,3 +242,29 @@ size_t Print::printFloat(double number, uint8_t digits)
 
   return n;
 }
+
+size_t Print::printf_impl(bool newline, const char* format, ...)
+{
+    char test[5];
+    va_list marker;
+    va_start(marker, format);
+    size_t n = vsnprintf(test, 1, format, marker);
+    va_end(marker);
+
+    if (n<5)
+    {
+        n = print(test);
+    }
+    else
+    {
+        char bigger[n+1];
+        va_start(marker, format);
+        n = vsnprintf(bigger, n+1, format, marker);
+        va_end(marker);
+        n = print(bigger);
+    }
+    if (newline)
+        n += println();
+    return n;
+}
+

--- a/wiring/src/spark_wiring_print.cpp
+++ b/wiring/src/spark_wiring_print.cpp
@@ -245,13 +245,14 @@ size_t Print::printFloat(double number, uint8_t digits)
 
 size_t Print::printf_impl(bool newline, const char* format, ...)
 {
-    char test[5];
+    const int bufsize = 20;
+    char test[bufsize];
     va_list marker;
     va_start(marker, format);
-    size_t n = vsnprintf(test, 1, format, marker);
+    size_t n = vsnprintf(test, bufsize, format, marker);
     va_end(marker);
 
-    if (n<5)
+    if (n<bufsize)
     {
         n = print(test);
     }


### PR DESCRIPTION
This little gem allows you to write printf-like statements to any Print instance (Serial, TCPClient etc...)


```
Serial.printfln("There are %s types of people in the world, those that understand binary and those that don't", "10");

Serial.printfln("There are %d sweets in the jar", rand()%560);
```

Without the API we'd have to write:

```
Serial.print("There are");
Serial.print(10);
Serial.println("types of people in the world, those that understand binary and those that don't");

Serial.print("There are ");
Serial.print(rand()%560);
Serial.println("sweets in the jar");

```

I've wanted this for ages - formatting messages otherwise is quite tedious, requiring them to be split over many lines of code.

`printf` formats the message as given, `printfln` adds a newline at the end. 