### PR TITLE
cloud disconnect detect

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -33,6 +33,7 @@
 #include "system_task.h"
 #include "system_network.h"
 #include "system_network_internal.h"
+#include "system_cloud_internal.h"
 #include "core_hal.h"
 #include "syshealth_hal.h"
 #include "watchdog_hal.h"
@@ -116,7 +117,7 @@ extern "C" void HAL_SysTick_Handler(void)
     {
         //Do nothing
     }
-    else if(SPARK_LED_FADE)
+    else if(SPARK_LED_FADE && (!SPARK_CLOUD_CONNECTED || system_cloud_active()))
     {
         LED_Fade(LED_RGB);
         TimingLED = 20;//Breathing frequency kept constant

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -142,6 +142,8 @@ bool spark_function_internal(const cloud_function_descriptor* desc, void* reserv
     return item!=NULL;
 }
 
+uint32_t lastCloudEvent = 0;
+
 /**
  * This is the internal function called by the background loop to pump cloud events.
  */
@@ -151,6 +153,10 @@ void Spark_Process_Events()
     {
         SPARK_CLOUD_CONNECTED = 0;
         SPARK_CLOUD_SOCKETED = 0;
+    }
+    else
+    {
+        lastCloudEvent = millis();
     }
 }
 
@@ -696,4 +702,19 @@ void Multicast_Presence_Announcement(void)
 
     socket_close(multicast_socket);
 #endif
+}
+
+const int SYSTEM_CLOUD_TIMEOUT = 15*1000;
+
+bool system_cloud_active()
+{
+    if (!SPARK_CLOUD_SOCKETED)
+        return false;
+
+    if (SPARK_CLOUD_CONNECTED && ((millis()-lastCloudEvent))>SYSTEM_CLOUD_TIMEOUT)
+    {
+        cloud_disconnect(false);
+        return false;
+    }
+    return true;
 }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -708,6 +708,7 @@ const int SYSTEM_CLOUD_TIMEOUT = 15*1000;
 
 bool system_cloud_active()
 {
+#ifndef SPARK_NO_CLOUD
     if (!SPARK_CLOUD_SOCKETED)
         return false;
 
@@ -716,5 +717,6 @@ bool system_cloud_active()
         cloud_disconnect(false);
         return false;
     }
+#endif
     return true;
 }

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -72,4 +72,13 @@ User_Func_Lookup_Table_t* find_func_by_key_or_add(const char* funcKey);
 
 extern SparkProtocol* sp;
 
+
+/**
+ * regular async update to check that the cloud has been serviced recently.
+ * After 15 seconds of inactivity, the LED status is changed to
+ * @return
+ */
+bool system_cloud_active();
+
+
 #endif	/* SYSTEM_CLOUD_INTERNAL_H */

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -219,11 +219,11 @@ void establish_cloud_connection()
         }
         else
         {
+            SPARK_CLOUD_SOCKETED = 0;
             if (SPARK_WLAN_RESET)
                 return;
 
             cloud_connection_failed();
-            SPARK_CLOUD_SOCKETED = 0;
             handle_cfod();
             wlan_set_error_count(Spark_Error_Count);
         }
@@ -265,10 +265,9 @@ void handle_cloud_connection(bool force_events)
                 // the socket may quickly disconnect and the connection retried, turning
                 // the LED back to cyan
                 system_tick_t start = HAL_Timer_Get_Milli_Seconds();
-                Spark_Disconnect(); // clean up the socket
+                // allow time for the LED to be flashed
                 while ((HAL_Timer_Get_Milli_Seconds()-start)<250);
-                SPARK_CLOUD_SOCKETED = 0;
-
+                cloud_disconnect();
             }
             else
             {


### PR DESCRIPTION
addresses #616 - revert to breathing green when the cloud isn't serviced for 15 seconds.  System modes are unchanged - in automatic mode, the system will try to reconnect once the background loop is executed again. Semi-automatic and manual mode requires the application code to call `Particle.connect()`.