### PR TITLE
Feature/mutexes

### DIFF
--- a/hal/inc/hal_dynalib_concurrent.h
+++ b/hal/inc/hal_dynalib_concurrent.h
@@ -40,6 +40,19 @@ DYNALIB_FN(hal_concurrent,os_timer_create)
 DYNALIB_FN(hal_concurrent,os_timer_destroy)
 DYNALIB_FN(hal_concurrent,os_timer_get_id)
 DYNALIB_FN(hal_concurrent,os_timer_change)
+
+DYNALIB_FN(hal_concurrent,os_mutex_create)
+DYNALIB_FN(hal_concurrent,os_mutex_destroy)
+DYNALIB_FN(hal_concurrent,os_mutex_lock)
+DYNALIB_FN(hal_concurrent,os_mutex_trylock)
+DYNALIB_FN(hal_concurrent,os_mutex_unlock)
+
+DYNALIB_FN(hal_concurrent,os_mutex_recursive_create)
+DYNALIB_FN(hal_concurrent,os_mutex_recursive_destroy)
+DYNALIB_FN(hal_concurrent,os_mutex_recursive_lock)
+DYNALIB_FN(hal_concurrent,os_mutex_recursive_trylock)
+DYNALIB_FN(hal_concurrent,os_mutex_recursive_unlock)
+
 #endif
 DYNALIB_END(hal_concurrent)
 

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -32,6 +32,8 @@
 #include "spark_wiring.h"   // for serialReadLine
 #include "system_network_internal.h"
 #include "system_network.h"
+#include "system_task.h"
+#include "spark_wiring_thread.h"
 
 #if SETUP_OVER_SERIAL1
 #define SETUP_LISTEN_MAGIC 1
@@ -61,13 +63,15 @@ public:
 template <typename Config> SystemSetupConsole<Config>::SystemSetupConsole(Config& config_)
     : config(config_)
 {
+	WITH_LOCK(serial);
     if (serial.baud()==0)
         serial.begin(9600);
 }
 
 template<typename Config> void SystemSetupConsole<Config>::loop(void)
 {
-    if (serial.available()) {
+	WITH_LOCK(serial);
+	if (serial.available()) {
         int c = serial.read();
         if (c>=0)
             handle((char)c);

--- a/system/src/system_threading.cpp
+++ b/system/src/system_threading.cpp
@@ -117,7 +117,18 @@ namespace std {
     }
 }
 
+static os_mutex_recursive_t usb_serial_mutex;
+
+os_mutex_recursive_t mutex_usb_serial()
+{
+	if (nullptr==usb_serial_mutex) {
+		os_mutex_recursive_create(&usb_serial_mutex);
+	}
+	return usb_serial_mutex;
+}
+
 #endif
+
 
 
 void* system_internal(int item, void* reserved)
@@ -126,6 +137,7 @@ void* system_internal(int item, void* reserved)
 #if PLATFORM_THREADING
     case 0: return &ApplicationThread;
     case 1: return &SystemThread;
+    case 2: return mutex_usb_serial();
 #endif
     }
     return nullptr;

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -189,6 +189,7 @@ public:
 #define SINGLE_THREADED_SECTION()
 #define WITH_LOCK(x)
 #define TRY_LOCK(x)
+#define IS_LOCKED(lock)  (true)
 
 #endif
 

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -28,7 +28,9 @@
 
 #include "concurrent_hal.h"
 #include <stddef.h>
+#include <mutex>
 #include <functional>
+#include <type_traits>
 
 typedef std::function<os_thread_return_t(void)> wiring_thread_fn_t;
 
@@ -178,10 +180,15 @@ public:
 };
 
 #define SINGLE_THREADED_SECTION() SingleThreadedSection __cs;
+#define WITH_LOCK(lock) std::lock_guard<decltype(lock)> __lock##lock((lock));
+#define TRY_LOCK(lock) std::unique_lock<std::remove_reference<decltype(lock)>::type> __lock##lock((lock), std::try_to_lock);
+#define IS_LOCKED(lock) (__lock##lock)
 
 #else
 
 #define SINGLE_THREADED_SECTION()
+#define WITH_LOCK(x)
+#define TRY_LOCK(x)
 
 #endif
 

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -104,6 +104,68 @@ private:
     }
 };
 
+class Mutex
+{
+	os_mutex_t handle_;
+public:
+	/**
+	 * Creates a shared mutex from an existing handle.
+	 * This is mainly used to share mutexes between dynamically linked modules.
+	 */
+	Mutex(os_mutex_t handle) : handle_(handle) {}
+
+	/**
+	 * Creates a new mutex.
+	 */
+	Mutex() : handle_(nullptr)
+	{
+		os_mutex_create(&handle_);
+	}
+
+	void dispose()
+	{
+		if (handle_) {
+			os_mutex_destroy(handle_);
+			handle_ = nullptr;
+		}
+	}
+
+	void lock() { os_mutex_lock(handle_); }
+	bool trylock() { return os_mutex_trylock(handle_)==0; }
+	void unlock() { os_mutex_unlock(handle_); }
+
+};
+
+
+class RecursiveMutex
+{
+	os_mutex_recursive_t handle_;
+public:
+	/**
+	 * Creates a shared mutex.
+	 */
+	RecursiveMutex(os_mutex_recursive_t handle) : handle_(handle) {}
+
+	RecursiveMutex() : handle_(nullptr)
+	{
+		os_mutex_recursive_create(&handle_);
+	}
+
+	void dispose()
+	{
+		if (handle_) {
+			os_mutex_recursive_destroy(handle_);
+			handle_ = nullptr;
+		}
+	}
+
+	void lock() { os_mutex_recursive_lock(handle_); }
+	bool trylock() { return os_mutex_recursive_trylock(handle_)==0; }
+	void unlock() { os_mutex_recursive_unlock(handle_); }
+
+};
+
+
 class SingleThreadedSection {
 public:
 	SingleThreadedSection() {

--- a/wiring/inc/spark_wiring_usbserial.h
+++ b/wiring/inc/spark_wiring_usbserial.h
@@ -29,6 +29,7 @@
 
 #include "spark_wiring_stream.h"
 #include "usb_hal.h"
+#include "system_task.h"
 
 class USBSerial : public Stream
 {
@@ -48,6 +49,36 @@ public:
 	virtual int read();
 	virtual int available();
 	virtual void flush();
+
+#if PLATFORM_THREADING
+	os_mutex_recursive_t get_mutex()
+	{
+		return os_mutex_recursive_t(system_internal(2, nullptr));
+	}
+#endif
+
+	bool try_lock()
+	{
+#if PLATFORM_THREADING
+		return !os_mutex_recursive_trylock(get_mutex());
+#else
+		return true;
+#endif
+	}
+
+	void lock()
+	{
+#if PLATFORM_THREADING
+		os_mutex_recursive_lock(get_mutex());
+#endif
+	}
+
+	void unlock()
+	{
+#if PLATFORM_THREADING
+		os_mutex_recursive_unlock(get_mutex());
+#endif
+	}
 
 	using Print::write;
 };


### PR DESCRIPTION
Addresses issue #669.  Multiple threads accessing serial produce jumbled output that is an interleaving of the output of both threads. 

This PR adds a system mutex for USB serial so that access to this resource can be serialized when used concurrently. 

To lock USB serial for a given code block, such as a function:

```
void print_status()
{
    WITH_LOCK(Serial);
    Serial.println("current status is:");
    Serial.println("happy");
}
```
Even when other threads attempt to access serial, their output will be blocked while this function is printing, so the status information will always appear intact.  Node that this method will block if another thread has acquired the lock.

To try to lock the resource, and conditionally execute code on successful locking:

```
void print_status()
{
    TRY_LOCK(Serial);
    if (IS_LOCKED(Serial)) {
       Serial.println("current status is:");
       Serial.println("happy");
   |
}
```

The try lock attempts to lock the resource, but doesn't block if the resource is already locked. 

cc: @jenesaisdiq 