### PR TITLE
Update spark_wiring_udp.cpp

### DIFF
--- a/wiring/src/spark_wiring_udp.cpp
+++ b/wiring/src/spark_wiring_udp.cpp
@@ -261,3 +261,8 @@ int UDP::leaveMulticast(const IPAddress& ip)
     HAL_IPAddress address = ip.raw();
     return socket_leave_multicast(&address, _nif, 0);
 }
+
+bool UDP::isOpen() 
+{
+  return _sock != socket_handle_invalid();
+}


### PR DESCRIPTION
add UDP::isOpen() to let catch sockets become invalid after a wifi reconnect