### PR TITLE
SPI_DMA_UserCallback should be called in SPI RX DMA IRQ Handler

### DIFF
--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -133,7 +133,7 @@ IDX[x] = added IRQ handler
 71 [x] TIM7_IRQHandler                   // TIM7
 72 [ ] DMA2_Stream0_IRQHandler           // DMA2 Stream 0
 73 [ ] DMA2_Stream1_IRQHandler           // DMA2 Stream 1
-74 [ ] DMA2_Stream2_IRQHandler           // DMA2 Stream 2
+74 [x] DMA2_Stream2_IRQHandler           // DMA2 Stream 2
 75 [ ] DMA2_Stream3_IRQHandler           // DMA2 Stream 3
 76 [ ] DMA2_Stream4_IRQHandler           // DMA2 Stream 4
 77 [ ] ETH_IRQHandler                    // Ethernet
@@ -200,6 +200,7 @@ const unsigned UART4_IRQHandler_Idx                 = 68;
 const unsigned UART5_IRQHandler_Idx                 = 69;
 const unsigned TIM6_DAC_IRQHandler_Idx              = 70;
 const unsigned TIM7_IRQHandler_Idx                  = 71;
+const unsigned DMA2_Stream2_IRQHandler_Idx          = 74;
 const unsigned CAN2_TX_IRQHandler_Idx               = 79;
 const unsigned CAN2_RX0_IRQHandler_Idx              = 80;
 const unsigned CAN2_RX1_IRQHandler_Idx              = 81;
@@ -272,6 +273,7 @@ void HAL_Core_Setup_override_interrupts(void)
     isrs[UART4_IRQHandler_Idx]              = (uint32_t)HAL_USART4_Handler;
     isrs[UART5_IRQHandler_Idx]              = (uint32_t)HAL_USART5_Handler;
     isrs[TIM6_DAC_IRQHandler_Idx]           = (uint32_t)TIM6_DAC_irq;
+    isrs[DMA2_Stream2_IRQHandler_Idx]       = (uint32_t)DMA2_Stream2_irq_override;
     isrs[TIM7_IRQHandler_Idx]               = (uint32_t)TIM7_override;  // WICED uses this for a JTAG watchdog handler
     isrs[CAN2_TX_IRQHandler_Idx]            = (uint32_t)CAN2_TX_irq;
     isrs[CAN2_RX0_IRQHandler_Idx]           = (uint32_t)CAN2_RX0_irq;
@@ -613,7 +615,7 @@ void SDIO_IRQHandler(void)          {__ASM("bkpt 0");}
 void SPI3_IRQHandler(void)          {__ASM("bkpt 0");}
 void DMA2_Stream0_IRQHandler(void)  {__ASM("bkpt 0");}
 void DMA2_Stream1_IRQHandler(void)  {__ASM("bkpt 0");}
-void DMA2_Stream2_IRQHandler(void)  {__ASM("bkpt 0");}
+//void DMA2_Stream2_IRQHandler(void)  {__ASM("bkpt 0");}
 void DMA2_Stream3_IRQHandler(void)  {__ASM("bkpt 0");}
 void DMA2_Stream4_IRQHandler(void)  {__ASM("bkpt 0");}
 void ETH_IRQHandler(void)           {__ASM("bkpt 0");}

--- a/hal/src/photon/core_hal.c
+++ b/hal/src/photon/core_hal.c
@@ -49,7 +49,7 @@ const unsigned USART1Index = 53;
 const unsigned USART2Index = 54;
 const unsigned ButtonExtiIndex = BUTTON1_EXTI_IRQ_INDEX;
 const unsigned TIM7Index = 71;
-
+const unsigned DMA2Stream2Index = 74;
 /**
  * Updated by HAL_1Ms_Tick()
  */
@@ -72,6 +72,7 @@ void HAL_Core_Setup_override_interrupts(void) {
     isrs[USART2Index] = (uint32_t)HAL_USART2_Handler;
     isrs[ButtonExtiIndex] = (uint32_t)Mode_Button_EXTI_irq;
     isrs[TIM7Index] = (uint32_t)TIM7_override;  // WICED uses this for a JTAG watchdog handler
+    isrs[DMA2Stream2Index] = (uint32_t)DMA2_Stream2_irq_override;
     SCB->VTOR = (unsigned long)isrs;
 }
 

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.h
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.h
@@ -71,6 +71,8 @@ void I2C3_EV_irq(void);
 void I2C3_ER_irq(void);
 void DMA1_Stream7_irq(void);
 void DMA2_Stream5_irq(void);
+void DMA1_Stream2_irq(void);
+void DMA2_Stream2_irq_override(void);
 
 void EXTI0_IRQHandler(void);
 void EXTI1_IRQHandler(void);


### PR DESCRIPTION
Fixes #791

SPI hardware might still be busy pushing out bytes when SPI TX DMA transfer complete IRQ handler is fired. To ensure that SPI user callback is called when the actual transfer has been completed, it should be called from SPI RX DMA transfer complete IRQ handler.

1 (Yellow) - MISO/MOSI (loopback mode)
2 (Blue) - SPI User callback indicator pin (pulled low in callback)
3 (Purple) - SCK

This is the behavior observed in develop branch at 100KHz.
Left cursor indicates a point the user callback was called, right cursor indicates a start of a non-DMA single byte transfer sequence (0x00, 0xff, 0x00). Despite the fact that all the bytes were pushed out, this is still incorrect behavior, since neither actual TX transfer has been completed, nor RX DMA has been completed when user callback was called.
![ds1z_quickprint3](https://cloud.githubusercontent.com/assets/388478/12213406/c0d00c50-b6a1-11e5-9f4a-e673f02aeaeb.png)

The behavior observed with this PR again at 100KHz.
The cursor indicates a point the user callback was called, immediately followed by non-DMA single byte transfer sequence (0x00, 0xff, 0x00).
![ds1z_quickprint4](https://cloud.githubusercontent.com/assets/388478/12213439/3b8ca656-b6a2-11e5-9f12-c0b72dded67f.png)


A test application used:

```C++
#include "application.h"

Serial1DebugOutput dbg(57600);

static volatile bool SPI_DMA_TransferCompleted = false;

void SPI_User_Callback(void)
{
    digitalWrite(D0, LOW);
    SPI_DMA_TransferCompleted = true;
}

static uint8_t tx[512];
static uint8_t rx[512];

void test() {
    memset(rx, 0, sizeof(rx));
    SPI_DMA_TransferCompleted = false;
    digitalWrite(D0, HIGH);
    SPI.transfer(tx, NULL, sizeof(tx), SPI_User_Callback);
    while(!SPI_DMA_TransferCompleted);
    SPI.transfer(0x00);
    SPI.transfer(0xff);
    SPI.transfer(0x00);    
    DEBUG("Complete");
}

void setup()
{
    for (int i = 0; i < sizeof(tx); i++)
        tx[i] = (uint8_t)i;
    Serial.begin(9600);
    pinMode(D0, OUTPUT);
    pinMode(SCK, AF_OUTPUT_PUSHPULL);
    pinMode(MOSI, AF_OUTPUT_PUSHPULL);
    pinMode(MISO, INPUT);
    SPI.setDataMode(SPI_MODE0);
    SPI.setBitOrder(MSBFIRST);
    SPI.setClockSpeed(100000);
    SPI.begin();
}

void loop()
{
    test();
    delay(2000);
}
```