### PR TITLE
String varaibles

### DIFF
--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -119,7 +119,13 @@ struct  cloud_function_descriptor {
 
 STATIC_ASSERT(cloud_function_descriptor_size, sizeof(cloud_function_descriptor)==16 || sizeof(void*)!=4);
 
-bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef userVarType, void* reserved);
+typedef struct spark_variable_t
+{
+    uint16_t size;
+    const void* (*update)(const char* nane, Spark_Data_TypeDef type, const void* var, void* reserved);
+} spark_variable_t;
+
+bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef userVarType, spark_variable_t* extra);
 
 /**
  * @param funcKey   The name of the function to register. When NULL, pFunc is taken to be a

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -35,13 +35,13 @@ typedef enum
 struct CloudVariableTypeBase {};
 struct CloudVariableTypeBool : public CloudVariableTypeBase {
     using vartype = bool;
-    using varref = bool*;
+    using varref = const bool*;
     CloudVariableTypeBool(){};
     static inline Spark_Data_TypeDef value() { return CLOUD_VAR_BOOLEAN; }
 };
 struct CloudVariableTypeInt : public CloudVariableTypeBase {
     using vartype = int;
-    using varref = int*;
+    using varref = const int*;
     CloudVariableTypeInt(){};
     static inline Spark_Data_TypeDef value() { return CLOUD_VAR_INT; }
 };
@@ -53,7 +53,7 @@ struct CloudVariableTypeString : public CloudVariableTypeBase {
 };
 struct CloudVariableTypeDouble : public CloudVariableTypeBase {
     using vartype = double;
-    using varref = double*;
+    using varref = const double*;
 
     CloudVariableTypeDouble(){};
     static inline Spark_Data_TypeDef value() { return CLOUD_VAR_DOUBLE; }

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -81,9 +81,9 @@ bool spark_send_event(const char* name, const char* data, int ttl, Spark_Event_T
     return spark_protocol_send_event(sp, name, data, ttl, convert(eventType), NULL);
 }
 
-bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef userVarType, void* reserved)
+bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef userVarType, spark_variable_t* extra)
 {
-    SYSTEM_THREAD_CONTEXT_SYNC(spark_variable(varKey, userVar, userVarType, reserved));
+    SYSTEM_THREAD_CONTEXT_SYNC(spark_variable(varKey, userVar, userVarType, extra));
 
     User_Var_Lookup_Table_t* item = NULL;
     if (NULL != userVar && NULL != varKey && strlen(varKey)<=USER_VAR_KEY_LENGTH)
@@ -92,6 +92,9 @@ bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef 
         {
             item->userVar = userVar;
             item->userVarType = userVarType;
+            if (extra) {
+                item->update = extra->update;
+            }
             memset(item->userVarKey, 0, USER_VAR_KEY_LENGTH);
             memcpy(item->userVarKey, varKey, USER_VAR_KEY_LENGTH);
         }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -657,7 +657,14 @@ int userVarType(const char *varKey)
 const void *getUserVar(const char *varKey)
 {
     User_Var_Lookup_Table_t* item = find_var_by_key(varKey);
-    return item ? item->userVar : NULL;
+    const void* result = nullptr;
+    if (item) {
+    	if (item->update)
+            result = item->update(item->userVarKey, item->userVarType, item->userVar, nullptr);
+    	else
+            result = item->userVar;
+    }
+    return result;
 }
 
 void userFuncScheduleImpl(User_Func_Lookup_Table_t* item, const char* paramString, bool freeParamString, SparkDescriptor::FunctionResultCallback callback)

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -59,8 +59,12 @@ struct User_Var_Lookup_Table_t
 {
     const void *userVar;
     Spark_Data_TypeDef userVarType;
-    char userVarKey[USER_VAR_KEY_LENGTH];
+    char userVarKey[USER_VAR_KEY_LENGTH+1];
+
+    const void* (*update)(const char* name, Spark_Data_TypeDef varType, const void* var, void* reserved);
 };
+
+
 struct User_Func_Lookup_Table_t
 {
     void* pUserFuncData;

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -26,9 +26,12 @@
 test(api_spark_variable) {
 
     int valueInt = 0;
+    int32_t valueInt32 = 0;
+    uint32_t valueUint32 = 0;
     double valueDouble = 0;
-    const char* UNUSED(constValueString) = "oh no!";
+    const char* constValueString = "oh no!";
     char valueString[] = "oh yeah!";
+
     String valueSmartString(valueString);
 
     API_COMPILE(Particle.variable("myint", &valueInt, INT));
@@ -40,6 +43,23 @@ test(api_spark_variable) {
     //API_COMPILE(Particle.variable("mystring", &valueString, STRING));
 
     API_NO_COMPILE(Particle.variable("mystring", constValueString, STRING));
+
+    API_COMPILE(Particle.variable("mystring", &valueSmartString, STRING));
+
+    API_COMPILE(Particle.variable("mystring", &valueInt32, INT));
+    API_COMPILE(Particle.variable("mystring", &valueUint32, INT));
+
+    API_NO_COMPILE(Particle.variable("mystring", valueUint32));
+    API_COMPILE(Particle.variable("mystring", valueInt));
+    API_COMPILE(Particle.variable("mystring", valueInt32));
+    API_COMPILE(Particle.variable("mystring", valueUint32));
+
+    API_COMPILE(Particle.variable("mystring", valueDouble));
+
+    API_COMPILE(Particle.variable("mystring", valueString));
+    API_COMPILE(Particle.variable("mystring", constValueString));
+    API_COMPILE(Particle.variable("mystring", valueSmartString));
+
 }
 
 test(api_spark_function) {

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -70,8 +70,10 @@ public:
     template<typename T>
     static inline bool variable(const T *varKey, const String *userVar, const CloudVariableTypeString& userVarType)
     {
-        static_assert(sizeof(T)==0, "\n\nIn Particle.variable(\"name\", myVar, STRING); myVar must be declared as char myVar[] not String myVar\n\n");
-        return false;
+        spark_variable_t extra;
+        extra.size = sizeof(extra);
+        extra.update = update_string_variable;
+        return CLOUD_FN(spark_variable(varKey, userVar, CloudVariableTypeString::value(), &extra), false);
     }
     template<typename T>
     static inline bool variable(const T *varKey, const String &userVar, const CloudVariableTypeString& userVarType)
@@ -205,6 +207,12 @@ private:
         }
         return success;
 #endif
+    }
+
+    static const void* update_string_variable(const char* name, Spark_Data_TypeDef type, const void* var, void* reserved)
+    {
+        const String* s = (const String*)var;
+        return s->c_str();
     }
 };
 

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -49,10 +49,13 @@ public:
     {
         return variable(varKey, &var, INT);
     }
+#if PLATFORM_ID!=3
+    // compiling with gcc this function duplicates the previous one.
     static inline bool variable(const char* varKey, const int32_t& var)
     {
         return variable(varKey, &var, INT);
     }
+#endif
     static inline bool variable(const char* varKey, const uint32_t& var)
     {
         return variable(varKey, &var, INT);

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -45,6 +45,46 @@ class CloudClass {
 
 public:
 
+    static inline bool variable(const char* varKey, const int& var)
+    {
+        return variable(varKey, &var, INT);
+    }
+    static inline bool variable(const char* varKey, const int32_t& var)
+    {
+        return variable(varKey, &var, INT);
+    }
+    static inline bool variable(const char* varKey, const uint32_t& var)
+    {
+        return variable(varKey, &var, INT);
+    }
+
+    static inline bool variable(const char* varKey, const double& var)
+    {
+        return variable(varKey, &var, DOUBLE);
+    }
+
+    static inline bool variable(const char* varKey, const String& var)
+    {
+        return variable(varKey, &var, STRING);
+    }
+
+    static inline bool variable(const char* varKey, const char* var)
+    {
+        return variable(varKey, var, STRING);
+    }
+
+    template<std::size_t N>
+    static inline bool variable(const char* varKey, const char var[N])
+    {
+        return variable(varKey, var, STRING);
+    }
+
+    template<std::size_t N>
+    static inline bool variable(const char* varKey, const unsigned char var[N])
+    {
+        return variable(varKey, var, STRING);
+    }
+
     static inline bool variable(const char *varKey, const uint8_t* userVar, const CloudVariableTypeString& userVarType)
     {
         return variable(varKey, (const char*)userVar, userVarType);
@@ -53,6 +93,11 @@ public:
     template<typename T> static inline bool variable(const char *varKey, const typename T::varref userVar, const T& userVarType)
     {
         return CLOUD_FN(spark_variable(varKey, (const void*)userVar, T::value(), NULL), false);
+    }
+
+    static inline bool variable(const char *varKey, const int32_t* userVar, const CloudVariableTypeInt& userVarType)
+    {
+        return CLOUD_FN(spark_variable(varKey, (const void*)userVar, CloudVariableTypeInt::value(), NULL), false);
     }
 
     static inline bool variable(const char *varKey, const uint32_t* userVar, const CloudVariableTypeInt& userVarType)
@@ -67,6 +112,7 @@ public:
         static_assert(sizeof(T)==0, "\n\nUse Particle.variable(\"name\", myVar, STRING); without & in front of myVar\n\n");
         return false;
     }
+
     template<typename T>
     static inline bool variable(const T *varKey, const String *userVar, const CloudVariableTypeString& userVarType)
     {
@@ -75,6 +121,7 @@ public:
         extra.update = update_string_variable;
         return CLOUD_FN(spark_variable(varKey, userVar, CloudVariableTypeString::value(), &extra), false);
     }
+
     template<typename T>
     static inline bool variable(const T *varKey, const String &userVar, const CloudVariableTypeString& userVarType)
     {


### PR DESCRIPTION
Allows `String` instances to be used as variables. 

static String myString;
```
Particle.variable("myvar", myString);
```

Simpler variable API - no need for address-of `&` operator, and the 3rd argument is dropped, since the variable type is determined from the variable.


