### PR TITLE
Fixes FIRM-275 - Electron socket leak

### DIFF
--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -578,11 +578,21 @@ protected:
     NetStatus   _net; //!< collected network information
     IP          _ip;  //!< assigned ip address
     // management struture for sockets
-    typedef struct { int handle; system_tick_t timeout_ms; volatile bool connected; volatile int pending; } SockCtrl;
+    typedef struct {
+        int handle;
+        system_tick_t timeout_ms;
+        volatile bool connected;
+        volatile int pending;
+        volatile bool open;
+    } SockCtrl;
     // LISA-C has 6 TCP and 6 UDP sockets
     // LISA-U and SARA-G have 7 sockets
     SockCtrl _sockets[7];
     int _findSocket(int handle = MDM_SOCKET_ERROR/* = CREATE*/);
+    int _socketCloseHandleIfOpen(int socket);
+    int _socketCloseUnusedHandles(void);
+    int _socketSocket(int socket, IpProtocol ipproto, int port);
+    bool _socketFree(int socket);
     static MDMParser* inst;
     bool _init;
     bool _pwr;

--- a/hal/src/electron/socket_hal.cpp
+++ b/hal/src/electron/socket_hal.cpp
@@ -3,7 +3,7 @@
 #include "socket_hal.h"
 #include "parser.h"
 
-const sock_handle_t SOCKET_MAX = (sock_handle_t)7;
+const sock_handle_t SOCKET_MAX = (sock_handle_t)7; // 7 total sockets, handle 0-6
 const sock_handle_t SOCKET_INVALID = (sock_handle_t)-1;
 
 
@@ -57,8 +57,7 @@ uint8_t socket_active_status(sock_handle_t socket)
 
 sock_result_t socket_close(sock_handle_t sock)
 {
-    bool result = electronMDM.socketClose(sock);
-    electronMDM.socketFree(sock);
+    bool result = electronMDM.socketFree(sock); // closes and frees the socket
     return (result ? 0 : 1);
 }
 
@@ -77,7 +76,7 @@ sock_result_t socket_sendto(sock_handle_t sd, const void* buffer, socklen_t len,
 
 inline bool is_valid(sock_handle_t handle)
 {
-    return handle<=SOCKET_MAX;
+    return handle<SOCKET_MAX;
 }
 
 uint8_t socket_handle_valid(sock_handle_t handle)

--- a/hal/src/electron/socket_hal.cpp
+++ b/hal/src/electron/socket_hal.cpp
@@ -69,7 +69,10 @@ sock_result_t socket_send(sock_handle_t sd, const void* buffer, socklen_t len)
 
 sock_result_t socket_sendto(sock_handle_t sd, const void* buffer, socklen_t len, uint32_t flags, sockaddr_t* addr, socklen_t addr_size)
 {
-    return 0;
+    const uint8_t* addr_data = addr->sa_data;
+    uint16_t port = addr_data[0]<<8 | addr_data[1];
+    ElectronMDM::IP ip = IPADR(addr_data[2], addr_data[3], addr_data[4], addr_data[5]);
+    return electronMDM.socketSendTo(sd, ip, port, (const char*)buffer, len);
 }
 
 inline bool is_valid(sock_handle_t handle)

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -784,8 +784,10 @@ void Multicast_Presence_Announcement(void)
 {
 #ifndef SPARK_NO_CLOUD
     long multicast_socket = socket_create(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0, NIF_DEFAULT);
-    if (!socket_handle_valid(multicast_socket))
+    if (!socket_handle_valid(multicast_socket)) {
+        DEBUG("socket_handle_valid() = %d", socket_handle_valid(multicast_socket));
         return;
+    }
 
     unsigned char announcement[19];
     uint8_t id_length = HAL_device_ID(NULL, 0);
@@ -806,9 +808,10 @@ void Multicast_Presence_Announcement(void)
     //why loop here? Uncommenting this leads to SOS(HardFault Exception) on local cloud
     //for (int i = 3; i > 0; i--)
     {
+        DEBUG("socket_sendto()");
         socket_sendto(multicast_socket, announcement, 19, 0, &addr, sizeof (sockaddr_t));
     }
-
+    DEBUG("socket_close(multicast_socket)");
     socket_close(multicast_socket);
 #endif
 }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -476,7 +476,7 @@ int Internet_Test(void)
     long testSocket;
     sockaddr_t testSocketAddr;
     int testResult = 0;
-    DEBUG("internet test socket");
+    DEBUG("Internet test socket");
     testSocket = socket_create(AF_INET, SOCK_STREAM, IPPROTO_TCP, 53, NIF_DEFAULT);
     DEBUG("socketed testSocket=%d", testSocket);
 
@@ -500,16 +500,16 @@ int Internet_Test(void)
     testSocketAddr.sa_data[5] = 8;
 
     uint32_t ot = HAL_WLAN_SetNetWatchDog(S2M(MAX_SEC_WAIT_CONNECT));
-    DEBUG("connect");
+    DEBUG("Connect Attempt");
     testResult = socket_connect(testSocket, &testSocketAddr, sizeof (testSocketAddr));
-    DEBUG("connected testResult=%d", testResult);
+    DEBUG("socket_connect()=%s", (testResult ? "fail":"success"));
     HAL_WLAN_SetNetWatchDog(ot);
 
 #if defined(SEND_ON_CLOSE)
-    DEBUG("send");
+    DEBUG("Send Attempt");
     char c = 0;
     int rc = send(testSocket, &c, 1, 0);
-    DEBUG("send %d", rc);
+    DEBUG("send()=%d", rc);
 #endif
     DEBUG("Close");
     socket_close(testSocket);
@@ -533,7 +533,7 @@ int Spark_Connect(void)
 
     if (!socket_handle_valid(sparkSocket))
     {
-        DEBUG("socket_handle_valid()=%d", socket_handle_valid(sparkSocket));
+        DEBUG("sparkSocket not a valid socket handle!");
         return -1;
     }
     sockaddr_t tSocketAddr;
@@ -615,9 +615,9 @@ int Spark_Connect(void)
         uint32_t ot = HAL_WLAN_SetNetWatchDog(S2M(MAX_SEC_WAIT_CONNECT));
         DEBUG("Connect Attempt");
         rv = socket_connect(sparkSocket, &tSocketAddr, sizeof (tSocketAddr));
-        DEBUG("socket_connect()=%d", rv);
+        DEBUG("socket_connect()=%s", (rv ? "fail":"success"));
         if (rv)
-            ERROR("connection failed to %d.%d.%d.%d, code=%d", ip_addr[0], ip_addr[1], ip_addr[2], ip_addr[3], rv);
+            ERROR("connection failed to %d.%d.%d.%d", ip_addr[0], ip_addr[1], ip_addr[2], ip_addr[3]);
         else
             INFO("connected to cloud %d.%d.%d.%d", ip_addr[0], ip_addr[1], ip_addr[2], ip_addr[3]);
 
@@ -642,7 +642,7 @@ int Spark_Disconnect(void)
 #endif
         DEBUG("Close Attempt");
         retVal = socket_close(sparkSocket);
-        DEBUG("socket_close()=%d", retVal);
+        DEBUG("socket_close()=%s", (retVal ? "fail":"success"));
         sparkSocket = socket_handle_invalid();
     }
     return retVal;

--- a/wiring/src/spark_wiring_tcpclient.cpp
+++ b/wiring/src/spark_wiring_tcpclient.cpp
@@ -140,9 +140,9 @@ int TCPClient::available()
         if ( _total < arraySize(_buffer))
         {
             int ret = socket_receive(_sock, _buffer + _total , arraySize(_buffer)-_total, 0);
-            DEBUG("recv(=%d)",ret);
             if (ret > 0)
             {
+                DEBUG("recv(=%d)",ret);
                 if (_total == 0) _offset = 0;
                 _total += ret;
             }


### PR DESCRIPTION
* Sockets can be closed remotely now (if connected), or locally (if connected or not connected and just open) and the parser deals with this much better.
* UDP sockets will now be closed locally.
* added _sockets[socket].open flag to be able to close an unconnected socket.
* socketSocket() will now reclaim open sockets that are presumed closed.
* This is hard to reproduce without forcing sockets to be used up, which will be easier with the AT pass through cellular hal interface that's coming soon to a PR near you.
* Multicast Packet Announcement is not useful on the electron, but this helps to keep sockets from disappearing from the pool until this is refactored out for electrons (this was the main cause of socket leak as it would create sockets and not close them.  Then later on it would create them and not be able to close them.)
* upgrades socket connection and TCPClient debugging messages
