### PR TITLE
Fixes FIRM-279 - Modem unresponsive on power up

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -406,6 +406,7 @@ bool MDMParser::powerOn(const char* simpin)
     }
 
     bool continue_cancel = false;
+    bool retried_after_reset = false;
 
     MDM_INFO("\r\n[ Modem::powerOn ] = = = = = = = = = = = = = =");
     while (i--) {
@@ -436,9 +437,18 @@ bool MDMParser::powerOn(const char* simpin)
             _pwr = true;
             break;
         }
+        else if (i==0 && !retried_after_reset) {
+            MDM_INFO("[ Modem reset ]");
+            retried_after_reset = true; // only perform reset & retry sequence once
+            i = 10;
+            HAL_GPIO_Write(RESET_UC, 0);
+            HAL_Delay_Milliseconds(100);
+            HAL_GPIO_Write(RESET_UC, 1);
+        }
+
     }
     if (i < 0) {
-        MDM_ERROR("No Reply from Modem\r\n");
+        MDM_ERROR("[ No Reply from Modem ]\r\n");
     }
 
     if (continue_cancel) {

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -64,6 +64,11 @@ public:
             const char* password = NULL, Auth auth = AUTH_DETECT);
 
     /**
+     * Used to issue a hardware reset of the modem
+     */
+    void reset(void);
+
+    /**
      * powerOn Initialize the modem and SIM card
      * \param simpin a optional pin of the SIM card
      * \return true if successful, false otherwise
@@ -497,6 +502,7 @@ protected:
     int _socketCloseUnusedHandles(void);
     int _socketSocket(int socket, IpProtocol ipproto, int port);
     bool _socketFree(int socket);
+    bool _powerOn(void);
     static MDMParser* inst;
     bool _init;
     bool _pwr;


### PR DESCRIPTION
* if modem is unresponsive on power up, it will be reset and the power up sequence will be retried.
* if SIM card was inserted after power up, it may show up as not inserted.  System will now power down the modem & power back up (soft reset) to allow the SIM card to be recognized.