### PR TITLE
standardized print format

### DIFF
--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -89,7 +89,7 @@ template<typename Config> void SystemSetupConsole<Config>::handle(char c)
     }
     else if ('m' == c)
     {
-        print("Your device MAC address is\r\n");
+        print("Your device MAC address is ");
         WLanConfig ip_config;
         ip_config.size = sizeof(ip_config);
         network.fetch_ipconfig(&ip_config);


### PR DESCRIPTION
v,s,i are all doing a one line print follow by a linefeed but not sure why `m` needs to be special
