### PR TITLE
Ensure socket exists before removing it when closing in socket_hal

### DIFF
--- a/hal/src/photon/socket_hal.cpp
+++ b/hal/src/photon/socket_hal.cpp
@@ -511,13 +511,14 @@ public:
     bool remove(socket_t* item)
     {
         bool removed = false;
-            if (items==item) {
-                items = item->next;
+        if (items==item) {
+            items = item->next;
             removed = true;
         }
-        else
+        else if (exists(item))
         {
-                socket_t* current = items;
+            socket_t* current = items;
+
             while (current) {
                 if (current->next==item) {
                     current->next = item->next;
@@ -526,6 +527,7 @@ public:
                 }
             }
         }
+
         return removed;
     }
 

--- a/hal/src/photon/socket_hal.cpp
+++ b/hal/src/photon/socket_hal.cpp
@@ -508,23 +508,23 @@ public:
      * @param item
      * @param list
      */
-    bool remove(socket_t* item)
-    {
+     bool remove(socket_t* item)
+     {
         bool removed = false;
         if (items==item) {
             items = item->next;
             removed = true;
         }
-        else if (exists(item))
+        else
         {
             socket_t* current = items;
-
             while (current) {
                 if (current->next==item) {
                     current->next = item->next;
                     removed = true;
                     break;
                 }
+                current = current->next;
             }
         }
 

--- a/hal/src/photon/socket_hal.cpp
+++ b/hal/src/photon/socket_hal.cpp
@@ -508,8 +508,8 @@ public:
      * @param item
      * @param list
      */
-     bool remove(socket_t* item)
-     {
+    bool remove(socket_t* item)
+    {
         bool removed = false;
         if (items==item) {
             items = item->next;


### PR DESCRIPTION
We've have had an ongoing issue where once our Photon reconnects to WiFi it immediately hangs whilst breathing cyan.

Inside our application we make use of a UDP socket which once the WiFi connection comes up seems to be a stale resource no longer within `this->items` and once execution enters the following `while` block, hangs forever.

Our Lead Firmware Engineer (@mhazley) has [documented this on the forum](https://community.particle.io/t/photon-v0-4-7-hanging-in-udp-stop/17553) and managed to catch this in the debugger and it's looking very likely that the root of our issue is from recycling the socket every 30s (internal detail of our application) _after_ a WiFi disconnect / reconnect has happened.

**Work Done**

* [x] Check that a `socket_t` exists before attempting to remove it, otherwise `return false`