### PR TITLE
Electron multi-threading and OpenOCD support

### DIFF
--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -345,6 +345,15 @@ void HAL_Core_Init(void)
 {
 }
 
+void SysTickChain()
+{
+    void (*chain)(void) = (void (*)(void))((uint32_t*)&link_interrupt_vectors_location)[SysTick_Handler_Idx];
+
+    chain();
+
+    SysTickOverride();
+}
+
 void HAL_1Ms_Tick()
 {
     if (TimingDelay != 0x00)
@@ -359,6 +368,8 @@ void HAL_1Ms_Tick()
  */
 void HAL_Core_Setup_finalize(void)
 {
+    uint32_t* isrs = (uint32_t*)&link_ram_interrupt_vectors_location;
+    isrs[SysTick_Handler_Idx] = (uint32_t)SysTickChain;
 }
 
 /******************************************************************************/

--- a/hal/src/electron/delay_hal.c
+++ b/hal/src/electron/delay_hal.c
@@ -19,8 +19,8 @@
 
 /* Includes -----------------------------------------------------------------*/
 #include "delay_hal.h"
-#include <stdatomic.h>
-#include "watchdog_hal.h"
+#include "FreeRTOS.h"
+#include "task.h"
 
 /* Private typedef ----------------------------------------------------------*/
 
@@ -47,10 +47,6 @@ volatile uint32_t TimingDelay;
 *******************************************************************************/
 void HAL_Delay_Milliseconds(uint32_t nTime)
 {
-    __sync_lock_test_and_set(&TimingDelay, nTime);
-
-    while (TimingDelay != 0x00) {
-        HAL_Notify_WDT();
-    }
+    vTaskDelay(nTime);
 }
 

--- a/hal/src/photon/core_hal.c
+++ b/hal/src/photon/core_hal.c
@@ -29,10 +29,6 @@
 #include "wlan_internal.h"
 #include <stdint.h>
 
-#include "FreeRTOS.h"
-
-const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
-
 /**
  * Start of interrupt vector table.
  */

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -30,6 +30,8 @@
 #include "semphr.h"
 #include <mutex>
 
+// For OpenOCD FreeRTOS support
+extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
 
 // use the newer name
 typedef xTaskHandle TaskHandle_t;


### PR DESCRIPTION
I needed Electron threading to work for my application so I tweaked the FreeRTOS config for it to work. With these changes I'm able to use `SYSTEM_THREAD(ENABLED)` and wiring threads.

* Call the RTOS SysTick after the OS has been set up through `SysTickChain`
* Use RTOS `vTaskDelay` in `HAL_Delay_Milliseconds`
* Add `uxTopUsedPriority` to Electron

I don't know if you're ready to add multi-threading to the Electron, but I think this will be welcomed by all the beta testers.