### PR TITLE
Magical fix for strange build issue

### DIFF
--- a/build/verbose.mk
+++ b/build/verbose.mk
@@ -16,7 +16,7 @@ VERBOSE_REDIRECT=
 else
 ECHO = true
 VERBOSE=@
-VERBOSE_REDIRECT= &> /dev/null
+VERBOSE_REDIRECT= > /dev/null 2>&1
 endif
 
 echo=@$(ECHO) $1


### PR DESCRIPTION
It more looks like a bug in GNU make or bash, but I experienced weird issue related to this patch: e7b75d7848a3ac27e7428db766b18dd56bd88b24. When make is invoked in silent mode (-s argument) it fails to generate target binary with a valid checksum, leading newly flashed device to boot in safe mode after successful build.

Tested on Ubuntu 14.04 LTS (gmake 3.81 / 4.1, bash 4.3.11).
