### PR TITLE
Fix LED states

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -36,6 +36,8 @@ typedef int cellular_result_t;
  */
 cellular_result_t  cellular_on(void* reserved);
 
+cellular_result_t  cellular_init(void* reserved);
+
 /**
  * Power off the cellular module.
  */
@@ -122,6 +124,7 @@ cellular_result_t cellular_credentials_set(const char* apn, const char* username
  */
 CellularCredentials* cellular_credentials_get(void* reserved);
 
+bool cellular_sim_ready(void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -33,6 +33,7 @@
 DYNALIB_BEGIN(hal_cellular)
 DYNALIB_FN(hal_cellular, cellular_off)
 DYNALIB_FN(hal_cellular, cellular_on)
+DYNALIB_FN(hal_cellular, cellular_init)
 DYNALIB_FN(hal_cellular, cellular_register)
 DYNALIB_FN(hal_cellular, cellular_pdp_activate)
 DYNALIB_FN(hal_cellular, cellular_pdp_deactivate)
@@ -42,6 +43,7 @@ DYNALIB_FN(hal_cellular, cellular_fetch_ipconfig)
 DYNALIB_FN(hal_cellular, cellular_device_info)
 DYNALIB_FN(hal_cellular, cellular_credentials_set)
 DYNALIB_FN(hal_cellular, cellular_credentials_get)
+DYNALIB_FN(hal_cellular, cellular_sim_ready)
 DYNALIB_END(hal_cellular)
 
 

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -10,8 +10,14 @@ static CellularCredentials cellularCredentials;
 
 cellular_result_t  cellular_on(void* reserved)
 {
+    CHECK_SUCCESS(electronMDM.powerOn());
+    return 0;
+}
+
+cellular_result_t  cellular_init(void* reserved)
+{
     //MDMParser::DevStatus devStatus = {};
-    //CHECK_SUCCESS(electronMDM.init(NULL, &devStatus));
+    //CHECK_SUCCESS(electronMDM.init(&devStatus));
     CHECK_SUCCESS(electronMDM.init());
     return 0;
 }
@@ -92,8 +98,15 @@ CellularCredentials* cellular_credentials_get(void* reserved)
     return &cellularCredentials;
 }
 
+bool cellular_sim_ready(void* reserved)
+{
+    const MDMParser::DevStatus* status = electronMDM.getDevStatus();
+    return status->sim == MDMParser::SIM_READY;
+}
+
 // Todo rename me, and allow the different connect, disconnect etc. timeouts be set by the HAL
 uint32_t HAL_WLAN_SetNetWatchDog(uint32_t timeOutInuS)
 {
     return 0;
 }
+

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1010,7 +1010,7 @@ int MDMParser::socketSocket(IpProtocol ipproto, int port)
 
     if (_attached) {
         // find an free socket
-        socket = _findSocket();
+        socket = _findSocket(MDM_SOCKET_ERROR);
         DEBUG_D("socketSocket(%d)\r\n", ipproto);
         if (socket != MDM_SOCKET_ERROR) {
             if (ipproto == MDM_IPPROTO_UDP) {

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -242,9 +242,9 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                     // +CREG|CGREG: <n>,<stat>[,<lac>,<ci>[,AcT[,<rac>]]] // reply to AT+CREG|AT+CGREG
                     // +CREG|CGREG: <stat>[,<lac>,<ci>[,AcT[,<rac>]]]     // URC
                     b = (int)0xFFFF; c = (int)0xFFFFFFFF; d = -1;
-                    r = sscanf(cmd, "%s %*d,%d,\"%X\",\"%X\",%d",s,&a,&b,&c,&d);
+                    r = sscanf(cmd, "%s %*d,%d,\"%x\",\"%x\",%d",s,&a,&b,&c,&d);
                     if (r <= 1)
-                        r = sscanf(cmd, "%s %d,\"%X\",\"%X\",%d",s,&a,&b,&c,&d);
+                        r = sscanf(cmd, "%s %d,\"%x\",\"%x\",%d",s,&a,&b,&c,&d);
                     if (r >= 2) {
                         Reg *reg = !strcmp(s, "CREG:")  ? &_net.csd :
                                    !strcmp(s, "CGREG:") ? &_net.psd : NULL;

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -114,12 +114,18 @@ public:
             const char* apn = "spark.telefonica.com", const char* username = NULL,
             const char* password = NULL, Auth auth = AUTH_DETECT);
 
-    /** register (Attach) the MT to the GPRS service.
-        \param simpin a optional pin of the SIM card
+    /**
+     * powerOn Initialize the modem and SIM card
+     * \param simpin a optional pin of the SIM card
+     * \return true if successful, false otherwise
+     */
+    bool powerOn(const char* simpin = NULL);
+
+    /** init (Attach) the MT to the GPRS service.
         \param status an optional struture to with device information
         \return true if successful, false otherwise
     */
-    bool init(const char* simpin = NULL, DevStatus* status = NULL);
+    bool init(DevStatus* status = NULL);
 
     /** get the current device status
         \param strocture holding the device information.


### PR DESCRIPTION
* Fix LAC and Cell ID parsing
* Fix value used for finding a free socket
* If a SIM is not present after powerOn completes, the Electron will
flash blue.
* Cellular connection is moved to connect_finalize so it flashes green
during cellular registration and attachment.

Note: I was unable to get the uBlox module to allow persistent SIM polling. Thus if a SIM is not detected at startup, once it is inserted a RESET is required.

LED now behaves as below:

Power on: breathing white for a second or two
SIM present? No - flashing blue
Cellular connecting - Flashing green
Cloud connecting - Flashing cyan
Connected - Breathing cyan
