### PR TITLE
Serial.flush()

### DIFF
--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -53,7 +53,9 @@ DYNALIB_FN(hal_usart,HAL_USART_Peek_Data)
 DYNALIB_FN(hal_usart,HAL_USART_Flush_Data)
 DYNALIB_FN(hal_usart,HAL_USART_Is_Enabled)
 DYNALIB_FN(hal_usart,HAL_USART_Half_Duplex)
-
+#ifdef USB_CDC_ENABLE
+DYNALIB_FN(hal_usart,USB_USART_Flush_Data)
+#endif
 DYNALIB_END(hal_usart)
 
 #endif	/* HAL_DYNALIB_USART_H */

--- a/hal/inc/usb_hal.h
+++ b/hal/inc/usb_hal.h
@@ -95,6 +95,14 @@ int32_t USB_USART_Receive_Data(uint8_t peek);
  * @param Data      The data to write.
  */
 void USB_USART_Send_Data(uint8_t Data);
+
+/**
+ * Wait for data to be flushed. Returns true if the data was flushed within the given timeout, false otherwise.
+ * @param timeout
+ * @param reserved
+ */
+bool USB_USART_Flush_Data(uint32_t timeout, void* reserved);
+
 #endif
 
 #ifdef USB_HID_ENABLE

--- a/hal/src/stm32f2xx/usb_hal.c
+++ b/hal/src/stm32f2xx/usb_hal.c
@@ -33,6 +33,7 @@
 #include "usb_conf.h"
 #include "usbd_desc.h"
 #include "delay_hal.h"
+#include "timer_hal.h"
 
 /* Private typedef -----------------------------------------------------------*/
 
@@ -56,6 +57,7 @@ extern volatile uint8_t USB_DEVICE_CONFIGURED;
 extern volatile uint8_t USB_Rx_Buffer[];
 extern volatile uint8_t APP_Rx_Buffer[];
 extern volatile uint32_t APP_Rx_ptr_in;
+extern volatile uint32_t APP_Rx_ptr_out;
 extern volatile uint16_t USB_Rx_length;
 extern volatile uint16_t USB_Rx_ptr;
 extern volatile uint8_t  USB_Tx_State;
@@ -204,6 +206,14 @@ void USB_USART_Send_Data(uint8_t Data)
     //Delay 100us to avoid losing the data
     HAL_Delay_Microseconds(100);
 }
+
+bool USB_USART_Flush_Data(uint32_t timeout, void* reserved)
+{
+    system_tick_t start = HAL_Timer_Get_Milli_Seconds();
+    while ((APP_Rx_ptr_out != APP_Rx_ptr_in) &&  ((HAL_Timer_Get_Milli_Seconds()-start) < timeout));
+    return (APP_Rx_ptr_out == APP_Rx_ptr_in);
+}
+
 #endif
 
 #ifdef USB_HID_ENABLE

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -67,6 +67,7 @@ size_t USBSerial::write(uint8_t byte)
 
 void USBSerial::flush()
 {
+    USB_USART_Flush_Data(10000, NULL);
 }
 
 int USBSerial::peek()


### PR DESCRIPTION
Attempting to fix this, but this is not a solution since there is no way to know if there is a USB device connected that will consume the data.  While there is no device connected, the application will wait indefinitely for the data to be sent, blocking the call to flush().

It's not clear to me if that should be the correct behaviour. I can see it breaking existing programs.

Here's a test app:

```
void setup()
{
    Serial.begin(9600);
    pinMode(D7, OUTPUT);
}

void loop()
{
    Serial.println("Hello world here is a very long string to full a buffer");
    Serial.flush();
    delay(1000);
    digitalWrite(D7, !digitalRead(D7));
}
```

When the serial monitor is open (e.g. screen on OSX) then the application prints data and the D7 LED flashes on and off. Once the serial monitor is closed, the LED stops blinking for 10s (the default timeout.)