### PR TITLE
Setting _remoteIP by index doesn't set it as IPv4

### DIFF
--- a/wiring/src/spark_wiring_udp.cpp
+++ b/wiring/src/spark_wiring_udp.cpp
@@ -205,11 +205,7 @@ int UDP::receivePacket(uint8_t* buffer, size_t size)
         if (ret >= 0)
         {
             _remotePort = remoteSockAddr.sa_data[0] << 8 | remoteSockAddr.sa_data[1];
-
-            _remoteIP[0] = remoteSockAddr.sa_data[2];
-            _remoteIP[1] = remoteSockAddr.sa_data[3];
-            _remoteIP[2] = remoteSockAddr.sa_data[4];
-            _remoteIP[3] = remoteSockAddr.sa_data[5];
+            _remoteIP = &remoteSockAddr.sa_data[2];
         }
     }
     return ret;


### PR DESCRIPTION
I ran into an issue where I couldn't compare the remoteIP() to another IPAddress since the version was set to 0. Using index assignment doesn't set it to 4, but assigning uint8_t* to an IPAddress does set it as IPv4.