### PR TITLE
Make the errors clearer for Particle.variable()

### DIFF
--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -60,6 +60,26 @@ public:
         return CLOUD_FN(spark_variable(varKey, (const void*)userVar, CloudVariableTypeInt::value(), NULL), false);
     }
 
+    // Return clear errors for common misuses of Particle.variable()
+    template<typename T, std::size_t N>
+    static inline bool variable(const char *varKey, const T (*userVar)[N], const CloudVariableTypeString& userVarType)
+    {
+        static_assert(sizeof(T)==0, "\n\nUse Particle.varible(\"name\", myVar, STRING); without & in front of myVar\n\n");
+        return false;
+    }
+    template<typename T>
+    static inline bool variable(const T *varKey, const String *userVar, const CloudVariableTypeString& userVarType)
+    {
+        static_assert(sizeof(T)==0, "\n\nIn Particle.varible(\"name\", myVar, STRING); myVar must be declared as char myVar[] not String myVar\n\n");
+        return false;
+    }
+    template<typename T>
+    static inline bool variable(const T *varKey, const String &userVar, const CloudVariableTypeString& userVarType)
+    {
+        static_assert(sizeof(T)==0, "\n\nIn Particle.varible(\"name\", myVar, STRING); myVar must be declared as char myVar[] not String myVar\n\n");
+        return false;
+    }
+
     static bool function(const char *funcKey, user_function_int_str_t* func)
     {
         return CLOUD_FN(register_function(call_raw_user_function, (void*)func, funcKey), false);


### PR DESCRIPTION
Errors with Particle.variable("name", ..., STRING); are common. The changes in 0.4.7 introduce errors for incorrect cases instead of silently compiling. However the errors are weird template errors that are absolutely incomprehensible.

This at least shows clear error to users.

```C++
char buf[10];
String str;
Particle.variable("name", &buf, STRING);
Particle.variable("name", str, STRING);
Particle.variable("name", &str, STRING);
```
```
../wiring/inc/spark_wiring_cloud.h:67:9: error: static assertion failed:

Use Particle.varible("name", myVar, STRING); without & in front of myVar

../wiring/inc/spark_wiring_cloud.h:73:9: error: static assertion failed:

In Particle.varible("name", myVar, STRING); must be declared as char myVar[] not String myVar
```

See this forum discussion for why this is necessary...
http://community.particle.io/t/error-no-matching-function-for-call-to-cloudclass-variable/16125