### PR TITLE
inc gethostbyname() timeout from 10s to 30s, fix for FIRM-222 CFOD

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1115,7 +1115,7 @@ MDMParser::IP MDMParser::gethostbyname(const char* host)
     else {
         LOCK();
         sendFormated("AT+UDNSRN=0,\"%s\"\r\n", host);
-        if (RESP_OK != waitFinalResp(_cbUDNSRN, &ip))
+        if (RESP_OK != waitFinalResp(_cbUDNSRN, &ip, 30*1000))
             ip = NOIP;
         UNLOCK();
     }


### PR DESCRIPTION
`AT+ UDNSRN` has a response time of up to 30 seconds, and has been observed this high at least once.  Usually this command takes  anywhere from sub second to a couple seconds, and less frequently more than 5 seconds.