### PR TITLE
preserves the LED state

### DIFF
--- a/services/inc/rgbled.h
+++ b/services/inc/rgbled.h
@@ -43,6 +43,8 @@ void LED_On(Led_TypeDef Led);
 void LED_Off(Led_TypeDef Led);
 void LED_Toggle(Led_TypeDef Led);
 void LED_Fade(Led_TypeDef Led);
+uint32_t LED_GetColor(uint32_t index, void* reserved);
+
 
 uint8_t Get_LED_Brightness();
 // Hardware interface

--- a/services/inc/services_dynalib.h
+++ b/services/inc/services_dynalib.h
@@ -47,6 +47,7 @@ DYNALIB_FN(services, jsmn_parse)
 DYNALIB_FN(services, log_print_)
 DYNALIB_FN(services,LED_RGB_SetChangeHandler)
 DYNALIB_FN(services, log_print_direct_)
+DYNALIB_FN(services, LED_GetColor)
 DYNALIB_END(services)
 
 

--- a/services/src/rgbled.c
+++ b/services/src/rgbled.c
@@ -34,6 +34,13 @@ void LED_SetSignalingColor(uint32_t RGB_Color)
     lastSignalColor = RGB_Color;
 }
 
+uint32_t LED_GetColor(uint32_t index, void* reserved)
+{
+	if (index==0)
+		return lastRGBColor;
+	return lastSignalColor;
+}
+
 void LED_Signaling_Start(void)
 {
     LED_RGB_OVERRIDE = 1;

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -27,6 +27,7 @@
 #include "system_cloud_internal.h"
 #include "system_network.h"
 #include "system_threading.h"
+#include "system_rgbled.h"
 
 
 enum eWanTimings
@@ -143,8 +144,9 @@ protected:
         WLAN_SERIAL_CONFIG_DONE = 0;
 
         cloud_disconnect();
+        RGBLEDState led_state;
+        led_state.save();
         SPARK_LED_FADE = 0;
-        bool signaling = LED_RGB_IsOverRidden();
         LED_SetRGBColor(RGB_COLOR_BLUE);
         LED_Signaling_Stop();
         LED_On(LED_RGB);
@@ -200,8 +202,7 @@ protected:
         }
 
         LED_On(LED_RGB);
-        if (signaling)
-            LED_Signaling_Start();
+        led_state.restore();
 
         WLAN_LISTEN_ON_FAILED_CONNECT = started && on_stop_listening();
 

--- a/system/src/system_rgbled.h
+++ b/system/src/system_rgbled.h
@@ -1,0 +1,57 @@
+/**
+ ******************************************************************************
+  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#pragma once
+
+#include "system_task.h"
+#include "rgbled.h"
+
+// This is temporary until we can get scoped LED management in place.
+class RGBLEDState
+{
+	volatile uint8_t fade;
+	volatile uint8_t override;
+	volatile uint32_t color;
+
+public:
+
+	void save()
+	{
+		fade = SPARK_LED_FADE;
+		override = LED_RGB_IsOverRidden();
+		color = LED_GetColor(override ? 1 : 0, NULL);
+	}
+
+	void restore()
+	{
+		SPARK_LED_FADE = fade;
+		if (override)
+		{
+			LED_SetSignalingColor(color);
+			LED_Signaling_Start();
+		}
+		else
+		{
+			LED_SetRGBColor(color);
+			LED_Signaling_Stop();
+		}
+	}
+
+};
+

--- a/system/src/system_rgbled.h
+++ b/system/src/system_rgbled.h
@@ -45,6 +45,7 @@ public:
 		{
 			LED_SetSignalingColor(color);
 			LED_Signaling_Start();
+			LED_On(LED_RGB);
 		}
 		else
 		{


### PR DESCRIPTION
Fixes an issue where entering listening mode while breathing white (network turned off) then existing listening mode would cause the LED to flash blue.

This is because the SysTick does not handle the default case of no network. 

Preserving the LED state ensures it is restored correctly.