### PR TITLE
persist antenna selection

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -199,12 +199,26 @@ wlan_result_t wlan_connect_finalize()
 }
 
 int wlan_select_antenna_impl(WLanSelectAntenna_TypeDef antenna);
-static WLanSelectAntenna_TypeDef antennaSelection = ANT_INTERNAL;
-inline int wlan_refresh_antenna() { return wlan_select_antenna_impl(antennaSelection); }
+
+
+WLanSelectAntenna_TypeDef fetch_antenna_selection()
+{
+    uint8_t result = *(const uint8_t*)dct_read_app_data(DCT_ANTENNA_SELECTION_OFFSET);
+    if (result==0xFF)
+        result = ANT_INTERNAL;  // default
+    return WLanSelectAntenna_TypeDef(result);
+}
+
+void save_antenna_selection(WLanSelectAntenna_TypeDef selection)
+{
+    dct_write_app_data(&selection, DCT_ANTENNA_SELECTION_OFFSET, DCT_ANTENNA_SELECTION_SIZE);
+}
+
+inline int wlan_refresh_antenna() { return wlan_select_antenna_impl(fetch_antenna_selection()); }
 
 int wlan_select_antenna(WLanSelectAntenna_TypeDef antenna)
 {
-    antennaSelection = antenna;
+    save_antenna_selection(antenna);
     return wiced_wlan_connectivity_initialized() ? wlan_refresh_antenna() : 0;
 }
 

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
@@ -35,13 +35,13 @@ extern "C" {
 typedef  uint32_t dct_ip_address_v4_t;
 
 typedef struct _static_ip_config_t {
-	uint8_t config_mode;			// how the IPv4 address is assigned
-	uint8_t padding[3];				// use this for additional flags where possible
-	dct_ip_address_v4_t host;		// addresses stored in network order
-	dct_ip_address_v4_t netmask;
-	dct_ip_address_v4_t gateway;
-	dct_ip_address_v4_t dns1;
-	dct_ip_address_v4_t dns2;
+    uint8_t config_mode;            // how the IPv4 address is assigned
+    uint8_t padding[3];             // use this for additional flags where possible
+    dct_ip_address_v4_t host;       // addresses stored in network order
+    dct_ip_address_v4_t netmask;
+    dct_ip_address_v4_t gateway;
+    dct_ip_address_v4_t dns1;
+    dct_ip_address_v4_t dns2;
 } static_ip_config_t;
 
 STATIC_ASSERT(static_ip_config_size, sizeof(static_ip_config_t)==24);
@@ -57,7 +57,7 @@ typedef struct __attribute__((packed)) application_dct {
     union {
     uint8_t unused_server_address[128];         // no longer used - write the server address to offset
                                         // 0x180/384 in the server public key to emulate
-    	static_ip_config_t	ip_config;
+        static_ip_config_t  ip_config;
     };
     uint8_t claim_code[63];             // claim code. no terminating null.
     uint8_t claimed[1];                 // 0,0xFF, not claimed. 1 claimed.
@@ -69,7 +69,8 @@ typedef struct __attribute__((packed)) application_dct {
     uint8_t padding[2];                 // align to 4 byte boundary
     platform_flash_modules_t flash_modules[MAX_MODULES_SLOT];//100 bytes
     uint16_t product_store[12];
-    uint8_t reserved2[1282];
+    uint8_t antenna_selection;           // 0xFF is uninitialized
+    uint8_t reserved2[1281];
     // safe to add more data here or use up some of the reserved space to keep the end where it is
     uint8_t end[0];
 } application_dct_t;
@@ -87,6 +88,7 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_DEVICE_CLAIMED_OFFSET (offsetof(application_dct_t, claimed))
 #define DCT_FLASH_MODULES_OFFSET (offsetof(application_dct_t, flash_modules))
 #define DCT_PRODUCT_STORE_OFFSET (offsetof(application_dct_t, product_store))
+#define DCT_ANTENNA_SELECTION_OFFSET (offsetof(application_dct_t, antenna_selection))
 
 #define DCT_SYSTEM_FLAGS_SIZE  (sizeof(application_dct_t::system_flags))
 #define DCT_DEVICE_PRIVATE_KEY_SIZE  (sizeof(application_dct_t::device_private_key))
@@ -100,6 +102,7 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_DEVICE_CLAIMED_SIZE  (sizeof(application_dct_t::claimed))
 #define DCT_FLASH_MODULES_SIZE  (sizeof(application_dct_t::flash_modules))
 #define DCT_PRODUCT_STORE_SIZE  (sizeof(application_dct_t::product_store))
+#define DCT_ANTENNA_SELECTION_SIZE  (sizeof(application_dct_t::antenna_selection))
 
 #define STATIC_ASSERT_DCT_OFFSET(field, expected) STATIC_ASSERT( dct_##field, offsetof(application_dct_t, field)==expected)
 #define STATIC_ASSERT_FLAGS_OFFSET(field, expected) STATIC_ASSERT( dct_sysflag_##field, offsetof(platform_system_flags_t, field)==expected)
@@ -122,7 +125,8 @@ STATIC_ASSERT_DCT_OFFSET(server_public_key, 2082 /* 1890 + 192 */);
 STATIC_ASSERT_DCT_OFFSET(padding, 2850 /* 2082 + 768 */);
 STATIC_ASSERT_DCT_OFFSET(flash_modules, 2852 /* 2850 + 2 */);
 STATIC_ASSERT_DCT_OFFSET(product_store, 2952 /* 2852 + 100 */);
-STATIC_ASSERT_DCT_OFFSET(reserved2, 2976 /* 2952 + 24 */);
+STATIC_ASSERT_DCT_OFFSET(antenna_selection, 2976 /* 2952 + 24 */);
+STATIC_ASSERT_DCT_OFFSET(reserved2, 2977 /* 2976 + 1 */);
 STATIC_ASSERT_DCT_OFFSET(end, 4258 /* 2952 + 1282 */);
 
 STATIC_ASSERT_FLAGS_OFFSET(Bootloader_Version_SysFlag, 4);


### PR DESCRIPTION
save the antenna selection persistently so that safe-mode works when connected to an external antenna.  addresses #618