### PR TITLE
serialEventX() 

### DIFF
--- a/modules/shared/stm32f2xx/inc/user_part_export.c
+++ b/modules/shared/stm32f2xx/inc/user_part_export.c
@@ -71,6 +71,7 @@ void module_user_setup() {
 
 void module_user_loop() {
     loop();
+    serialEventRun();
 }
 
 #include "user_dynalib.h"

--- a/system/inc/system_user.h
+++ b/system/inc/system_user.h
@@ -26,6 +26,7 @@ extern "C" {
 void setup();
 void loop();
 
+void serialEventRun();
 
 void system_initialize_user_backup_ram();
 

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -205,7 +205,6 @@ void manage_safe_mode()
     }
 }
 
-
 void app_loop(bool threaded)
 {
     DECLARE_SYS_HEALTH(ENTERED_WLAN_Loop);
@@ -231,6 +230,9 @@ void app_loop(bool threaded)
             if (system_mode()!=SAFE_MODE) {
                 loop();
                 DECLARE_SYS_HEALTH(RAN_Loop);
+#if !MODULAR_FIRMWARE
+                serialEventRun();
+#endif
             }
         }
     }

--- a/user/libraries/Serial2/Serial2.h
+++ b/user/libraries/Serial2/Serial2.h
@@ -9,6 +9,11 @@ static Ring_Buffer serial2_tx_buffer;
 
 USARTSerial Serial2(HAL_USART_SERIAL2, &serial2_rx_buffer, &serial2_tx_buffer);
 
+void serialEventRun2()
+{
+    __handleSerialEvent(Serial2, serialEvent2);
+}
+
 #endif
 
 

--- a/user/libraries/Serial3/Serial3.h
+++ b/user/libraries/Serial3/Serial3.h
@@ -9,4 +9,10 @@ static Ring_Buffer serial3_tx_buffer;
 
 USARTSerial Serial3(HAL_USART_SERIAL3, &serial3_rx_buffer, &serial3_tx_buffer);
 
+void serialEventRun3()
+{
+    __handleSerialEvent(Serial3, serialEvent3);
+}
+
+
 #endif

--- a/user/libraries/Serial4/Serial4.h
+++ b/user/libraries/Serial4/Serial4.h
@@ -9,4 +9,9 @@ static Ring_Buffer serial4_tx_buffer;
 
 USARTSerial Serial4(HAL_USART_SERIAL4, &serial4_rx_buffer, &serial4_tx_buffer);
 
+void serialEventRun4()
+{
+    __handleSerialEvent(Serial4, serialEvent4);
+}
+
 #endif

--- a/user/libraries/Serial5/Serial5.h
+++ b/user/libraries/Serial5/Serial5.h
@@ -9,4 +9,10 @@ static Ring_Buffer serial5_tx_buffer;
 
 USARTSerial Serial5(HAL_USART_SERIAL5, &serial5_rx_buffer, &serial5_tx_buffer);
 
+void serialEventRun5()
+{
+    __handleSerialEvent(Serial5, serialEvent5);
+}
+
+
 #endif

--- a/wiring/inc/spark_wiring_platform.h
+++ b/wiring/inc/spark_wiring_platform.h
@@ -11,18 +11,14 @@
 // components of the platform. (I.e. platform  defines comes from the HAL)
 
 
-#if PLATFORM_ID==0      // core
+#if PLATFORM_ID==0 || PLATFORM_ID==2     // core / core hd
 #define Wiring_WiFi 1
 #define Wiring_IPv6 0
+#define Wiring_Serial2 1
 #endif
 
 #if PLATFORM_ID==1      // unused
 #error Unkonwn platform ID
-#endif
-
-#if PLATFORM_ID==2      // core-hd
-#define Wiring_WiFi 1
-#define Wiring_IPv6 0
 #endif
 
 #if PLATFORM_ID==3      // gcc
@@ -41,24 +37,28 @@
 #define Wiring_WiFi 1
 #define Wiring_IPv6 1
 #define Wiring_SPI1 1
+#define Wiring_Serial2 1
 #endif
 
 #if PLATFORM_ID==6      // photon
 #define Wiring_WiFi 1
 #define Wiring_IPv6 1
 #define Wiring_SPI1 1
+#define Wiring_Serial2 1
 #endif
 
 #if PLATFORM_ID==7
 #define Wiring_WiFi 1
 #define Wiring_IPv6 1
 #define Wiring_SPI1 1
+#define Wiring_Serial2 1
 #endif
 
 #if PLATFORM_ID==8      // P1 / bm14
 #define Wiring_WiFi 1
 #define Wiring_IPv6 1
 #define Wiring_SPI1 1
+#define Wiring_Serial2 1
 #endif
 
 #if PLATFORM_ID==9      // ethernet
@@ -68,6 +68,10 @@
 
 #if PLATFORM_ID==10      // electron
 #define Wiring_Cellular 1
+#define Wiring_Serial2 1
+#define Wiring_Serial3 1
+#define Wiring_Serial4 1
+#define Wiring_Serial5 1
 #define Wiring_SPI1 1
 #define Wiring_SPI2 1
 
@@ -94,6 +98,23 @@
 #ifndef Wiring_Cellular
 #define Wiring_Cellular 0
 #endif
+
+#ifndef Wiring_Serial2
+#define Wiring_Serial2 0
+#endif
+
+#ifndef Wiring_Serial3
+#define Wiring_Serial3 0
+#endif
+
+#ifndef Wiring_Serial4
+#define Wiring_Serial4 0
+#endif
+
+#ifndef Wiring_Serial5
+#define Wiring_Serial5 0
+#endif
+
 
 #endif	/* SPARK_WIRING_PLATFORM_H */
 

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -29,6 +29,7 @@
 
 #include "spark_wiring_stream.h"
 #include "usart_hal.h"
+#include "spark_wiring_platform.h"
 
 class USARTSerial : public Stream
 {
@@ -60,9 +61,54 @@ public:
   bool isEnabled(void);
 };
 
+#if Wiring_Serial2
+void serialEventRun2(void) __attribute__((weak));
+void serialEvent2(void) __attribute__((weak));
+#endif
+
+#if Wiring_Serial3
+void serialEventRun3(void) __attribute__((weak));
+void serialEvent3(void) __attribute__((weak));
+#endif
+
+#if Wiring_Serial4
+void serialEventRun4(void) __attribute__((weak));
+void serialEvent4(void) __attribute__((weak));
+#endif
+
+#if Wiring_Serial5
+void serialEventRun5(void) __attribute__((weak));
+void serialEvent5(void) __attribute__((weak));
+#endif
+
+inline void __handleSerialEvent(USARTSerial& serial, void (*handler)(void)) __attribute__((always_inline));
+
+inline void __handleSerialEvent(USARTSerial& serial, void (*handler)(void))
+{
+    if (handler && serial.isEnabled() && serial.available()>0)
+        handler();
+}
+
+
 #ifndef SPARK_WIRING_NO_USART_SERIAL
 extern USARTSerial Serial1;
+
+#if Wiring_Serial2
 extern USARTSerial Serial2;
+#endif
+
+#if Wiring_Serial3
+extern USARTSerial Serial3;
+#endif
+
+#if Wiring_Serial4
+extern USARTSerial Serial4;
+#endif
+
+#if Wiring_Serial5
+extern USARTSerial Serial5;
+#endif
+
 #endif
 
 #endif

--- a/wiring/src/user.cpp
+++ b/wiring/src/user.cpp
@@ -24,6 +24,10 @@
 #include "system_user.h"
 #include <stddef.h>
 #include <string.h>
+#include "spark_wiring_platform.h"
+#include "spark_wiring_usbserial.h"
+#include "spark_wiring_usartserial.h"
+
 
 /**
  * Declare the following function bodies as weak. They will only be used if no
@@ -42,6 +46,62 @@ void setup()  {
 
 
 void loop() {
+
+}
+
+
+/**
+ * Allow the application to override this to avoid processing
+ * overhead when serial events are not required.
+ */
+void serialEventRun() __attribute__((weak));
+
+void serialEvent() __attribute__((weak));
+void serialEvent1() __attribute__((weak));
+
+#if Wiring_Serial2
+void serialEvent2() __attribute__((weak));
+#endif
+
+#if Wiring_Serial3
+void serialEvent3() __attribute__((weak));
+#endif
+
+#if Wiring_Serial4
+void serialEvent4() __attribute__((weak));
+#endif
+
+#if Wiring_Serial5
+void serialEvent5() __attribute__((weak));
+#endif
+
+
+/**
+ * Provides background processing of serial data.
+ */
+void serialEventRun()
+{
+    if (serialEvent && Serial.available()>0)
+        serialEvent();
+
+    if (serialEvent1 && Serial1.available()>0)
+        serialEvent1();
+
+#if Wiring_Serial2
+    if (serialEventRun2) serialEventRun2();
+#endif
+
+#if Wiring_Serial3
+    if (serialEventRun3) serialEventRun3();
+#endif
+
+#if Wiring_Serial4
+    if (serialEventRun4) serialEventRun4();
+#endif
+
+#if Wiring_Serial5
+    if (serialEventRun5) serialEventRun5();
+#endif
 
 }
 


### PR DESCRIPTION
Emulation of `serialEvent()` from arduino wiring.  Implemented as weak functions in user app to allow the application to know if there is serial data available.

This is a requested feature. I'm a bit puzzled why we might need this since the user loop can easily add code like

```
void loop()
{
   // ... loopy stuff here
   if (Serial1.available())
          serialEvent1();
}

void serialEvent1()
{
    char c = Serial1.read();  
}
```

Which is more efficient than what we are able to provide from the system code.