### PR TITLE
Feature/electron/rssi ux threaded

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -139,7 +139,7 @@ void system_display_bars(int bars)
 {
     if (bars>=0)
     {
-		SYSTEM_LED_COUNT = (bars<<1)+2;
+		SYSTEM_LED_COUNT = ((bars<<1)+2) | 128;
     }
     else
     {
@@ -160,7 +160,6 @@ void system_handle_single_click()
      */
     if (SYSTEM_HANDLE_SINGLE_CLICK) {
         SYSTEM_HANDLE_SINGLE_CLICK = false;
-        system_tick_t startTime = SYSTEM_TICK_COUNTER;
         system_prepare_display_bars();
         int rssi = 0;
         int bars = 0;
@@ -178,9 +177,6 @@ void system_handle_single_click()
             else if (rssi > -104) bars = 1;
         }
         DEBUG("RSSI: %ddB BARS: %d\r\n", rssi, bars);
-
-        // Attempts to normalize beginning dim green time to 1 second
-	   while ( (SYSTEM_TICK_COUNTER - startTime) < (SYSTEM_US_TICKS*1000UL*1000UL) );
 
         system_display_bars(bars);
     }
@@ -379,6 +375,13 @@ extern "C" void HAL_SysTick_Handler(void)
   			LED_SetRGBColor(0<<16 | 10<<8 | 0);
     	        LED_On(LED_RGB);
     			TimingLED = 100;
+		}
+		else if (SYSTEM_LED_COUNT & 128)
+		{
+			LED_SetRGBColor(0<<16 | 10<<8 | 0);
+			LED_On(LED_RGB);
+			TimingLED = 1000;
+			SYSTEM_LED_COUNT &= ~128;
 		}
 		else
 		{

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -396,7 +396,7 @@ extern "C" void HAL_SysTick_Handler(void)
 			{
 				LED_SetRGBColor(0<<16 | 255<<8 | 0);
 				LED_On(LED_RGB);
-				TimingLED = 60;
+				TimingLED = 40;
 			}
 			else
 			{

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -160,6 +160,7 @@ void system_handle_single_click()
      */
     if (SYSTEM_HANDLE_SINGLE_CLICK) {
         SYSTEM_HANDLE_SINGLE_CLICK = false;
+        system_tick_t startTime = SYSTEM_TICK_COUNTER;
         system_prepare_display_bars();
         int rssi = 0;
         int bars = 0;
@@ -177,6 +178,10 @@ void system_handle_single_click()
             else if (rssi > -104) bars = 1;
         }
         DEBUG("RSSI: %ddB BARS: %d\r\n", rssi, bars);
+
+        // Attempts to normalize beginning dim green time to 1 second
+	   while ( (SYSTEM_TICK_COUNTER - startTime) < (SYSTEM_US_TICKS*1000UL*1000UL) );
+
         system_display_bars(bars);
     }
 }
@@ -391,7 +396,7 @@ extern "C" void HAL_SysTick_Handler(void)
 			{
 				LED_SetRGBColor(0<<16 | 255<<8 | 0);
 				LED_On(LED_RGB);
-				TimingLED = 40;
+				TimingLED = 60;
 			}
 			else
 			{

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -16,6 +16,7 @@
  ******************************************************************************
  */
 
+#include "spark_wiring_platform.h"
 #include "spark_wiring_system.h"
 #include "spark_wiring_usbserial.h"
 #include "system_task.h"
@@ -300,6 +301,11 @@ void manage_cloud_connection(bool force_events)
 }
 #endif
 
+
+#if Wiring_SetupButtonUX
+extern void		system_handle_single_click(); // display RSSI value on system LED for WiFi or Cellular
+#endif
+
 void Spark_Idle_Events(bool force_events/*=false*/)
 {
     HAL_Notify_WDT();
@@ -308,6 +314,11 @@ void Spark_Idle_Events(bool force_events/*=false*/)
     spark_loop_total_millis = 0;
 
     if (!SYSTEM_POWEROFF) {
+
+#if Wiring_SetupButtonUX
+		system_handle_single_click(); // display RSSI value on system LED for WiFi or Cellular
+#endif
+
         manage_serial_flasher();
 
         manage_network_connection();

--- a/wiring/inc/spark_wiring_rgb.h
+++ b/wiring/inc/spark_wiring_rgb.h
@@ -28,8 +28,6 @@ typedef void (raw_rgb_change_handler_t)(uint8_t, uint8_t, uint8_t);
 typedef std::function<raw_rgb_change_handler_t> wiring_rgb_change_handler_t;
 
 class RGBClass {
-private:
-	static bool _control;
 public:
 	static bool controlled(void);
 	static void control(bool);

--- a/wiring/src/spark_wiring_rgb.cpp
+++ b/wiring/src/spark_wiring_rgb.cpp
@@ -22,23 +22,19 @@
 #include "spark_wiring_rgb.h"
 #include "rgbled.h"
 
-bool RGBClass::_control = false;
-
 bool RGBClass::controlled(void)
 {
-    return _control;
+    return LED_RGB_IsOverRidden();
 }
 
 void RGBClass::control(bool override)
 {
-    if(override == _control)
+    if(override == controlled())
             return;
     else if (override)
             LED_Signaling_Start();
     else
             LED_Signaling_Stop();
-
-    _control = override;
 }
 
 void RGBClass::color(uint32_t rgb) {
@@ -47,7 +43,7 @@ void RGBClass::color(uint32_t rgb) {
 
 void RGBClass::color(int red, int green, int blue)
 {
-    if (true != _control)
+    if (!controlled())
             return;
 
     LED_SetSignalingColor(red << 16 | green << 8 | blue);
@@ -57,7 +53,7 @@ void RGBClass::color(int red, int green, int blue)
 void RGBClass::brightness(uint8_t brightness, bool update)
 {
     LED_SetBrightness(brightness);
-    if (_control && update)
+    if (controlled() && update)
         LED_On(LED_RGB);
 }
 


### PR DESCRIPTION
Moves the RSSI UX to the system tick thread, and the handling of the button press to the system thread so that it continues to work when the application thread is blocked. 

I upped the delay between pips from 250 to 350ms - 250ms seemed too quick and I had trouble counting. 

Manages system override and restoring the LED color, and fixes https://github.com/spark/firmware/issues/784
