### PR TITLE
Fixed unset wiced_result for tcp clients on socket_send

### DIFF
--- a/hal/inc/hal_dynalib_concurrent.h
+++ b/hal/inc/hal_dynalib_concurrent.h
@@ -40,6 +40,11 @@ DYNALIB_FN(hal_concurrent,os_timer_create)
 DYNALIB_FN(hal_concurrent,os_timer_destroy)
 DYNALIB_FN(hal_concurrent,os_timer_get_id)
 DYNALIB_FN(hal_concurrent,os_timer_change)
+
+DYNALIB_FN(hal_concurrent,os_queue_create)
+DYNALIB_FN(hal_concurrent,os_queue_destroy)
+DYNALIB_FN(hal_concurrent,os_queue_put)
+DYNALIB_FN(hal_concurrent,os_queue_take)
 #endif
 DYNALIB_END(hal_concurrent)
 

--- a/hal/src/photon/socket_hal.cpp
+++ b/hal/src/photon/socket_hal.cpp
@@ -994,7 +994,7 @@ sock_result_t socket_send(sock_handle_t sd, const void* buffer, socklen_t len)
         }
         else if (is_client(socket)) {
             tcp_server_client_t* server_client = client(socket);
-            result = server_client->write(buffer, len);
+            wiced_result = static_cast<wiced_result_t>(server_client->write(buffer, len));
         }
         if (!wiced_result)
             DEBUG("Write %d bytes to socket %d result=%d", (int)len, (int)sd, wiced_result);

--- a/modules/photon/user-part/makefile
+++ b/modules/photon/user-part/makefile
@@ -16,10 +16,12 @@ include $(PROJECT_ROOT)/build/platform-id.mk
 
 LIBS += $(MAKE_DEPENDENCIES)
 LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP)
-LIB_DEPS += $(PROJECT_ROOT)/hal/src/photon/lib/STM32F2xx_Peripheral_Libraries.a
+LIB_DEPS += $(PROJECT_ROOT)/hal/src/photon/lib/STM32F2xx_Peripheral_Libraries.a 
+LIB_DEPS += $(PROJECT_ROOT)/user/applications/photon-mpu/inv/mpl/mplmpu.a
+
 LIB_DIRS += $(dir $(LIB_DEPS))
 
-LDFLAGS += -Wl,--whole-archive $(PROJECT_ROOT)/hal/src/photon/lib/STM32F2xx_Peripheral_Libraries.a -Wl,--no-whole-archive
+LDFLAGS += -Wl,--whole-archive $(PROJECT_ROOT)/hal/src/photon/lib/STM32F2xx_Peripheral_Libraries.a $(PROJECT_ROOT)/user/applications/photon-mpu/inv/mpl/mplmpu.a -Wl,--no-whole-archive
 
 
 TARGET=elf bin lst hex size

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,0 +1,4 @@
+export PARTICLE_DEVELOP=1
+export DEBUG_BUILD=y
+export PLATFORM=photon
+export APP=photon-mpu

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -23,8 +23,7 @@
 
 #ifndef SPARK_WIRING_THREAD_H
 #define	SPARK_WIRING_THREAD_H
-
-#if PLATFORM_THREADING
+//#if PLATFORM_THREADING
 
 #include "concurrent_hal.h"
 #include <stddef.h>
@@ -117,11 +116,54 @@ public:
 
 #define CRITICAL_SECTION_BLOCK() CriticalSection __cs;
 
-#else
+template<typename T>
+class RtosQueue
+{
+public:
+	RtosQueue(size_t item_count) : m_queue(NULL) {
+		os_queue_create(&m_queue, sizeof(T), item_count);
+	}
+	virtual ~RtosQueue()
+	{
+	    if (m_queue) {
+	    	os_queue_destroy(m_queue);
+	    	m_queue = NULL;
+	    }
+	}
+	/**
+	 * Return 0 on success.
+	 * @param queue
+	 * @param item
+	 * @param delay
+	 * @return
+	 */
+	int put(const T& item, uint32_t delay)
+	{
+		return os_queue_put(m_queue, (const void*)&item, delay);
+	}
+	/**
+	 * Return 0 on success.
+	 * @param queue
+	 * @param item
+	 * @param delay
+	 * @return
+	 */
+	int take(T* item, uint32_t delay)
+	{
+		return os_queue_take(m_queue, (void*)item, delay);
+	}
 
-#define CRITICAL_SECTION_BLOCK()
 
-#endif
+private:
+	os_queue_t  m_queue;
+};
+
+
+//#else
+
+//#define CRITICAL_SECTION_BLOCK()
+
+//#endif
 
 #endif	/* SPARK_WIRING_THREAD_H */
 


### PR DESCRIPTION
I noticed that on the Photon platform, TCPClient::write does ALWAYS return -7009 if it is a client connection of a TCPServer. Looking at the code, I see that the socket return code is written to the wrong variable, result instead of wiced_result. This is leads to a constant return value of WICED_TCPIP_INVALID_SOCKET (7009) which subsequently gets negated.

Casting the int return code to wiced_result_t and assigning it to wiced_result is the fix. 

I also noticed that the documentation of TCPClient::write has gaps. It does not mention any return codes at all. The developer has to dig deep into wiced_result.h to see for example that -16 corresponds to WOULD_BLOCK. Should I create a pull request for the doc as well?

I also noticed that TCPClient::write returns size_t although the error codes are all <0. This is highly confusing and should be documented as well if there is a good reason for that. The developer has to cast it back to int before use.

Thanks