### PR TITLE
strict typechecks for Particle.variable()

### DIFF
--- a/hal/inc/spi_hal.h
+++ b/hal/inc/spi_hal.h
@@ -58,6 +58,8 @@ typedef void (*HAL_SPI_DMA_UserCallback)(void);
 #define SPI_CLOCK_DIV128        0x30
 #define SPI_CLOCK_DIV256        0x38
 
+#define SPI_DEFAULT_SS          ((uint16_t)(-1))
+
 /* Exported functions --------------------------------------------------------*/
 
 #ifdef __cplusplus

--- a/hal/src/core/spi_hal.c
+++ b/hal/src/core/spi_hal.c
@@ -53,6 +53,9 @@ void HAL_SPI_Init(HAL_SPI_Interface spi)
 
 void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin)
 {
+    if (pin==SPI_DEFAULT_SS)
+        pin = SS;
+
   RCC_APB2PeriphClockCmd(RCC_APB2Periph_SPI1, ENABLE);
 
   HAL_Pin_Mode(SCK, AF_OUTPUT_PUSHPULL);

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -59,31 +59,34 @@ typedef enum
 	CLOUD_VAR_BOOLEAN = 1, CLOUD_VAR_INT = 2, CLOUD_VAR_STRING = 4, CLOUD_VAR_DOUBLE = 9
 } Spark_Data_TypeDef;
 
+#ifdef PLATFORM_ID
 STATIC_ASSERT(spark_data_typedef_is_1_byte, sizeof(Spark_Data_TypeDef)==1);
+#endif
 
 struct CloudVariableTypeBase {};
 struct CloudVariableTypeBool : public CloudVariableTypeBase {
     using vartype = bool;
     using varref = bool*;
-
+    CloudVariableTypeBool(){};
     static inline Spark_Data_TypeDef value() { return CLOUD_VAR_BOOLEAN; }
 };
 struct CloudVariableTypeInt : public CloudVariableTypeBase {
     using vartype = int;
     using varref = int*;
-
+    CloudVariableTypeInt(){};
     static inline Spark_Data_TypeDef value() { return CLOUD_VAR_INT; }
 };
 struct CloudVariableTypeString : public CloudVariableTypeBase {
     using vartype = const char*;
     using varref = const char*;
-
+    CloudVariableTypeString(){};
     static inline Spark_Data_TypeDef value() { return CLOUD_VAR_STRING; }
 };
 struct CloudVariableTypeDouble : public CloudVariableTypeBase {
     using vartype = double;
     using varref = double*;
 
+    CloudVariableTypeDouble(){};
     static inline Spark_Data_TypeDef value() { return CLOUD_VAR_DOUBLE; }
 };
 

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -56,8 +56,42 @@ void system_set_time(time_t time, unsigned param, void* reserved);
 
 typedef enum
 {
-	BOOLEAN = 1, INT = 2, STRING = 4, DOUBLE = 9
+	CLOUD_VAR_BOOLEAN = 1, CLOUD_VAR_INT = 2, CLOUD_VAR_STRING = 4, CLOUD_VAR_DOUBLE = 9
 } Spark_Data_TypeDef;
+
+STATIC_ASSERT(spark_data_typedef_is_1_byte, sizeof(Spark_Data_TypeDef)==1);
+
+struct CloudVariableTypeBase {};
+struct CloudVariableTypeBool : public CloudVariableTypeBase {
+    using vartype = bool;
+    using varref = bool*;
+
+    static inline Spark_Data_TypeDef value() { return CLOUD_VAR_BOOLEAN; }
+};
+struct CloudVariableTypeInt : public CloudVariableTypeBase {
+    using vartype = int;
+    using varref = int*;
+
+    static inline Spark_Data_TypeDef value() { return CLOUD_VAR_INT; }
+};
+struct CloudVariableTypeString : public CloudVariableTypeBase {
+    using vartype = const char*;
+    using varref = const char*;
+
+    static inline Spark_Data_TypeDef value() { return CLOUD_VAR_STRING; }
+};
+struct CloudVariableTypeDouble : public CloudVariableTypeBase {
+    using vartype = double;
+    using varref = double*;
+
+    static inline Spark_Data_TypeDef value() { return CLOUD_VAR_DOUBLE; }
+};
+
+const CloudVariableTypeBool BOOLEAN;
+const CloudVariableTypeInt INT;
+const CloudVariableTypeString STRING;
+const CloudVariableTypeDouble DOUBLE;
+
 
 typedef enum
 {

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -8,8 +8,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct Stream Stream;
+    
+typedef class Stream Stream;
 #include <stdint.h>
 
 typedef bool (*ymodem_serial_flash_update_handler)(Stream *serialObj, FileTransfer::Descriptor& file, void*);

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -36,6 +36,8 @@ test(api_spark_variable) {
     API_COMPILE(Particle.variable("mydouble", &valueDouble, DOUBLE));
 
     API_COMPILE(Particle.variable("mystring", valueString, STRING));
+    // This doesn't compile and shouldn't
+    //API_COMPILE(Particle.variable("mystring", &valueString, STRING));
 
     API_NO_COMPILE(Particle.variable("mystring", constValueString, STRING));
 }

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -44,9 +44,20 @@ class CloudClass {
 
 
 public:
-    static bool variable(const char *varKey, const void *userVar, Spark_Data_TypeDef userVarType)
+
+    static inline bool variable(const char *varKey, const uint8_t* userVar, const CloudVariableTypeString& userVarType)
     {
-        return CLOUD_FN(spark_variable(varKey, userVar, userVarType, NULL), false);
+        return variable(varKey, (const char*)userVar, userVarType);
+    }
+
+    template<typename T> static inline bool variable(const char *varKey, const typename T::varref userVar, const T& userVarType)
+    {
+        return CLOUD_FN(spark_variable(varKey, (const void*)userVar, T::value(), NULL), false);
+    }
+
+    static inline bool variable(const char *varKey, const uint32_t* userVar, const CloudVariableTypeInt& userVarType)
+    {
+        return CLOUD_FN(spark_variable(varKey, (const void*)userVar, CloudVariableTypeInt::value(), NULL), false);
     }
 
     static bool function(const char *funcKey, user_function_int_str_t* func)

--- a/wiring/src/spark_wiring_spi.cpp
+++ b/wiring/src/spark_wiring_spi.cpp
@@ -37,7 +37,8 @@ SPIClass::SPIClass(HAL_SPI_Interface spi)
 
 void SPIClass::begin()
 {
-  begin(SS);
+    // todo - fetch default pin from HAL
+  HAL_SPI_Begin(_spi, SPI_DEFAULT_SS);
 }
 
 void SPIClass::begin(uint16_t ss_pin)


### PR DESCRIPTION
Catches this error:

```
Particle.variable("myvar", &string, STRING);
```

which comes up often in community discussions.