### PR TITLE
Servo HAL: Do not disable timer if some of its channels are still in use

### DIFF
--- a/hal/src/core/servo_hal.c
+++ b/hal/src/core/servo_hal.c
@@ -112,8 +112,32 @@ void HAL_Servo_Attach(uint16_t pin)
 
 void HAL_Servo_Detach(uint16_t pin)
 {
-  // TIM disable counter
-  TIM_Cmd(PIN_MAP[pin].timer_peripheral, DISABLE);
+  const STM32_Pin_Info* pin_info = HAL_Pin_Map() + pin;
+
+  // Disable timer's channel
+  switch (pin_info->timer_ch)
+  {
+    case TIM_Channel_1:
+      pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC1E;
+      break;
+    case TIM_Channel_2:
+      pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC2E;
+      break;
+    case TIM_Channel_3:
+      pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC3E;
+      break;
+    case TIM_Channel_4:
+      pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC4E;
+      break;
+    default:
+      break;
+  }
+
+  // Disable timer if none of its channels are enabled
+  if (!(pin_info->timer_peripheral->CCER & (TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E)))
+  {
+    TIM_Cmd(pin_info->timer_peripheral, DISABLE);
+  }
 }
 
 void HAL_Servo_Write_Pulse_Width(uint16_t pin, uint16_t pulseWidth)

--- a/hal/src/stm32f2xx/servo_hal.c
+++ b/hal/src/stm32f2xx/servo_hal.c
@@ -142,9 +142,32 @@ void HAL_Servo_Attach(uint16_t pin)
 
 void HAL_Servo_Detach(uint16_t pin)
 {
-    // TIM disable counter
-    STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
-    TIM_Cmd(PIN_MAP[pin].timer_peripheral, DISABLE);
+    const STM32_Pin_Info* pin_info = HAL_Pin_Map() + pin;
+
+    // Disable timer's channel
+    switch (pin_info->timer_ch)
+    {
+        case TIM_Channel_1:
+            pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC1E;
+            break;
+        case TIM_Channel_2:
+            pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC2E;
+            break;
+        case TIM_Channel_3:
+            pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC3E;
+            break;
+        case TIM_Channel_4:
+            pin_info->timer_peripheral->CCER &= ~TIM_CCER_CC4E;
+            break;
+        default:
+            break;
+    }
+
+    // Disable timer if none of its channels are enabled
+    if (!(pin_info->timer_peripheral->CCER & (TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E)))
+    {
+        TIM_Cmd(pin_info->timer_peripheral, DISABLE);
+    }
 }
 
 void HAL_Servo_Write_Pulse_Width(uint16_t pin, uint16_t pulseWidth)

--- a/user/tests/wiring/no_fixture/servo.cpp
+++ b/user/tests/wiring/no_fixture/servo.cpp
@@ -28,9 +28,9 @@
 #include "unit-test/unit-test.h"
 
 #if defined(STM32F2XX)
-static pin_t pin = D0;//pin under test
+static pin_t pin = D0, pin2 = D1; // Pins sharing the same hardware timer
 #else
-static pin_t pin = A0;//pin under test
+static pin_t pin = A0, pin2 = A1;
 #endif
 
 test(SERVO_CannotAttachWhenPinSelectedIsNotTimerChannel) {
@@ -75,4 +75,30 @@ test(SERVO_WritePulseWidthOnPinResultsInCorrectMicroSeconds) {
     // then
     assertEqual(readPulseWidth, pulseWidth);
     //To Do : Add test for remaining pins if required
+}
+
+test(SERVO_DetachDoesntAffectAnotherServoUsingSameTimer) {
+    const int pulseWidth = 2000;
+    // Attach 1st servo
+    Servo servo1;
+    servo1.attach(pin);
+    servo1.writeMicroseconds(pulseWidth);
+    // Attach 2nd servo
+    Servo servo2;
+    servo2.attach(pin2);
+    servo2.writeMicroseconds(pulseWidth);
+    // Detach 1st servo
+    servo1.detach();
+    // Ensure 2nd servo is not affected
+    int readPulseWidth = 0;
+    const uint32_t start = millis();
+    for (int i = 0; i < 100; ++i) {
+        readPulseWidth += pulseIn(pin2, HIGH);
+        if (millis() - start > 3000) {
+            break; // pulseIn() takes too long time
+        }
+    }
+    readPulseWidth /= 100; // Average pulse width
+    servo2.detach();
+    assertTrue(readPulseWidth > pulseWidth - 50 && readPulseWidth < pulseWidth + 50);
 }


### PR DESCRIPTION
This PR fixes #745 by tracking what timer channels are used to control attached servos.

Note that hardware timers are shared between different HAL submodules, namely, servo, tone and PWM HALs, and any of these still can override timer settings configured by another submodule. Ideally, we need to report an error when user application attempts to reuse already active timer with different settings.