### PR TITLE
initialize backup sram only on first use

### DIFF
--- a/build/arm/linker/stm32f2xx/backup_ram.ld
+++ b/build/arm/linker/stm32f2xx/backup_ram.ld
@@ -1,0 +1,8 @@
+    .backup :
+    {
+        link_global_retained_initial_values = LOADADDR( .backup ); /* This is the location in flash of the initial values of retained global variables */
+        link_global_retained_start = .;
+        *(.retained_user*)
+        link_global_retained_end = .;
+        . = ALIGN(., 4);
+    }>BACKUPSRAM AT> APP_FLASH

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -198,6 +198,11 @@ typedef enum HAL_Feature {
 int HAL_Feature_Set(HAL_Feature feature, bool enabled);
 bool HAL_Feature_Get(HAL_Feature feature);
 
+/**
+ * Externally defined function that is called before user constructors.
+ */
+extern void module_user_init_hook(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -119,6 +119,8 @@ void HAL_Core_Config(void)
 #endif
 
 	sFLASH_Init();
+
+        module_user_init_hook();
 }
 
 uint16_t HAL_Core_Mode_Button_Pressed_Time()

--- a/hal/src/electron/app_no_bootloader.ld
+++ b/hal/src/electron/app_no_bootloader.ld
@@ -176,6 +176,8 @@ SECTIONS
         _ebss = . ;
     }> SRAM AT> SRAM
 
+    include backup_ram.ld
+
     link_heap_location = end;
     link_heap_location_end = __Stack_Init;
     PROVIDE ( end = _ebss );

--- a/hal/src/electron/app_no_bootloader.ld
+++ b/hal/src/electron/app_no_bootloader.ld
@@ -176,7 +176,7 @@ SECTIONS
         _ebss = . ;
     }> SRAM AT> SRAM
 
-    include backup_ram.ld
+    INCLUDE backup_ram.ld
 
     link_heap_location = end;
     link_heap_location_end = __Stack_Init;

--- a/hal/src/electron/include.mk
+++ b/hal/src/electron/include.mk
@@ -34,9 +34,11 @@ ifneq (,$(HAL_LINK))
 LINKER_FILE=$(HAL_SRC_ELECTRON_INCL_PATH)/app_no_bootloader.ld
 LINKER_DEPS=$(LINKER_FILE)
 
+LDFLAGS += -L$(COMMON_BUILD)/arm/linker/stm32f2xx
 LDFLAGS += --specs=nano.specs -lc -lnosys
 LDFLAGS += -T$(LINKER_FILE)
 LDFLAGS += -Wl,--defsym,__STACKSIZE__=1400
+
 # support for external linker file
 
 # todo - factor out common code with photon include.mk

--- a/hal/src/photon/include.mk
+++ b/hal/src/photon/include.mk
@@ -47,6 +47,7 @@ LINKER_DEPS=$(LINKER_FILE) $(HAL_WICED_LIB_FILES)
 LDFLAGS += --specs=nano.specs -lc -lnosys
 LDFLAGS += -Wl,--whole-archive $(HAL_WICED_LIB_FILES) -Wl,--no-whole-archive
 LDFLAGS += -T$(LINKER_FILE)
+LDFLAGS += -L$(COMMON_BUILD)/arm/linker/stm32f2xx
 LDFLAGS += -L$(WICED_MCU)/STM32F2x5
 LDFLAGS += -Wl,--defsym,__STACKSIZE__=1400
 USE_PRINTF_FLOAT ?= n

--- a/hal/src/photon/wiced/platform/MCU/STM32F2xx/GCC/app_no_bootloader.ld
+++ b/hal/src/photon/wiced/platform/MCU/STM32F2xx/GCC/app_no_bootloader.ld
@@ -164,14 +164,7 @@ SECTIONS
         link_stack_end = .;
     }> SRAM AT> SRAM
 
-    .backup :
-    {
-        link_global_retained_initial_values = LOADADDR( .backup ); /* This is the location in flash of the initial values of retained global variables */
-        link_global_retained_start = .;
-        *(.data*)
-        link_global_retained_end = .;
-        . = ALIGN(., 4);
-    }>BACKUPSRAM AT> APP_FLASH
+    INCLUDE backup_ram.ld
 
     /DISCARD/ :
     {

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -259,6 +259,10 @@ void HAL_Core_Setup(void) {
 
     bootloader_update_if_needed();
     HAL_Bootloader_Lock(true);
+
+#if !MODULAR_FIRMWARE
+    module_user_init_hook();
+#endif
 }
 
 #if MODULAR_FIRMWARE

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -44,6 +44,7 @@
 #include "bootloader.h"
 #include "core_hal_stm32f2xx.h"
 #include "stm32f2xx.h"
+#include "timer_hal.h"
 
 void HardFault_Handler( void ) __attribute__( ( naked ) );
 
@@ -869,8 +870,18 @@ int HAL_Feature_Set(HAL_Feature feature, bool enabled)
             FunctionalState state = enabled ? ENABLE : DISABLE;
             // Switch on backup SRAM clock
             RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_BKPSRAM, state);
-            // Switch on backup power regulator, so that it survives the sleep mode
+            // Switch on backup power regulator, so that it survives the deep sleep mode,
+            // software and hardware reset. Power must be supplied to VIN or VBAT to retain SRAM values.
             PWR_BackupRegulatorCmd(state);
+            // Wait until backup power regulator is ready, should be fairly instantaneous... but timeout in 10ms.
+            if (state == ENABLE) {
+                system_tick_t start = HAL_Timer_Get_Milli_Seconds();
+                while (PWR_GetFlagStatus(PWR_FLAG_BRR) == RESET) {
+                    if (HAL_Timer_Get_Milli_Seconds() - start > 10UL) {
+                        return -2;
+                    }
+                };
+            }
             return 0;
         }
 
@@ -882,9 +893,15 @@ bool HAL_Feature_Get(HAL_Feature feature)
 {
     switch (feature)
     {
+        // Warm Start: active when resuming from Standby mode (deep sleep)
         case FEATURE_WARM_START:
         {
             return (PWR_GetFlagStatus(PWR_FLAG_SB) != RESET);
+        }
+        // Retained Memory: active when backup regulator is enabled
+        case FEATURE_RETAINED_MEMORY:
+        {
+            return (PWR_GetFlagStatus(PWR_FLAG_BRR) != RESET);
         }
     }
     return false;

--- a/modules/shared/stm32f2xx/inc/user_part_export.c
+++ b/modules/shared/stm32f2xx/inc/user_part_export.c
@@ -4,6 +4,7 @@
 #include "system_user.h"
 #include <stddef.h>
 #include <string.h>
+#include "core_hal.h"
 
 
 extern char link_heap_start;
@@ -54,6 +55,8 @@ extern constructor_ptr_t link_constructors_end;
 
 void module_user_init()
 {
+    module_user_init_hook();
+
     // invoke constructors
     int ctor_num;
     for (ctor_num=0; ctor_num < link_constructors_size/sizeof(constructor_ptr_t); ctor_num++ )

--- a/modules/shared/stm32f2xx/include.mk
+++ b/modules/shared/stm32f2xx/include.mk
@@ -1,2 +1,4 @@
 
 INCLUDE_DIRS += $(SHARED_MODULAR)/inc
+
+LDFLAGS += -L$(COMMON_BUILD)/arm/linker/stm32f2xx

--- a/modules/shared/stm32f2xx/user.ld
+++ b/modules/shared/stm32f2xx/user.ld
@@ -74,15 +74,7 @@ SECTIONS
         __extab_end = .;
     } > APP_FLASH  AT> APP_FLASH
 
-    .backup :
-    {
-        link_global_retained_initial_values = LOADADDR( .backup ); /* This is the location in flash of the initial values of retained global variables */
-        link_global_retained_start = .;
-        *(.retained_user*)
-        link_global_retained_end = .;
-        . = ALIGN(., 4);
-    }>BACKUPSRAM AT> APP_FLASH
-
+    INCLUDE backup_ram.ld
 
     .data : /* Contains the non-zero initialised global variables */
     {

--- a/system/inc/system_user.h
+++ b/system/inc/system_user.h
@@ -28,7 +28,10 @@ void loop();
 
 void serialEventRun();
 
-void system_initialize_user_backup_ram();
+/**
+ * Code that is initialized before any user constructors are called.
+ */
+void module_user_init_hook(void);
 
 #ifdef __cplusplus
 }

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -156,8 +156,18 @@ public:
 
     inline int enableFeature(HAL_Feature feature)
     {
+        /* PRE-ENABLE TASKS */
+        bool init_sram = false;
+        // Initialize SRAM on first use of retained memory
+        if (feature==FEATURE_RETAINED_MEMORY && !HAL_Feature_Get(FEATURE_RETAINED_MEMORY)) {
+            init_sram = true;
+        }
+
+        /* ENABLE FEATURE */
         int result = HAL_Feature_Set(feature, true);
-        if (feature==FEATURE_RETAINED_MEMORY && !HAL_Feature_Get(FEATURE_WARM_START)) {
+
+        /* POST-ENABLE TASKS */
+        if (feature==FEATURE_RETAINED_MEMORY && init_sram) {
             system_initialize_user_backup_ram();
         }
         return result;

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -156,21 +156,7 @@ public:
 
     inline int enableFeature(HAL_Feature feature)
     {
-        /* PRE-ENABLE TASKS */
-        bool init_sram = false;
-        // Initialize SRAM on first use of retained memory
-        if (feature==FEATURE_RETAINED_MEMORY && !HAL_Feature_Get(FEATURE_RETAINED_MEMORY)) {
-            init_sram = true;
-        }
-
-        /* ENABLE FEATURE */
-        int result = HAL_Feature_Set(feature, true);
-
-        /* POST-ENABLE TASKS */
-        if (feature==FEATURE_RETAINED_MEMORY && init_sram) {
-            system_initialize_user_backup_ram();
-        }
-        return result;
+        return HAL_Feature_Set(feature, true);
     }
 
     inline int disableFeature(HAL_Feature feature)

--- a/wiring/src/user.cpp
+++ b/wiring/src/user.cpp
@@ -133,3 +133,12 @@ void system_initialize_user_backup_ram()
     memcpy(&link_global_retained_start, &link_global_retained_initial_values, len);
 }
 #endif
+
+#include "core_hal.h"
+void module_user_init_hook()
+{
+#if PLATFORM_BACKUP_RAM
+    if (!HAL_Feature_Get(FEATURE_RETAINED_MEMORY))
+        system_initialize_user_backup_ram();
+#endif
+}


### PR DESCRIPTION
* The code currently (v0.4.6) attempts to initialize SRAM if it's not waking up from Standby mode, but should instead be initializing based on if it powered up when the Backup RAM is enabled. Since it's a bit tricky to store a system variable in SRAM for this purpose, checking the Backup Regulator Ready status bit will do nicely; which is a hardware controlled bit that won't be cleared if we are waking up from Standby, software or hardware reset. This backup regulator is only enabled if we are enabling Backup RAM, so this is perfect.

* I've been testing this in all modes of operation it's rock solid now. Docs really need a matrix table to show all of the different states for SRAM. This will make it super clear when SRAM is initialized and when it's retained (at least that's the hope).  

* Fixes issue: https://github.com/spark/firmware/issues/661

* What do you think about this table? Is the expectation for SRAM clear under the following conditions?

| Power_Down_Method | Power_Up_Method | When VIN Powered | When VBAT Powered | SRAM Initialized | SRAM Retained |
| :-: | :-: | :-: | :-: | :-: | :-: |
| Power removed on VIN and VBAT | Power applied on VIN | - | - | Yes | No |
| Power removed on VIN | Power applied on VIN | - | Yes | No | Yes |
| System.sleep(SLEEP_MODE_DEEP) | Rising edge on WKP pin, or Hard Reset | Yes | Yes/No | No | Yes |
| System.sleep(SLEEP_MODE_DEEP,10) | RTC alarm after 10 seconds | Yes | Yes/No | No | Yes |
| System.reset() | Boot after software reset | Yes | Yes/No | No | Yes |
| Hard reset | Boot after hard reset | Yes | Yes/No | No | Yes |
