### PR TITLE
pulseIn() for Photon/P1/Core/Electron, with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@
  - Esure bootloader region is write protected.
  - White breathing LED on exiting listening mode. [#682](https://github.com/spark/firmware/issues/682)
 
+## v0.4.7
+
+### FEATURES
+ - [pulseIn(pin, value)](https://docs.particle.io/reference/firmware/photon/#pulsein-) now available for all devices.
+
+### ENHANCEMENTS
+
+ -
+
+### BUGFIXES
+
+ -
+
 ## v0.4.6
 
 ### FEATURES

--- a/hal/inc/gpio_hal.h
+++ b/hal/inc/gpio_hal.h
@@ -46,6 +46,7 @@ void HAL_Pin_Mode(pin_t pin, PinMode mode);
 PinMode HAL_Get_Pin_Mode(pin_t pin);
 void HAL_GPIO_Write(pin_t pin, uint8_t value);
 int32_t HAL_GPIO_Read(pin_t pin);
+uint32_t HAL_Pulse_In(pin_t pin, uint16_t value);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -64,6 +64,8 @@ DYNALIB_FN(hal_gpio,HAL_PWM_Get_AnalogValue)
 DYNALIB_FN(hal_gpio, HAL_Set_System_Interrupt_Handler)
 DYNALIB_FN(hal_gpio, HAL_Get_System_Interrupt_Handler)
 DYNALIB_FN(hal_gpio, HAL_System_Interrupt_Trigger)
+
+DYNALIB_FN(hal_gpio, HAL_Pulse_In)
 DYNALIB_END(hal_gpio)
 
 #endif	/* HAL_DYNALIB_GPIO_H */

--- a/hal/src/core/gpio_hal.c
+++ b/hal/src/core/gpio_hal.c
@@ -28,6 +28,7 @@
 #include "pinmap_impl.h"
 #include "stm32f10x.h"
 #include <stddef.h>
+#include "hw_ticks.h"
 
 /* Private typedef ----------------------------------------------------------*/
 
@@ -198,4 +199,37 @@ int32_t HAL_GPIO_Read(uint16_t pin)
   }
 
   return GPIO_ReadInputDataBit(PIN_MAP[pin].gpio_peripheral, PIN_MAP[pin].gpio_pin);
+}
+
+/*
+ * @brief   blocking call to measure a high or low pulse
+ * @returns uint32_t pulse width in microseconds up to 3 seconds,
+ *          returns 0 on 3 second timeout error, or invalid pin.
+ */
+uint32_t HAL_Pulse_In(pin_t pin, uint16_t value)
+{
+    #define pinReadFast(_pin) ((PIN_MAP[_pin].gpio_peripheral->IDR & PIN_MAP[_pin].gpio_pin) == 0 ? 0 : 1)
+
+    volatile uint32_t timeoutStart = SYSTEM_TICK_COUNTER; // total 3 seconds for entire function!
+
+    /* If already on the value we want to measure, wait for the next one.
+     * Time out after 3 seconds so we don't block the background tasks
+     */
+    while (pinReadFast(pin) != value) {
+        if (SYSTEM_TICK_COUNTER - timeoutStart > 216000000UL) {
+            return 0;
+        }
+    }
+
+    /* Wait until this value changes, this will be our elapsed pulse width.
+     * Time out after 3 seconds so we don't block the background tasks
+     */
+    volatile uint32_t pulseStart = SYSTEM_TICK_COUNTER;
+    while (pinReadFast(pin) == value) {
+        if (SYSTEM_TICK_COUNTER - timeoutStart > 216000000UL) {
+            return 0;
+        }
+    }
+
+    return (SYSTEM_TICK_COUNTER - pulseStart)/SYSTEM_US_TICKS;
 }

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -79,7 +79,7 @@ uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
 void serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout);
 
-
+uint32_t pulseIn(pin_t pin, uint16_t value);
 
 #ifdef __cplusplus
 }

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -233,3 +233,15 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val)
     digitalWrite(clockPin, LOW);
   }
 }
+
+/*
+ * @brief   blocking call to measure a high or low pulse
+ * @returns uint32_t pulse width in microseconds up to 3 seconds,
+ *          returns 0 on 3 second timeout error, or invalid pin.
+ */
+uint32_t pulseIn(pin_t pin, uint16_t value) {
+
+    // NO SAFETY CHECKS!!! WILD WILD WEST!!!
+
+    return HAL_Pulse_In(pin, value);
+}


### PR DESCRIPTION
Quick implementation of a [**pulseIn()**](https://www.arduino.cc/en/Reference/PulseIn) from Arduino/Wiring.
* Times out automatically after 3 seconds to keep from blocking background tasks.
* Tests ran and passed on Photon and Core, but Electron TEST=wiring/no_fixture has compiler errors from different tests, so could not run for E.  Ran tests for P1 and pulseIn() passed but about 8 other tests failed :(
* Thought it might be hard to test pulseIn() without a fixture, but surprise... you can read the state of an output when the PWM peripheral is banging out bits :joy: 