### PR TITLE
Fixed unset wiced_result for tcp clients on socket_send

### DIFF
--- a/hal/src/photon/socket_hal.cpp
+++ b/hal/src/photon/socket_hal.cpp
@@ -994,7 +994,7 @@ sock_result_t socket_send(sock_handle_t sd, const void* buffer, socklen_t len)
         }
         else if (is_client(socket)) {
             tcp_server_client_t* server_client = client(socket);
-            result = server_client->write(buffer, len);
+            wiced_result = static_cast<wiced_result_t>(server_client->write(buffer, len));
         }
         if (!wiced_result)
             DEBUG("Write %d bytes to socket %d result=%d", (int)len, (int)sd, wiced_result);


### PR DESCRIPTION
I noticed that on the Photon platform, TCPClient::write does ALWAYS return -7009 if it is a client connection of a TCPServer. Looking at the code, I see that the socket return code is written to the wrong variable, result instead of wiced_result. This is leads to a constant return value of WICED_TCPIP_INVALID_SOCKET (7009) which subsequently gets negated.

Casting the int return code to wiced_result_t and assigning it to wiced_result is the fix.

