### PR TITLE
Fixes sleep (STOP mode) on Photon platform

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -108,7 +108,7 @@ void HAL_Notify_Button_State(uint8_t button, uint8_t state);
 
 void HAL_Core_Enter_Safe_Mode(void* reserved);
 void HAL_Core_Enter_Bootloader(bool persist);
-void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode);
+void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds);
 void HAL_Core_Execute_Stop_Mode(void);
 void HAL_Core_Enter_Standby_Mode(void);
 void HAL_Core_Execute_Standby_Mode(void);

--- a/hal/inc/hal_dynalib.h
+++ b/hal/inc/hal_dynalib.h
@@ -69,4 +69,5 @@ DYNALIB_FN(hal,HAL_EEPROM_Length)
 
 DYNALIB_FN(hal,HAL_disable_irq)
 DYNALIB_FN(hal,HAL_enable_irq)
+DYNALIB_FN(hal,HAL_RTC_Cancel_UnixAlarm)
 DYNALIB_END(hal)

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -66,6 +66,8 @@ DYNALIB_FN(hal_gpio, HAL_Get_System_Interrupt_Handler)
 DYNALIB_FN(hal_gpio, HAL_System_Interrupt_Trigger)
 
 DYNALIB_FN(hal_gpio, HAL_Pulse_In)
+DYNALIB_FN(hal_gpio, HAL_Interrupts_Suspend)
+DYNALIB_FN(hal_gpio, HAL_Interrupts_Restore)
 DYNALIB_END(hal_gpio)
 
 #endif	/* HAL_DYNALIB_GPIO_H */

--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -60,6 +60,9 @@ void HAL_Interrupts_Detach(uint16_t pin);
 void HAL_Interrupts_Enable_All(void);
 void HAL_Interrupts_Disable_All(void);
 
+void HAL_Interrupts_Suspend(void);
+void HAL_Interrupts_Restore(void);
+
 void HAL_Interrupts_Trigger(uint16_t pin, void* reserved);
 
 

--- a/hal/inc/rtc_hal.h
+++ b/hal/inc/rtc_hal.h
@@ -47,6 +47,7 @@ void HAL_RTC_Configuration(void);
 time_t HAL_RTC_Get_UnixTime(void);
 void HAL_RTC_Set_UnixTime(time_t value);
 void HAL_RTC_Set_UnixAlarm(time_t value);
+void HAL_RTC_Cancel_UnixAlarm(void);
 
 #ifdef __cplusplus
 }

--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -190,7 +190,7 @@ void HAL_Core_Enter_Bootloader(bool persist)
     HAL_Core_System_Reset();
 }
 
-void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode)
+void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds)
 {
 	if ((wakeUpPin < TOTAL_PINS) && (edgeTriggerMode <= FALLING))
 	{

--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -192,6 +192,9 @@ void HAL_Core_Enter_Bootloader(bool persist)
 
 void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds)
 {
+    if (seconds > 0)
+       HAL_RTC_Set_UnixAlarm((time_t) seconds);
+
 	if ((wakeUpPin < TOTAL_PINS) && (edgeTriggerMode <= FALLING))
 	{
 		uint16_t BKP_DR9_Data = wakeUpPin;//set wakeup pin mumber
@@ -216,6 +219,7 @@ void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long
 
 void HAL_Core_Execute_Stop_Mode(void)
 {
+    HAL_disable_irq();
 	if((BKP_ReadBackupRegister(BKP_DR9) >> 12) == 0xA)
 	{
 		uint16_t wakeUpPin = BKP_ReadBackupRegister(BKP_DR9) & 0xFF;
@@ -254,6 +258,9 @@ void HAL_Core_Execute_Stop_Mode(void)
 			/* Detach the Interrupt pin */
 	        HAL_Interrupts_Detach(wakeUpPin);
 
+            /* Disable RTC Alarm */
+            HAL_RTC_Cancel_UnixAlarm();
+
 			/* At this stage the system has resumed from STOP mode */
 			/* Enable HSE, PLL and select PLL as system clock source after wake-up from STOP */
 
@@ -280,6 +287,7 @@ void HAL_Core_Execute_Stop_Mode(void)
 			while(RCC_GetSYSCLKSource() != 0x08);
 		}
 	}
+    HAL_enable_irq(0);
 }
 
 void HAL_Core_Enter_Standby_Mode(void)

--- a/hal/src/core/interrupts_hal.c
+++ b/hal/src/core/interrupts_hal.c
@@ -197,6 +197,16 @@ void HAL_Interrupts_Disable_All(void)
   NVIC_DisableIRQ(EXTI9_5_IRQn);
 }
 
+void HAL_Interrupts_Suspend(void)
+{
+  // Untested/Unsupported
+}
+
+void HAL_Interrupts_Restore(void)
+{
+  // Untested/Unsupported
+}
+
 /*******************************************************************************
  * Function Name  : HAL_EXTI_Handler (Declared as weak in stm32_it.cpp)
  * Description    : This function is called by any of the interrupt handlers. It

--- a/hal/src/core/rtc_hal.c
+++ b/hal/src/core/rtc_hal.c
@@ -151,6 +151,8 @@ void HAL_RTC_Set_UnixTime(time_t value)
 
 void HAL_RTC_Set_UnixAlarm(time_t value)
 {
+  RTC_ITConfig(RTC_IT_ALR, ENABLE);
+  RTC_WaitForLastTask();
   /* Set the RTC Alarm */
   RTC_SetAlarm(RTC_GetCounter() + (uint32_t)value);
   /* Wait until last write operation on RTC registers has finished */
@@ -159,6 +161,10 @@ void HAL_RTC_Set_UnixAlarm(time_t value)
 
 void HAL_RTC_Cancel_UnixAlarm(void)
 {
+    RTC_ITConfig(RTC_IT_ALR, DISABLE);
+    RTC_WaitForLastTask();
+    EXTI_ClearITPendingBit(EXTI_Line17);
+    RTC_ClearITPendingBit(RTC_IT_ALR);
 }
 
 /*******************************************************************************

--- a/hal/src/core/rtc_hal.c
+++ b/hal/src/core/rtc_hal.c
@@ -157,6 +157,10 @@ void HAL_RTC_Set_UnixAlarm(time_t value)
   RTC_WaitForLastTask();
 }
 
+void HAL_RTC_Cancel_UnixAlarm(void)
+{
+}
+
 /*******************************************************************************
  * Function Name  : HAL_RTC_Handler (Declared as weak in stm32_it.h)
  * Description    : This function handles RTC global interrupt request.

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -146,7 +146,7 @@ void HAL_Core_Enter_Bootloader(void)
     MSG("Enter bootloader not implemented.");
 }
 
-void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode)
+void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds)
 {
     MSG("Stop mode not implemented.");
 }

--- a/hal/src/gcc/rtc_hal.cpp
+++ b/hal/src/gcc/rtc_hal.cpp
@@ -35,6 +35,6 @@ void HAL_RTC_Set_UnixAlarm(time_t value)
 {
 }
 
-
-
-
+void HAL_RTC_Cancel_UnixAlarm(void)
+{
+}

--- a/hal/src/stm32f2xx/interrupts_hal.c
+++ b/hal/src/stm32f2xx/interrupts_hal.c
@@ -66,6 +66,15 @@ typedef struct exti_channel {
 //Array to hold user ISR function pointers
 static exti_channel exti_channels[16];
 
+typedef struct exti_state {
+    uint32_t imr;
+    uint32_t emr;
+    uint32_t rtsr;
+    uint32_t ftsr;
+} exti_state;
+
+static exti_state exti_saved_state;
+
 /* Extern variables ----------------------------------------------------------*/
 
 /* Private function prototypes -----------------------------------------------*/
@@ -205,6 +214,22 @@ void HAL_Interrupts_Disable_All(void)
   NVIC_DisableIRQ(EXTI4_IRQn);
   NVIC_DisableIRQ(EXTI9_5_IRQn);
   NVIC_DisableIRQ(EXTI15_10_IRQn);
+}
+
+void HAL_Interrupts_Suspend(void) {
+  exti_saved_state.imr = EXTI->IMR;
+  exti_saved_state.emr = EXTI->EMR;
+  exti_saved_state.rtsr = EXTI->RTSR;
+  exti_saved_state.ftsr = EXTI->FTSR;
+
+  EXTI_DeInit();
+}
+
+void HAL_Interrupts_Restore(void) {
+  EXTI->IMR = exti_saved_state.imr;
+  EXTI->EMR = exti_saved_state.emr;
+  EXTI->RTSR = exti_saved_state.rtsr;
+  EXTI->FTSR = exti_saved_state.ftsr;
 }
 
 /*******************************************************************************

--- a/hal/src/stm32f2xx/rtc_hal.c
+++ b/hal/src/stm32f2xx/rtc_hal.c
@@ -210,8 +210,6 @@ void HAL_RTC_Set_UnixTime(time_t value)
         setRTCTime(&RTC_TimeStructure, &RTC_DateStructure);
 }
 
-
-
 void HAL_RTC_Set_UnixAlarm(time_t value)
 {
 	RTC_AlarmTypeDef RTC_AlarmStructure;
@@ -242,6 +240,14 @@ void HAL_RTC_Set_UnixAlarm(time_t value)
 
 	/* Clear RTC Alarm Flag */
 	RTC_ClearFlag(RTC_FLAG_ALRAF);
+}
+
+void HAL_RTC_Cancel_UnixAlarm(void) {
+    RTC_AlarmCmd(RTC_Alarm_A, DISABLE);
+    RTC_ClearFlag(RTC_FLAG_ALRAF);
+    RTC_WaitForSynchro();
+    RTC_ClearITPendingBit(RTC_IT_ALRA);
+    EXTI_ClearITPendingBit(EXTI_Line17);
 }
 
 void RTC_Alarm_irq(void)

--- a/hal/src/template/interrupts_hal.cpp
+++ b/hal/src/template/interrupts_hal.cpp
@@ -41,6 +41,14 @@ void HAL_Interrupts_Disable_All(void)
 {
 }
 
+void HAL_Interrupts_Suspend(void)
+{
+}
+
+void HAL_Interrupts_Restore(void)
+{
+}
+
 /*******************************************************************************
  * Function Name  : HAL_EXTI_Handler (Declared as weak in stm32_it.cpp)
  * Description    : This function is called by any of the interrupt handlers. It

--- a/hal/src/template/rtc_hal.c
+++ b/hal/src/template/rtc_hal.c
@@ -56,6 +56,10 @@ void HAL_RTC_Set_UnixAlarm(time_t value)
 
 }
 
+void HAL_RTC_Cancel_UnixAlarm(void)
+{
+}
+
 void HAL_RTC_Set_UnixTime(time_t value)
 {
 }

--- a/hal/src/template/rtc_hal.cpp
+++ b/hal/src/template/rtc_hal.cpp
@@ -40,6 +40,10 @@ void HAL_RTC_Set_UnixAlarm(time_t value)
 
 }
 
+void HAL_RTC_Cancel_UnixAlarm(void)
+{
+}
+
 void HAL_RTC_Set_UnixTime(time_t value)
 {
 }

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -98,9 +98,7 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
 
 void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
 {
-    if (seconds>0)
-        HAL_RTC_Set_UnixAlarm((time_t) seconds);
-
     LED_Off(LED_RGB);
-    HAL_Core_Enter_Stop_Mode(wakeUpPin, edgeTriggerMode);
+
+    HAL_Core_Enter_Stop_Mode(wakeUpPin, edgeTriggerMode, seconds);
 }

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -38,6 +38,26 @@ struct WakeupState
 
 WakeupState wakeupState;
 
+static void network_suspend() {
+    // save the current state so it can be restored on wakeup
+    wakeupState.wifi = !SPARK_WLAN_SLEEP;
+    wakeupState.wifiConnected = wakeupState.cloud | network_ready(0, 0, NULL) | network_connecting(0, 0, NULL);
+#ifndef SPARK_NO_CLOUD
+    wakeupState.cloud = spark_connected();
+    spark_disconnect();
+#endif
+    network_off(0, 0, 0, NULL);
+}
+
+static void network_resume() {
+    if (wakeupState.wifiConnected || wakeupState.wifi)  // at present, no way to get the background loop to only turn on wifi.
+        SPARK_WLAN_SLEEP = 0;
+#ifndef SPARK_NO_CLOUD
+    if (wakeupState.cloud)
+        spark_connect();
+#endif
+}
+
 /*******************************************************************************
  * Function Name  : HAL_RTCAlarm_Handler
  * Description    : This function handles additional application requirements.
@@ -48,12 +68,7 @@ WakeupState wakeupState;
 extern "C" void HAL_RTCAlarm_Handler(void)
 {
     /* Wake up from System.sleep mode(SLEEP_MODE_WLAN) */
-    if (wakeupState.wifiConnected || wakeupState.wifi)  // at present, no way to get the background loop to only turn on wifi.
-        SPARK_WLAN_SLEEP = 0;
-#ifndef SPARK_NO_CLOUD
-    if (wakeupState.cloud)
-        spark_connect();
-#endif
+    network_resume();
 }
 
 void sleep_fuel_gauge()
@@ -71,14 +86,7 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
     switch (sleepMode)
     {
         case SLEEP_MODE_WLAN:
-            // save the current state so it can be restored on wakeup
-            wakeupState.wifi = !SPARK_WLAN_SLEEP;
-            wakeupState.wifiConnected = wakeupState.cloud | network_ready(0, 0, NULL) | network_connecting(0, 0, NULL);
-#ifndef SPARK_NO_CLOUD
-            wakeupState.cloud = spark_connected();
-            spark_disconnect();
-#endif
-            network_off(0, 0, 0, NULL);
+            network_suspend();
             break;
 
         case SLEEP_MODE_DEEP:
@@ -98,7 +106,8 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
 
 void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
 {
+    network_suspend();
     LED_Off(LED_RGB);
-
     HAL_Core_Enter_Stop_Mode(wakeUpPin, edgeTriggerMode, seconds);
+    network_resume();
 }


### PR DESCRIPTION
HAL_Core_Enter_Stop_Mode should be wrapped with a critical section (cpsid/cpsie) to avoid
having an interrupt triggered while the device is entering sleep mode. Interrupts can be safely
disabled while in STOP mode.
All EXTI interrupts but the one associated with selected wakeup pin should be disabled as well
and restored after exiting STOP mode.

Fixes #655 