### PR TITLE
ensure global Serial object is initialized before use

### DIFF
--- a/wiring/inc/spark_wiring_eeprom.h
+++ b/wiring/inc/spark_wiring_eeprom.h
@@ -122,6 +122,12 @@ struct EEPtr{
 
 struct EEPROMClass{
 
+	EEPROMClass()
+    {
+    		HAL_EEPROM_Init();
+    }
+
+
     //Basic user access methods.
     EERef operator[]( const int idx )    { return idx; }
     uint8_t read( int idx )              { return EERef( idx ); }
@@ -149,12 +155,8 @@ struct EEPROMClass{
     }
 };
 
-extern EEPROMClass EEPROM;
+#define EEPROM __fetch_global_EEPROM()
+EEPROMClass& __fetch_global_EEPROM();
 
-class EEPROMInitClass
-{
-  public:
-    EEPROMInitClass();
-};
 
 #endif /* __SPARK_WIRING_EEPROM_H */

--- a/wiring/inc/spark_wiring_i2c.h
+++ b/wiring/inc/spark_wiring_i2c.h
@@ -85,14 +85,16 @@ public:
  */
 #ifndef SPARK_WIRING_NO_I2C
 
-extern TwoWire Wire;
+#define Wire __fetch_global_Wire()
+TwoWire& __fetch_global_Wire();
 
 #if Wiring_Wire1
 #ifdef Wire1
 #undef Wire1
 #endif  // Wire1
 
-extern TwoWire Wire1;
+#define Wire1 __fetch_global_Wire1()
+TwoWire& __fetch_global_Wire1();
 #endif  // Wiring_Wire1
 
 /* System PMIC and Fuel Guage I2C3 */
@@ -101,7 +103,9 @@ extern TwoWire Wire1;
 #undef Wire3
 #endif  // Wire3
 
-extern TwoWire Wire3;
+#define Wire3 __fetch_global_Wire3()
+TwoWire& __fetch_global_Wire3();
+
 #endif  // Wiring_Wire3
 
 #endif

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -112,14 +112,17 @@ public:
 
 #ifndef SPARK_WIRING_NO_SPI
 
-extern SPIClass SPI;
+#define SPI __fetch_global_SPI()
+SPIClass __fetch_global_SPI();
 
 #if Wiring_SPI1
 #ifdef SPI1
 #undef SPI1
 #endif  // SPI1
 
-extern SPIClass SPI1;
+#define SPI1 __fetch_global_SPI1()
+SPIClass __fetch_global_SPI1();
+
 #endif  // Wiring_SPI1
 
 #if Wiring_SPI2
@@ -127,7 +130,9 @@ extern SPIClass SPI1;
 #undef SPI2
 #endif  // SPI2
 
-extern SPIClass SPI2;
+#define SPI2 __fetch_global_SPI2()
+SPIClass __fetch_global_SPI2();
+
 #endif  // Wiring_SPI2
 
 #endif  // SPARK_WIRING_NO_SPI

--- a/wiring/inc/spark_wiring_usbserial.h
+++ b/wiring/inc/spark_wiring_usbserial.h
@@ -52,6 +52,8 @@ public:
 	using Print::write;
 };
 
-extern USBSerial Serial;
+USBSerial& _fetch_global_serial();
+
+#define Serial _fetch_global_serial()
 
 #endif

--- a/wiring/src/spark_wiring_eeprom.cpp
+++ b/wiring/src/spark_wiring_eeprom.cpp
@@ -29,10 +29,4 @@
 /* Includes ------------------------------------------------------------------*/
 #include "spark_wiring_eeprom.h"
 
-EEPROMInitClass::EEPROMInitClass()
-{
-    HAL_EEPROM_Init();
-    //Calling the below here just to get rid of compiler error: 'EEPROM' defined but not used
-    EEPROM.length();
-}
 

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -76,5 +76,11 @@ int USBSerial::peek()
 
 // Preinstantiate Objects //////////////////////////////////////////////////////
 #ifdef SPARK_USB_SERIAL
-USBSerial Serial;
+USBSerial& _fetch_global_serial()
+{
+	static USBSerial _globalSerial;
+	return _globalSerial;
+}
+
+
 #endif

--- a/wiring_globals/src/wiring_globals_eeprom.cpp
+++ b/wiring_globals/src/wiring_globals_eeprom.cpp
@@ -3,6 +3,8 @@
 // we don't use this global instance since there's no actual instance data
 // Having this keeps the unoptimized build happy
 
-
-EEPROMClass EEPROM;
-EEPROMInitClass EEPROMInit;
+EEPROMClass& __fetch_global_EEPROM()
+{
+	static EEPROMClass eeprom;
+	return eeprom;
+}

--- a/wiring_globals/src/wiring_globals_i2c.cpp
+++ b/wiring_globals/src/wiring_globals_i2c.cpp
@@ -8,15 +8,29 @@
 
 #ifndef SPARK_WIRING_NO_I2C
 
-TwoWire Wire(HAL_I2C_INTERFACE1);
+TwoWire& __fetch_global_Wire()
+{
+	static TwoWire wire(HAL_I2C_INTERFACE1);
+	return wire;
+}
 
 #if Wiring_Wire1
-TwoWire Wire1(HAL_I2C_INTERFACE2);
+TwoWire& __fetch_global_Wire1()
+{
+	static TwoWire wire(HAL_I2C_INTERFACE2);
+	return wire;
+}
+
 #endif
 
 /* System PMIC and Fuel Guage I2C3 */
 #if Wiring_Wire3
-TwoWire Wire3(HAL_I2C_INTERFACE3);
+TwoWire& __fetch_global_Wire3()
+{
+	static TwoWire wire(HAL_I2C_INTERFACE3);
+	return wire;
+}
+
 #endif
 
 #endif //SPARK_WIRING_NO_I2C

--- a/wiring_globals/src/wiring_globals_spi.cpp
+++ b/wiring_globals/src/wiring_globals_spi.cpp
@@ -6,14 +6,27 @@
 
 #ifndef SPARK_WIRING_NO_SPI
 
-SPIClass SPI(HAL_SPI_INTERFACE1);
+
+SPIClass __fetch_global_SPI()
+{
+	static SPIClass spi(HAL_SPI_INTERFACE1);
+	return spi;
+}
 
 #if Wiring_SPI1
-SPIClass SPI1(HAL_SPI_INTERFACE2);
+SPIClass __fetch_global_SPI1()
+{
+	static SPIClass spi1(HAL_SPI_INTERFACE2);
+	return spi1;
+}
 #endif
 
 #if Wiring_SPI2
-SPIClass SPI2(HAL_SPI_INTERFACE3);
+SPIClass __fetch_global_SPI2()
+{
+	static SPIClass spi2(HAL_SPI_INTERFACE3);
+	return spi2;
+}
 #endif
 
 #endif //SPARK_WIRING_NO_SPI


### PR DESCRIPTION
Test case:

```
SerialDebugOutput output(9600, ALL_LEVEL);
PRODUCT_ID(123);
```

Compile with DEBUG_BUILD=y.   The device doesn't get further than initializing the application. LED breathes white continually. 

Putting the PR out here for review, with a plan to apply this pattern to all global objects in Wiring so that application code can be certain they are properly initialized.