### PR TITLE
Feature/system ticks

### DIFF
--- a/platform/MCU/newhal-mcu/inc/hw_ticks.h
+++ b/platform/MCU/newhal-mcu/inc/hw_ticks.h
@@ -1,8 +1,6 @@
 /**
-  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
-
-  Copyright 2012 STMicroelectronics
-  http://www.st.com/software_license_agreement_liberty_v2
+ ******************************************************************************
+  Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -19,18 +17,23 @@
  ******************************************************************************
  */
 
+
 #pragma once
 
-#ifdef	__cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * The number of ticks per microsecond of the system counter.
+ * SYSTEM_TICK_COUNTER
+ */
+#define SYSTEM_US_TICKS		100     // cycles per microsecond
 
-#include "platform_config.h"
-#include "system_tick_hal.h"
-
-#define SYSTEM_US_TICKS		(SystemCoreClock / 1000000)//cycles per microsecond
-#define SYSTEM_TICK_COUNTER     (DWT->CYCCNT)
+/**
+ * Should return a value from a system counter.
+ */
+#define SYSTEM_TICK_COUNTER     0
 
 /**
  * Increment the millisecond tick counter.
@@ -57,18 +60,6 @@ system_tick_t GetSystem1MsTick();
 system_tick_t GetSystem1UsTick();
 
 
-/**
- * Testing method that simulates advancing the time forward.
- */
-void __advance_system1MsTick(system_tick_t millis, system_tick_t micros_from_rollover);
-
-void SysTick_Disable();
-
-
-
-#ifdef	__cplusplus
+#ifdef __cplusplus
 }
 #endif
-
-
-

--- a/user/tests/wiring/api/platform.cpp
+++ b/user/tests/wiring/api/platform.cpp
@@ -16,3 +16,12 @@ test(api_platform_stm32f2) {
 }
 
 #endif
+
+
+test(system_ticks)
+{
+    uint32_t value;
+    API_COMPILE(value=System.ticks());
+    API_COMPILE(value=System.ticks());
+    (void)value;
+}

--- a/user/tests/wiring/api/platform.cpp
+++ b/user/tests/wiring/api/platform.cpp
@@ -22,6 +22,7 @@ test(system_ticks)
 {
     uint32_t value;
     API_COMPILE(value=System.ticks());
-    API_COMPILE(value=System.ticks());
+    API_COMPILE(value=System.ticksPerMicrosecond());
+    API_COMPILE(System.ticksDelay(30));
     (void)value;
 }

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -68,12 +68,20 @@ public:
     }
 
 #ifdef SPARK_PLATFORM
-    static inline uint32_t ticksPerMicrosecond() {
+    static inline uint32_t ticksPerMicrosecond()
+    {
         return SYSTEM_US_TICKS;
     }
 
-    static inline uint32_t ticks() {
+    static inline uint32_t ticks()
+    {
         return DWT->CYCCNT;
+    }
+
+    static inline void ticksDelay(uint32_t duration)
+    {
+        uint32_t start = ticks();
+        while ((ticks()-start)<duration) {}
     }
 #endif
 

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -35,11 +35,6 @@
 #include "system_user.h"
 #ifdef SPARK_PLATFORM
 #include "hw_ticks.h"
-#if PLATFORM_ID<3
-#include "stm32f10x.h"
-#else
-#include "stm32f2xx.h"
-#endif
 #endif
 
 class Stream;
@@ -75,7 +70,7 @@ public:
 
     static inline uint32_t ticks()
     {
-        return DWT->CYCCNT;
+        return SYSTEM_TICK_COUNTER;
     }
 
     static inline void ticksDelay(uint32_t duration)

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -33,6 +33,14 @@
 #include "interrupts_hal.h"
 #include "core_hal.h"
 #include "system_user.h"
+#ifdef SPARK_PLATFORM
+#include "hw_ticks.h"
+#if PLATFORM_ID<3
+#include "stm32f10x.h"
+#else
+#include "stm32f2xx.h"
+#endif
+#endif
 
 class Stream;
 
@@ -58,6 +66,16 @@ public:
     static void enterSafeMode(void) {
         HAL_Core_Enter_Safe_Mode(NULL);
     }
+
+#ifdef SPARK_PLATFORM
+    static inline uint32_t ticksPerMicrosecond() {
+        return SYSTEM_US_TICKS;
+    }
+
+    static inline uint32_t ticks() {
+        return DWT->CYCCNT;
+    }
+#endif
 
     static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0);
     static void sleep(long seconds) { sleep(SLEEP_MODE_WLAN, seconds); }


### PR DESCRIPTION
#406 

Allows implementation of accurate microsecond delays.  (Although not that when we introduce the RTOS loops like this will need to be made atomic so there is no chance of a context switch.)

```
// get the current system ticks value
uint32_t now = System.ticks();

// for converting an the unknown system tick frequency into microseconds
uint32_t scale = System.ticksPerMicrosecond();

// delay a given number of ticks. 
System.ticksDelay(20*System.ticksPerMicrosecond());

```

The main motivation for this is that it allows very precise timing measurements and delays without function call overhead (all functions are ideally inlined by the compiler.)