### PR TITLE
Zero out unused fields in DAC_InitStructure - seems to fix the DAC

### DIFF
--- a/hal/src/stm32f2xx/dac_hal.c
+++ b/hal/src/stm32f2xx/dac_hal.c
@@ -48,7 +48,7 @@ uint8_t dacInitFirstTime = true;
  */
 static void HAL_DAC_Init()
 {
-    DAC_InitTypeDef DAC_InitStructure;
+    DAC_InitTypeDef DAC_InitStructure = {0};
 
     /* DAC Periph clock enable */
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_DAC, ENABLE);


### PR DESCRIPTION
Zeroing out the only unused field in DAC_InitStructure - DAC_InitTypeDef::DAC_LFSRUnmask_TriangleAmplitude - appears to completely fix DAC behavior for me (issues #671 and #662). Setting the unused field to 255 brings back erratic behavior.

Can someone else please try this fix and report if it works for them?