### PR TITLE
wiring_interrupt_handler_t* handlers[] should hold TOTAL_PINS entries

### DIFF
--- a/wiring/src/spark_wiring_interrupts.cpp
+++ b/wiring/src/spark_wiring_interrupts.cpp
@@ -27,7 +27,7 @@
  */
 #include "spark_wiring_interrupts.h"
 
-static wiring_interrupt_handler_t* handlers[16];
+static wiring_interrupt_handler_t* handlers[TOTAL_PINS];
 
 wiring_interrupt_handler_t* allocate_handler(uint16_t pin, wiring_interrupt_handler_t& fn)
 {


### PR DESCRIPTION
Fixes #819 