### PR TITLE
Check for EAGAIN error code (gcc platform) and minor compilation fixes

### DIFF
--- a/communication/src/lightssl_message_channel.h
+++ b/communication/src/lightssl_message_channel.h
@@ -97,10 +97,10 @@ public:
 
 	ProtocolError notify_established() override { return NO_ERROR; }
 
-	virtual ProtocolError command(Command cmd, void* arg=nullptr) override;
+	virtual ProtocolError command(Command cmd, void* arg=nullptr) override {
 		// not used presently
+		return NO_ERROR;
 	}
-
 
 protected:
 

--- a/hal/src/gcc/device_config.cpp
+++ b/hal/src/gcc/device_config.cpp
@@ -139,11 +139,13 @@ void read_config_file(const char* config_name, void* data, size_t length)
 }
 
 uint8_t hex2dec(char c) {
-    if (c<='9')
-        return uint8_t(c-'0');
-    if (c<='Z')
-        return uint8_t(c-'A');
-    return uint8_t(c-'a');
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    return 0xFF;
 }
 
 

--- a/hal/src/gcc/rtc_hal.cpp
+++ b/hal/src/gcc/rtc_hal.cpp
@@ -1,15 +1,16 @@
 
 #include "rtc_hal.h"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/version.hpp>
 
 
 void HAL_RTC_Configuration(void)
 {
 }
 
-#if 0
+#if BOOST_VERSION < 105800
 time_t to_time_t(boost::posix_time::ptime t)
 {
     using namespace boost::posix_time;

--- a/hal/src/gcc/socket_hal.cpp
+++ b/hal/src/gcc/socket_hal.cpp
@@ -30,7 +30,6 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wmissing-braces"
 #include <boost/array.hpp>
-#include <boost/system/system_error.hpp>
 
 // conflict of types
 #define socklen_t boost_socklen_t

--- a/hal/src/gcc/socket_hal.cpp
+++ b/hal/src/gcc/socket_hal.cpp
@@ -30,6 +30,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wmissing-braces"
 #include <boost/array.hpp>
+#include <boost/system/system_error.hpp>
 
 // conflict of types
 #define socklen_t boost_socklen_t


### PR DESCRIPTION
Sockets HAL implementation in GCC platform creates non-blocking sockets and read operation on them may return EAGAIN if there's no data available.