### PR TITLE
Feature/button events

### DIFF
--- a/system/inc/system_dynalib.h
+++ b/system/inc/system_dynalib.h
@@ -47,6 +47,7 @@ DYNALIB_FN(system, system_sleep)
 DYNALIB_FN(system, system_sleep_pin)
 DYNALIB_FN(system, system_subscribe_event)
 DYNALIB_FN(system, system_unsubscribe_event)
+DYNALIB_FN(system, system_button_pushed_duration)
 DYNALIB_END(system)
 
 

--- a/system/inc/system_mode.h
+++ b/system/inc/system_mode.h
@@ -19,6 +19,8 @@
 #ifndef SYSTEM_MODE_H
 #define	SYSTEM_MODE_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,6 +32,8 @@ typedef enum
 
 void set_system_mode(System_Mode_TypeDef mode);
 System_Mode_TypeDef system_mode();
+
+uint16_t system_button_pushed_duration(uint8_t button, void* reserved);
 
 #ifdef __cplusplus
 }

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -80,7 +80,9 @@ void HAL_Notify_Button_State(uint8_t button, uint8_t pressed)
 {
     if (button==0)
     {
-        if (pressed) {
+        if (pressed)
+        {
+            WLAN_DELETE_PROFILES = 0;
             wasListeningOnButtonPress = network.listening();
             buttonPushed = HAL_Timer_Get_Milli_Seconds();
             if (!wasListeningOnButtonPress)
@@ -160,14 +162,13 @@ extern "C" void HAL_SysTick_Handler(void)
     }
     else if(network.listening() && HAL_Core_Mode_Button_Pressed(10000))
     {
-        network.listen_command();
-        HAL_Core_Mode_Button_Reset();
+        network.listen_command();       
     }
     // determine if the button press needs to change the state (and hasn't done so already))
     else if(!network.listening() && HAL_Core_Mode_Button_Pressed(3000) && !wasListeningOnButtonPress)
     {
         if (network.connecting()) {
-            network.connect_cancel();
+            network.connect_cancel(true);
         }
         // fire the button event to the user, then enter listening mode (so no more button notifications are sent)
         // there's a race condition here - the HAL_notify_button_state function should

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -62,6 +62,13 @@ static volatile uint32_t TimingIWDGReload;
 static volatile bool wasListeningOnButtonPress;
 static volatile uint16_t buttonPushed;
 
+uint16_t system_button_pushed_duration(uint8_t button, void*)
+{
+    if (button || WLAN_SMART_CONFIG_START)
+        return 0;
+    return buttonPushed ? HAL_Timer_Get_Milli_Seconds()-buttonPushed : 0;
+}
+
 /* Extern variables ----------------------------------------------------------*/
 
 /* Private function prototypes -----------------------------------------------*/

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -64,7 +64,7 @@ static volatile uint16_t buttonPushed;
 
 uint16_t system_button_pushed_duration(uint8_t button, void*)
 {
-    if (button || WLAN_SMART_CONFIG_START)
+    if (button || network.listening())
         return 0;
     return buttonPushed ? HAL_Timer_Get_Milli_Seconds()-buttonPushed : 0;
 }
@@ -82,7 +82,6 @@ void HAL_Notify_Button_State(uint8_t button, uint8_t pressed)
     {
         if (pressed)
         {
-            WLAN_DELETE_PROFILES = 0;
             wasListeningOnButtonPress = network.listening();
             buttonPushed = HAL_Timer_Get_Milli_Seconds();
             if (!wasListeningOnButtonPress)
@@ -162,13 +161,13 @@ extern "C" void HAL_SysTick_Handler(void)
     }
     else if(network.listening() && HAL_Core_Mode_Button_Pressed(10000))
     {
-        network.listen_command();       
+        network.listen_command();
     }
     // determine if the button press needs to change the state (and hasn't done so already))
     else if(!network.listening() && HAL_Core_Mode_Button_Pressed(3000) && !wasListeningOnButtonPress)
     {
         if (network.connecting()) {
-            network.connect_cancel(true);
+            network.connect_cancel();
         }
         // fire the button event to the user, then enter listening mode (so no more button notifications are sent)
         // there's a race condition here - the HAL_notify_button_state function should

--- a/user/tests/unit/dcd.cpp
+++ b/user/tests/unit/dcd.cpp
@@ -144,7 +144,7 @@ SCENARIO("DCD can write whole sector", "[dcd]")
     TestDCD dcd;
 
     uint8_t expected[dcd.Length];
-    for (int i=0; i<dcd.Length; i++)
+    for (unsigned i=0; i<dcd.Length; i++)
         expected[i] = rand();
 
     dcd.write(0, expected, dcd.Length);

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -57,6 +57,10 @@ public:
     static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0);
     static String deviceID(void) { return spark_deviceID(); }
 
+    static uint16_t buttonPushed(uint8_t button=0) {
+        return system_button_pushed_duration(button, NULL);
+    }
+
     static bool on(system_event_t events, void(*handler)(system_event_t, uint32_t,void*)) {
         return !system_subscribe_event(events, handler, nullptr);
     }


### PR DESCRIPTION
reworked button events to be more flexible, simpler to code and easier to hook by applications.

e.g. example app that turns the LED magenta while the button is held down

```
void button_handler(system_event_t event, uint32_t duration, void* )
{
    if (!duration) { // just pressed
        RGB.control(true);
        RGB.color(255,0,128);
    }
    else {    // just released
        RGB.control(false);
    }
}

void setup()
{
    System.on(button_status, button_handler);
}

void loop()
{
// it would be nice to fire routine events while the button is being pushed, rather than rely upon loop
    if (System.buttonPushed()>1000) {
        RGB.color(255,128,0);
    }
}
```

