### PR TITLE
DCT control

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -166,6 +166,29 @@ typedef enum HAL_SystemClock
  */
 unsigned HAL_Core_System_Clock(HAL_SystemClock clock, void* reserved);
 
+
+typedef enum hal_system_config_t
+{
+    SYSTEM_CONFIG_NONE,
+    SYSTEM_CONFIG_DEVICE_PRIVATE_KEY,
+    SYSTEM_CONFIG_SERVER_PUBLIC_KEY,
+    /**
+     * Device family name. Used also as the SSID prefix
+     */
+    SYSTEM_CONFIG_DEVICE_FAMILY_NAME
+
+} hal_system_config_t;
+
+/**
+ * Sets a system configuration item.
+ * @param config_item       The item to set
+ * @param data              The data to set to
+ * @param length            The length of the data.
+ * @return      0 on success.
+ */
+int HAL_Set_System_Config(hal_system_config_t config_item, const void* data, unsigned length);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -170,12 +170,12 @@ unsigned HAL_Core_System_Clock(HAL_SystemClock clock, void* reserved);
 typedef enum hal_system_config_t
 {
     SYSTEM_CONFIG_NONE,
-    SYSTEM_CONFIG_DEVICE_PRIVATE_KEY,
-    SYSTEM_CONFIG_SERVER_PUBLIC_KEY,
-    /**
-     * Device family name. Used also as the SSID prefix
-     */
-    SYSTEM_CONFIG_DEVICE_FAMILY_NAME
+    SYSTEM_CONFIG_DEVICE_KEY,
+    SYSTEM_CONFIG_SERVER_KEY,
+
+    SYSTEM_CONFIG_SOFTAP_PREFIX,
+    SYSTEM_CONFIG_SOFTAP_SUFFIX,
+    SYSTEM_CONFIG_SOFTAP_HOSTNAMES
 
 } hal_system_config_t;
 

--- a/hal/inc/hal_dynalib_core.h
+++ b/hal/inc/hal_dynalib_core.h
@@ -56,6 +56,7 @@ DYNALIB_FN(hal_core,HAL_Bootloader_Get_Flag)
 DYNALIB_FN(hal_core,HAL_Bootloader_Lock)
 DYNALIB_FN(hal_core,HAL_Core_System_Reset_FlagSet)
 DYNALIB_FN(hal_core,HAL_Core_Runtime_Info)
+DYNALIB_FN(hal_core,HAL_Set_System_Config)
 DYNALIB_END(hal_core)
 
 

--- a/hal/src/photon/ota_flash_hal.cpp
+++ b/hal/src/photon/ota_flash_hal.cpp
@@ -56,27 +56,35 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
 int HAL_Set_System_Config(hal_system_config_t config_item, const void* data, unsigned data_length)
 {
     unsigned offset;
-    unsigned length = 0;
+    unsigned length = -1;
 
     switch (config_item)
     {
-    case SYSTEM_CONFIG_DEVICE_PRIVATE_KEY:
+    case SYSTEM_CONFIG_DEVICE_KEY:
         offset = DCT_DEVICE_PRIVATE_KEY_OFFSET;
         length = DCT_DEVICE_PRIVATE_KEY_SIZE;
         break;
-    case SYSTEM_CONFIG_SERVER_PUBLIC_KEY:
+    case SYSTEM_CONFIG_SERVER_KEY:
         offset = DCT_SERVER_PUBLIC_KEY_OFFSET;
         length = DCT_SERVER_PUBLIC_KEY_SIZE;
         break;
-    case SYSTEM_CONFIG_DEVICE_FAMILY_NAME:
+    case SYSTEM_CONFIG_SOFTAP_PREFIX:
         offset = DCT_SSID_PREFIX_OFFSET;
+        length = DCT_SSID_PREFIX_SIZE-1;
+        if (data_length>length)
+            data_length = length;
         dct_write_app_data(&data_length, offset++, 1);
-        length = data_length;
+        break;
+    case SYSTEM_CONFIG_SOFTAP_SUFFIX:
+        offset = DCT_DEVICE_ID_OFFSET;
+        length = DCT_DEVICE_ID_SIZE;
+        break;
+    case SYSTEM_CONFIG_SOFTAP_HOSTNAMES:
         break;
     }
 
-    if (length)
+    if (length>=0)
         dct_write_app_data(data, offset, length>data_length ? data_length : length);
 
-    return length==0;
+    return length;
 }

--- a/hal/src/photon/ota_flash_hal.cpp
+++ b/hal/src/photon/ota_flash_hal.cpp
@@ -26,6 +26,8 @@
 #include "ota_module.h"
 #include "spark_macros.h"
 #include "ota_flash_hal_stm32f2xx.h"
+#include "core_hal.h"
+#include "dct.h"
 
 #if MODULAR_FIRMWARE
 const module_bounds_t module_bootloader = { 0x4000, 0x8000000, 0x8004000, MODULE_FUNCTION_BOOTLOADER, 0, MODULE_STORE_MAIN };
@@ -52,10 +54,11 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
 {
     info->key_values = NULL;
     info->key_value_count = 0;
-    }
+}
+
 int HAL_Set_System_Config(hal_system_config_t config_item, const void* data, unsigned data_length)
 {
-    unsigned offset;
+    unsigned offset = 0;
     unsigned length = -1;
 
     switch (config_item)

--- a/hal/src/photon/ota_flash_hal.cpp
+++ b/hal/src/photon/ota_flash_hal.cpp
@@ -52,4 +52,31 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
 {
     info->key_values = NULL;
     info->key_value_count = 0;
+    }
+int HAL_Set_System_Config(hal_system_config_t config_item, const void* data, unsigned data_length)
+{
+    unsigned offset;
+    unsigned length = 0;
+
+    switch (config_item)
+    {
+    case SYSTEM_CONFIG_DEVICE_PRIVATE_KEY:
+        offset = DCT_DEVICE_PRIVATE_KEY_OFFSET;
+        length = DCT_DEVICE_PRIVATE_KEY_SIZE;
+        break;
+    case SYSTEM_CONFIG_SERVER_PUBLIC_KEY:
+        offset = DCT_SERVER_PUBLIC_KEY_OFFSET;
+        length = DCT_SERVER_PUBLIC_KEY_SIZE;
+        break;
+    case SYSTEM_CONFIG_DEVICE_FAMILY_NAME:
+        offset = DCT_SSID_PREFIX_OFFSET;
+        dct_write_app_data(&data_length, offset++, 1);
+        length = data_length;
+        break;
+    }
+
+    if (length)
+        dct_write_app_data(data, offset, length>data_length ? data_length : length);
+
+    return length==0;
 }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -77,3 +77,20 @@ test(system_waitfor) {
     API_COMPILE(waitFor(WiFi.ready, 10000));
     API_COMPILE(waitUntil(WiFi.ready));
 }
+
+
+test(system_config_set) {
+
+    API_COMPILE(System.set(SYSTEM_CONFIG_DEVICE_KEY, NULL, 123));
+    API_COMPILE(System.set(SYSTEM_CONFIG_SOFTAP_PREFIX, "hello"));
+    API_COMPILE(System.set(SYSTEM_CONFIG_SOFTAP_SUFFIX, "hello"));
+}
+
+/*
+test(system_config_get) {
+
+    uint8_t buf[123];
+    API_COMPILE(System.get(CONFIG_DEVICE_KEY, buf, 123));
+    API_COMPILE(System.get(CONFIG_SSID_PREFIX, buf, 123));
+}
+*/

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -30,6 +30,7 @@
 #include "system_cloud.h"
 #include "system_event.h"
 #include "interrupts_hal.h"
+#include "core_hal.h"
 
 class Stream;
 
@@ -99,6 +100,16 @@ public:
     template<typename Condition> static bool waitCondition(Condition _condition, system_tick_t timeout) {
         const system_tick_t start = millis();
         return waitConditionWhile(_condition, [=]{ return (millis()-start)<timeout; });
+    }
+
+    bool set(hal_system_config_t config_type, const void* data, unsigned length)
+    {
+        return HAL_Set_System_Config(config_type, data, length)>=0;
+    }
+
+    bool set(hal_system_config_t config_type, const char* data)
+    {
+        return set(config_type, data, strlen(data));
     }
 
 };


### PR DESCRIPTION
Implementation of #630. Application firmware can set device keys and SSID prefix.

To set the prefix, use

```
    HAL_Set_System_Config(SYSTEM_CONFIG_DEVICE_FAMILY_NAME, "Batman", 6);
```

To set the device private key:

```
// use xxd to convert .der key to C array. Add `const` to ensure data goes to flash rather than RAM
const char* key[612] = "....";

STARTUP(HAL_Set_System_Config(SYSTEM_CONFIG_DEVICE_PRIVATE_KEY, key, 612));

```