### PR TITLE
Electron RSSI UX via SETUP button

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -124,6 +124,7 @@ void system_handle_single_click()
      */
     if (SYSTEM_HANDLE_SINGLE_CLICK) {
         SYSTEM_HANDLE_SINGLE_CLICK = false;
+        volatile system_tick_t startTime = SYSTEM_TICK_COUNTER;
         RGB.control(true);
         RGB.color(0,10,0);
         int rssi = 0;
@@ -141,10 +142,14 @@ void system_handle_single_click()
             else if (rssi > -92) bars = 2;
             else if (rssi > -104) bars = 1;
         }
-        DEBUG_D("RSSI: %ddB BARS: %d\r\n", rssi, bars);
+        DEBUG("RSSI: %ddB BARS: %d\r\n", rssi, bars);
+
         /* flash sequence */
         /* TODO - REFACTOR Flash Sequence to be non-blocking via HAL_SysTick_Handler() */
-        delay(1000);
+
+        // Attempts to normalize beginning dim green time to 1 second
+        while ( (SYSTEM_TICK_COUNTER - startTime) < (SYSTEM_US_TICKS*1000UL*1000UL) );
+
         if (bars > 0) {
             for (int x=0; x<bars; x++) {
                 RGB.color(0,255,0);

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -85,7 +85,7 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
             HAL_Core_Enter_Standby_Mode();
             break;
 
-#if Wiring_SoftPowerOff
+#if Wiring_SetupButtonUX
         case SLEEP_MODE_SOFTPOWEROFF:
             network_disconnect(0,0,NULL);
             network_off(0, 0, 0, NULL);

--- a/wiring/inc/spark_wiring_platform.h
+++ b/wiring/inc/spark_wiring_platform.h
@@ -76,7 +76,7 @@
 
 #define Wiring_Wire1 1
 #define Wiring_Wire3 1 /* System PMIC and Fuel Guage I2C3 */
-#define Wiring_SoftPowerOff 1
+#define Wiring_SetupButtonUX 1
 #endif
 
 #ifndef Wiring_SPI1
@@ -119,8 +119,8 @@
 #define Wiring_Serial5 0
 #endif
 
-#ifndef Wiring_SoftPowerOff
-#define Wiring_SoftPowerOff 0
+#ifndef Wiring_SetupButtonUX
+#define Wiring_SetupButtonUX 0
 #endif
 
 #endif	/* SPARK_WIRING_PLATFORM_H */


### PR DESCRIPTION
* One click of the SETUP button invokes a blocking call for signal strength, when received it is converted to 0-5 "bars" of signal strength via a green LED.  First the LED dims to make the flashes more apparent and easy to count, then the LED is flashed bright green once for each bar of signal strength.  If the signal is really weak, dim green with no flashes equates to zero bars.
* Two clicks of the SETUP button invokes the Soft Power Down feature that was previously implemented, which powers off the modem and puts the STM32 in deep sleep mode.
* Disables the single/double tap feature for non-electron devices.

A little preview of how this works with 1 bar of signal strength.  Sorry my signal is not the best right now :)
https://www.dropbox.com/s/hph5mldtxysr185/rssi-ux-and-soft-power-down.mov?dl=0