### PR TITLE
short circuit debugging

### DIFF
--- a/services/inc/service_debug.h
+++ b/services/inc/service_debug.h
@@ -85,7 +85,7 @@ void log_print_(int level, int line, const char *func, const char *file, const c
 void log_direct_(const char* s);
 
 /* log print with (formatting arguments) without any extra info or \r\n */
-void log_print_direct_(const char *msg, ...);
+void log_print_direct_(int level, void* reserved, const char *msg, ...);
 
 /**
  * The debug output function.
@@ -120,7 +120,7 @@ extern void HAL_Delay_Microseconds(uint32_t delay);
 #define WARN(fmt, ...)   do { if ( __LOG_LEVEL_TEST(WARN_LEVEL) )  {log_print_(WARN_LEVEL,__LINE__,__PRETTY_FUNCTION__,_FILE_PATH,fmt,##__VA_ARGS__);}}while(0)
 #define ERROR(fmt, ...)  do { if ( __LOG_LEVEL_TEST(ERROR_LEVEL) ) {log_print_(ERROR_LEVEL,__LINE__,__PRETTY_FUNCTION__,_FILE_PATH,fmt,##__VA_ARGS__);}}while(0)
 #define PANIC(code,fmt, ...)  do { if ( __LOG_LEVEL_TEST(PANIC_LEVEL) ) {log_print_(PANIC_LEVEL,__LINE__,__PRETTY_FUNCTION__,_FILE_PATH,fmt,##__VA_ARGS__);} panic_(code, NULL, HAL_Delay_Microseconds);}while(0)
-#define DEBUG_D(fmt, ...)  do { if ( __LOG_LEVEL_TEST(DEBUG_LEVEL))  {log_print_direct_(fmt,##__VA_ARGS__);}}while(0)
+#define DEBUG_D(fmt, ...)  do { if ( __LOG_LEVEL_TEST(DEBUG_LEVEL))  {log_print_direct_(LOG_LEVEL, nullptr, fmt,##__VA_ARGS__);}}while(0)
 #endif
 #define SPARK_ASSERT(predicate) do { if (!(predicate)) PANIC(AssertionFailure,"AssertionFailure "#predicate);} while(0);
 

--- a/services/src/debug.c
+++ b/services/src/debug.c
@@ -28,7 +28,7 @@ void set_logger_output(debug_output_fn output, LoggerOutputLevel level)
 
 void log_print_(int level, int line, const char *func, const char *file, const char *msg, ...)
 {
-    if (level<log_level_at_run_time)
+    if (level<log_level_at_run_time || !debug_output_)
         return;
 
     char _buffer[MAX_DEBUG_MESSAGE_LENGTH];
@@ -45,44 +45,41 @@ void log_print_(int level, int line, const char *func, const char *file, const c
     va_start(args, msg);
     file = file ? strrchr(file,'/') + 1 : "";
     int trunc = snprintf(_buffer, arraySize(_buffer), "%010u:%s: %s %s(%d):", (unsigned)HAL_Timer_Get_Milli_Seconds(), levels[level/10], func, file, line);
-    if (debug_output_)
-    {
-        debug_output_(_buffer);
-        if (trunc > arraySize(_buffer))
-        {
-            debug_output_("...");
-        }
-    }
+	debug_output_(_buffer);
+	if (trunc > arraySize(_buffer))
+	{
+		debug_output_("...");
+	}
     trunc = vsnprintf(_buffer,arraySize(_buffer), msg, args);
-    if (debug_output_)
-    {
-        debug_output_(_buffer);
-        if (trunc > arraySize(_buffer))
-        {
-            debug_output_("...");
-        }
-        debug_output_("\r\n");
-    }
+	debug_output_(_buffer);
+	if (trunc > arraySize(_buffer))
+	{
+		debug_output_("...");
+	}
+	debug_output_("\r\n");
 }
 
-void log_print_direct_(const char *msg, ...)
+void log_print_direct_(int level, void* reserved, const char *msg, ...)
 {
+    if (level<log_level_at_run_time || !debug_output_)
+        return;
+
     char _buffer[MAX_DEBUG_MESSAGE_LENGTH];
     va_list args;
     va_start(args, msg);
     int trunc = vsnprintf(_buffer, arraySize(_buffer), msg, args);
-    if (debug_output_)
-    {
-        debug_output_(_buffer);
-        if (trunc > arraySize(_buffer))
-        {
-            debug_output_("...");
-        }
-    }
+	debug_output_(_buffer);
+	if (trunc > arraySize(_buffer))
+	{
+		debug_output_("...");
+	}
 }
 
 void log_direct_(const char* s) {
-    if (debug_output_)
-        debug_output_(s);
+
+    if (LOG_LEVEL<log_level_at_run_time || !debug_output_)
+        return;
+
+	debug_output_(s);
 }
 


### PR DESCRIPTION
short-circuits debug functions if no debug output defined (making the debug function mostly a no-op) - parameters to the function are still evaluated by the caller, but vsnprintf() is not invoked.

Adds a log level and void* extension point to `log_direct_`