### PR TITLE
UDP ping keepalive

### DIFF
--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -423,6 +423,12 @@ ProtocolError DTLSMessageChannel::send(Message& message)
   if (ssl_context.state != MBEDTLS_SSL_HANDSHAKE_OVER)
     return INVALID_STATE;
 
+  if (!message.length())
+  {
+	  this->send(nullptr, 0);
+	  return NO_ERROR;
+  }
+
 #ifdef DEBUG_BUILD
       DEBUG("message length %d", message.length());
       for (size_t i=0; i<message.length(); i++)

--- a/communication/src/dtls_protocol.cpp
+++ b/communication/src/dtls_protocol.cpp
@@ -8,10 +8,10 @@ void DTLSProtocol::init(const char *id,
 		  const SparkCallbacks &callbacks,
 		  const SparkDescriptor &descriptor)
 {
-	set_protocol_flags(0);
+	set_protocol_flags(PING_AS_EMPTY_MESSAGE);
 	memcpy(device_id, id, sizeof(device_id));
 	// send pings once per hour
-	initialize_ping(24*60*1000,30000);
+	initialize_ping(23*60*1000,30000);
 	DTLSMessageChannel::Callbacks channelCallbacks;
 	memset(&channelCallbacks,0, sizeof(channelCallbacks));
 	channelCallbacks.millis = callbacks.millis;

--- a/communication/src/lightssl_message_channel.cpp
+++ b/communication/src/lightssl_message_channel.cpp
@@ -40,10 +40,12 @@ namespace protocol
 //                DEBUG("message length %d, last 20 bytes %s ", message.length(), message.buf()+message.length()-20);
 //            else
 //                DEBUG("message length %d ", message.length());
+		if (!message.length())
+			return NO_ERROR;
 
-            uint8_t* buf = message.buf()-2;
-            size_t to_write = wrap(buf, message.length());
-            return blocking_send(buf, to_write)<0 ? IO_ERROR : NO_ERROR;
+		uint8_t* buf = message.buf()-2;
+		size_t to_write = wrap(buf, message.length());
+		return blocking_send(buf, to_write)<0 ? IO_ERROR : NO_ERROR;
 	}
 
 	ProtocolError LightSSLMessageChannel::receive(Message& message)

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -133,6 +133,12 @@ protected:
 		 * Set if sending a hello response on resuming a session isn't required.
 		 */
 		SKIP_SESSION_RESUME_HELLO = 1<<1,
+
+		/**
+		 * send ping as an empty message - this functions as
+		 * a keep-alive for UDP
+		 */
+		PING_AS_EMPTY_MESSAGE = 1<<2,
 	};
 
 	void set_protocol_flags(int flags)
@@ -170,7 +176,10 @@ protected:
 	{
 		Message message;
 		channel.create(message);
-		size_t len = Messages::ping(message.buf(), 0);
+		size_t len = 0;
+		if (flags & PING_AS_EMPTY_MESSAGE) {
+			len = Messages::ping(message.buf(), 0);
+		}
 		last_message_millis = callbacks.millis();
 		message.set_length(len);
 		return channel.send(message);


### PR DESCRIPTION
Sends the ping as a zero-length UDP packet to keep the UDP NAT pathway open to the cloud. 