### PR TITLE
Implement WiFi.getCredentials

### DIFF
--- a/hal/inc/hal_dynalib_wlan.h
+++ b/hal/inc/hal_dynalib_wlan.h
@@ -67,6 +67,7 @@ DYNALIB_FN(hal_wlan,wlan_select_antenna)
 DYNALIB_FN(hal_wlan,wlan_set_ipaddress)
 DYNALIB_FN(hal_wlan,wlan_set_ipaddress_source)
 DYNALIB_FN(hal_wlan,wlan_scan)
+DYNALIB_FN(hal_wlan,wlan_get_credentials)
 DYNALIB_END(hal_wlan)
 
 #endif	/* HAL_DYNALIB_WLAN_H */

--- a/hal/inc/wlan_hal.h
+++ b/hal/inc/wlan_hal.h
@@ -261,6 +261,15 @@ typedef void (*wlan_scan_result_t)(WiFiAccessPoint* ap, void* cookie);
  */
 int wlan_scan(wlan_scan_result_t callback, void* cookie);
 
+/**
+ * Lists all WLAN credentials currently stored on the device
+ * @param callback  The callback that receives each stored AP
+ * @param callback_data An opaque handle that is passed to the callback.
+ * @return count of stored credentials, negative on error.
+ */
+
+int wlan_get_credentials(wlan_scan_result_t callback, void* callback_data);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/hal/src/core/wlan_hal.c
+++ b/hal/src/core/wlan_hal.c
@@ -567,3 +567,11 @@ int wlan_scan(wlan_scan_result_t callback, void* cookie)
     return err < 0 ? err : count;
 }
 
+/**
+ * Lists all WLAN credentials currently stored on the device
+ */
+int wlan_get_credentials(wlan_scan_result_t callback, void* callback_data)
+{
+    // Reading credentials from the CC3000 is not possible
+    return 0;
+}

--- a/user/tests/wiring/api/wifi.cpp
+++ b/user/tests/wiring/api/wifi.cpp
@@ -161,4 +161,17 @@ test(api_wifi_ipconfig)
     (void)address;
 }
 
+test(api_wifi_get_credentials)
+{
+    WiFiAccessPoint ap[10];
+    int found = WiFi.getCredentials(ap, 10);
+    for (int i=0; i<found; i++) {
+        Serial.print("ssid: ");
+        Serial.println(ap[i].ssid);
+        Serial.println(ap[i].security);
+        Serial.println(ap[i].channel);
+        Serial.println(ap[i].rssi);
+    }
+}
+
 #endif

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -213,6 +213,8 @@ public:
     int scan(void (*handler)(WiFiAccessPoint* ap, T* instance), T* instance) {
         return scan((wlan_scan_result_t)handler, (void*)instance);
     }
+
+    int getCredentials(WiFiAccessPoint* results, size_t result_count);
 };
 
 extern WiFiClass WiFi;

--- a/wiring/src/spark_wiring_wifi.cpp
+++ b/wiring/src/spark_wiring_wifi.cpp
@@ -34,16 +34,11 @@ License along with this library; if not, see <http://www.gnu.org/licenses/>.
 
 namespace spark {
 
-    class ScanArray
+    class APArrayPopulator
     {
         WiFiAccessPoint* results;
         int count;
         int index;
-
-        static void scan_callback(WiFiAccessPoint* result, void* cookie)
-        {
-            ((ScanArray*)cookie)->addResult(result);
-        }
 
         void addResult(WiFiAccessPoint* result) {
             if (index<count) {
@@ -51,25 +46,50 @@ namespace spark {
             }
         }
 
+    protected:
+        static void callback(WiFiAccessPoint* result, void* cookie)
+        {
+            ((APArrayPopulator*)cookie)->addResult(result);
+        }
+
     public:
-        ScanArray(WiFiAccessPoint* results, int size) {
+        APArrayPopulator(WiFiAccessPoint* results, int size) {
             this->results = results;
             this->count = size;
             this->index = 0;
         }
+    };
+
+    class APScan : public APArrayPopulator {
+        public:
+        using APArrayPopulator::APArrayPopulator;
 
         int start()
         {
-            return wlan_scan(scan_callback, this);
+            return wlan_scan(callback, this);
+        }
+    };
+
+    class APList : public APArrayPopulator {
+        public:
+        using APArrayPopulator::APArrayPopulator;
+
+        int start()
+        {
+            return wlan_get_credentials(callback, this);
         }
     };
 
 
     int WiFiClass::scan(WiFiAccessPoint* results, size_t result_count) {
-        ScanArray scanArray(results, result_count);
-        return scanArray.start();
+        APScan apScan(results, result_count);
+        return apScan.start();
     }
 
+    int WiFiClass::listCredentials(WiFiAccessPoint* results, size_t result_count) {
+        APList apList(results, result_count);
+        return apList.start();
+    }
 
     int8_t WiFiClass::RSSI() {
         if (!network_ready(*this, 0, NULL))


### PR DESCRIPTION
* User provides an array of WiFiAccessPoint that get filled with the APs saved on the device
* Returns number of APs on device
* Photon only. Returns 0 on the Core since it cannot read APs back from the CC3000 :disappointed:

Changes
* Implement wlan_get_credentials in HAL
* Implement WiFi.getCredentials with array arguments
* Add API test

Fixes #453

Usage:
```
    WiFiAccessPoint ap[5];
    int found = WiFi.getCredentials(ap, 5);
    for (int i=0; i<found; i++) {
        Serial.print("ssid: ");
        Serial.println(ap[i].ssid);
        Serial.println(ap[i].security);
        Serial.println(ap[i].channel);
        Serial.println(ap[i].rssi);
    }
```

For discussion: my first cut of this was to return a `vector<WiFiAccessPoint>` (typedefed to `WiFiAccessPointList`) from `WiFi.getCredentials`. This made for very nice application code:
```
WiFiAccessPointList list = WiFi.getCredentials();
for(WiFiAccessPoint ap : list) {
  Serial.println(ap.ssid);
}
```
But I noticed that `WiFi.scan` is currently implemented to accept an array allocated on the stack by the caller, so I went with that solution in the end.

Any strong reasons why not create a `vector` that allocates a few `WiFiAccessPoint` on the heap whenever `WiFi.scan` or `WiFi.getCredentials` is called? It is simple to make a version of `WiFi.scan` that returns a `WiFiAccessPointList` too.

Another point of discussion:
Printing the list of available networks on one of my Photon gives me this:
```
Listing stored access points
Count=5
SSID=TechBreweryNew, security=3
SSID=TechBreweryNew, security=3
SSID=TechBreweryNew, security=3
SSID=TechBreweryNew, security=3
SSID=TechBreweryNew, security=3
End listing
```

Is it OK that there are 5 copies of the same network? Now that people will be able to read this list out it might cause confusion.

Would it be better to overwrite existing credentials if the SSID is the same rather than make multiple copies?