### PR TITLE
Process system queue events while in listening mode

### DIFF
--- a/user/tests/wiring/threading/application.cpp
+++ b/user/tests/wiring/threading/application.cpp
@@ -26,61 +26,41 @@
 #include "system_threading.h"
 #include <functional>
 
-void* abc = NULL;
-
 UNIT_TEST_APP();
 SYSTEM_THREAD(ENABLED);
 
-int test_val;
+volatile int test_val;
 void increment(void)
 {
 	test_val++;
+}
+
+test(system_thread_can_pump_events)
+{
+    test_val = 0;
+
+    ActiveObjectBase* system = (ActiveObjectBase*)system_internal(1, nullptr); // Returns system thread instance
+    system->invoke_async(std::function<void()>(increment));
+
+    uint32_t start = millis();
+    while (test_val != 1 && millis() - start < 1000); // Busy wait
+
+    assertEqual((int)test_val, 1);
 }
 
 test(application_thread_can_pump_events)
 {
 	test_val = 0;
 
-	ActiveObjectBase* app = (ActiveObjectBase*)system_internal(0, nullptr);
+	ActiveObjectBase* app = (ActiveObjectBase*)system_internal(0, nullptr); // Returns application thread instance
 	std::function<void(void)> fn = increment;
 	app->invoke_async(fn);
 
 	// test value not incremented
-	assertEqual(test_val, 0);
+	assertEqual((int)test_val, 0);
 
     Particle.process();
 
     // validate the function was called.
-    assertEqual(test_val, 1);
-
+    assertEqual((int)test_val, 1);
 }
-
-uint32_t last_listen_event = 0;
-void app_listening(system_event_t event, uint32_t time, void*)
-{
-	last_listen_event = time;
-	if (time>2000)
-		WiFi.listen(false); // exit listening mode
-}
-
-// This test ensures the RTOS time slices between threads when the system is in listening mode.
-// It's not a complete test, since we never exit or re-enter loop so the loop-calling logic isn't exercised.
-// This test indirectly ensures the system thread also runs, since if it didn't then the listen update events wouldn't be
-// published.
-test(application_thread_runs_during_listening_mode)
-{
-	System.on(wifi_listen_update, app_listening);
-
-	uint32_t start = millis();
-	WiFi.listen();
-	delay(10);		// time for the system thread to enter listening mode
-
-	while (millis()-start<1000);		// busy wait 1000 ms
-
-	uint32_t end = millis();
-	assertLess(end-start, 1200);		// small margin of error
-	assertMore(last_listen_event, 0);	// system event should have ran the listen loop
-
-	System.off(app_listening);
-}
-

--- a/user/tests/wiring/threading/listening.cpp
+++ b/user/tests/wiring/threading/listening.cpp
@@ -1,0 +1,35 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "system_threading.h"
+
+volatile bool listening_flag = false;
+
+void listening_start() {
+    listening_flag = false;
+    WiFi.listen();
+    delay(100); // Time for the system thread to enter listening loop
+}
+
+void listening_stop() {
+    WiFi.listen(false);
+    delay(100); // Time for the system thread to exit listening loop
+}
+
+void listening_set_flag() {
+    listening_flag = true;
+}
+
+// Checks whether listening loop performs processing of the system thread's queued events
+test(listening_loop_is_processing_system_events) {
+    listening_start();
+
+    ActiveObjectBase *system = (ActiveObjectBase*)system_internal(1 /* System thread */, nullptr);
+    system->invoke_async(std::function<void()>(listening_set_flag));
+
+    uint32_t time = millis();
+    while (!listening_flag && millis() - time < 500); // Busy wait
+
+    listening_stop();
+
+    assertTrue((bool)listening_flag);
+}

--- a/user/tests/wiring/threading/listening.cpp
+++ b/user/tests/wiring/threading/listening.cpp
@@ -2,34 +2,79 @@
 #include "unit-test/unit-test.h"
 #include "system_threading.h"
 
-volatile bool listening_flag = false;
+volatile bool listening_test_flag;
 
 void listening_start() {
-    listening_flag = false;
-    WiFi.listen();
-    delay(100); // Time for the system thread to enter listening loop
+    listening_test_flag = false;
+    WiFi.listen(true);
+    delay(1000); // Time for the system thread to enter listening mode
 }
 
 void listening_stop() {
     WiFi.listen(false);
-    delay(100); // Time for the system thread to exit listening loop
+    delay(1000); // Time for the system thread to exit listening mode
 }
 
-void listening_set_flag() {
-    listening_flag = true;
+void listening_set_test_flag() {
+    listening_test_flag = true;
+}
+
+// Following test ensures that handler function is invoked for SystemEvents::wifi_listen_update events
+uint32_t listening_update_time;
+
+void listening_update_handler(system_event_t, uint32_t time, void*) {
+    listening_update_time = time;
+}
+
+test(listening_update_event_is_sent) {
+    listening_update_time = 0;
+    System.on(wifi_listen_update, listening_update_handler); // Register handler
+
+    listening_start();
+
+    uint32_t start = millis();
+    while (millis() - start < 1000); // Busy wait
+
+    listening_stop();
+
+    System.off(listening_update_handler); // Unregister handler
+
+    // Handler function should be invoked only in the context of application thread
+    assertEqual(listening_update_time, 0);
+
+    // Process application queue
+    start = millis();
+    do {
+        Particle.process();
+    } while (listening_update_time == 0 && millis() - start < 1000);
+
+    assertMore(listening_update_time, 0);
+}
+
+// This test ensures the RTOS time slices between threads when the system is in listening mode
+test(listening_application_thread_is_running) {
+    listening_start();
+
+    uint32_t start = millis();
+    while (millis() - start < 1000); // Busy wait
+    uint32_t end = millis();
+
+    listening_stop();
+
+    assertLess(end - start, 1200); // Small margin of error
 }
 
 // Checks whether listening loop performs processing of the system thread's queued events
 test(listening_loop_is_processing_system_events) {
     listening_start();
 
-    ActiveObjectBase *system = (ActiveObjectBase*)system_internal(1 /* System thread */, nullptr);
-    system->invoke_async(std::function<void()>(listening_set_flag));
+    ActiveObjectBase *system = (ActiveObjectBase*)system_internal(1, nullptr); // Returns system thread instance
+    system->invoke_async(std::function<void()>(listening_set_test_flag));
 
     uint32_t time = millis();
-    while (!listening_flag && millis() - time < 500); // Busy wait
+    while (!listening_test_flag && millis() - time < 1000); // Busy wait
 
     listening_stop();
 
-    assertTrue((bool)listening_flag);
+    assertTrue((bool)listening_test_flag);
 }


### PR DESCRIPTION
This is to keep up the discussion summarized here: #788, and also a generic fix for #743 and #761.

The patch ensures that system queue is processed while listening mode is enabled in multithreaded configuration, so that synchronous calls that need to be executed in the context of system thread don't block application code.

Solution is far from ideal, as listening loop is still separated from the main system loop, and thus additional checks in unrelated parts of the code are required in order to break this listening loop when necessary (e.g. https://github.com/sergeuz/firmware/blob/loop/system/src/system_network_internal.h#L378). In general, it seems that our whole flags and loops stuff needs to be refactored in favor of more or less strict state machine with centralized control over initialization and uninitialization of different device modes, related LED indication, etc -- but I'm not sure whether it goes well with our current priorities.

As for potentially interleaved user and system serial communications, proposed solution is to allow user to explicitly disable serial console in listening mode:

```c++
SYSTEM_THREAD(ENABLED)
SYSTEM_OPTIONS(SERIAL_CONSOLE_DISABLED)

void setup() {
    // ...
}

void loop() {
    // ...
}
```

`SYSTEM_OPTIONS(...)` macro expands to a series of calls to `system_set_option(int option, void *value)` function exposed by the system module, and can be extended to support other options if necessary:

```c++
SYSTEM_OPTIONS(
    SOME_SYSTEM_FLAG, // or SOME_SYSTEM_FLAG = true
    SOME_SYSTEM_TIMEOUT = 10000,
    SOME_STRING_OPTION = "hello"
)
```
