### PR TITLE
Electron resumes session after sleep

### DIFF
--- a/system/inc/system_sleep.h
+++ b/system/inc/system_sleep.h
@@ -18,7 +18,7 @@
  */
 
 #ifndef SYSTEM_SLEEP_H
-#define	SYSTEM_SLEEP_H
+#define SYSTEM_SLEEP_H
 
 #include <stdint.h>
 
@@ -33,12 +33,12 @@ typedef enum
 
 enum class SystemSleepNetwork
 {
-	Off,
-	Standby,
+    Off,
+    Standby,
 };
 
 /**
- * @param param	A SystemSleepNetwork enum cast as an integer.
+ * @param param A SystemSleepNetwork enum cast as an integer.
  */
 void system_sleep(Spark_Sleep_TypeDef mode, long seconds, uint32_t param, void* reserved);
 void system_sleep_pin(uint16_t pin, uint16_t mode, long seconds, uint32_t param, void* reserved);
@@ -48,5 +48,5 @@ void system_sleep_pin(uint16_t pin, uint16_t mode, long seconds, uint32_t param,
 #endif
 
 
-#endif	/* SYSTEM_SLEEP_H */
+#endif /* SYSTEM_SLEEP_H */
 

--- a/system/inc/system_sleep.h
+++ b/system/inc/system_sleep.h
@@ -31,6 +31,15 @@ typedef enum
     SLEEP_MODE_WLAN = 0, SLEEP_MODE_DEEP = 1, SLEEP_MODE_SOFTPOWEROFF = 2
 } Spark_Sleep_TypeDef;
 
+enum class SystemSleepNetwork
+{
+	Off,
+	Standby,
+};
+
+/**
+ * @param param	A SystemSleepNetwork enum cast as an integer.
+ */
 void system_sleep(Spark_Sleep_TypeDef mode, long seconds, uint32_t param, void* reserved);
 void system_sleep_pin(uint16_t pin, uint16_t mode, long seconds, uint32_t param, void* reserved);
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -81,9 +81,9 @@ void sleep_fuel_gauge()
 
 bool network_sleep_flag(uint32_t flags)
 {
-	static_assert(static_cast<int>(SystemSleepNetwork::Off)==0, "expected SystemSleepNetwork::Off==0");
-	static_assert(static_cast<int>(SystemSleepNetwork::Standby)==1, "expected SystemSleepNetwork::Standby==1");
-	return (flags & 1)==0;
+    static_assert(static_cast<int>(SystemSleepNetwork::Off)==0, "expected SystemSleepNetwork::Off==0");
+    static_assert(static_cast<int>(SystemSleepNetwork::Standby)==1, "expected SystemSleepNetwork::Standby==1");
+    return (flags & 1)==0;
 }
 
 void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, void* reserved)
@@ -98,11 +98,11 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
             break;
 
         case SLEEP_MODE_DEEP:
-        		if (network_sleep_flag(param))
-        		{
-				network_disconnect(0,0,NULL);
-				network_off(0, 0, 0, NULL);
-        		}
+            if (network_sleep_flag(param))
+            {
+                network_disconnect(0, 0, NULL);
+                network_off(0, 0, 0, NULL);
+            }
             HAL_Core_Enter_Standby_Mode();
             break;
 
@@ -119,11 +119,15 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
 
 void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
 {
-	bool network_sleep = (param & 1)==0;
-	if (network_sleep)
-		network_suspend();
+    bool network_sleep = network_sleep_flag(param);
+    if (network_sleep)
+    {
+        network_suspend();
+    }
     LED_Off(LED_RGB);
     HAL_Core_Enter_Stop_Mode(wakeUpPin, edgeTriggerMode, seconds);
     if (network_sleep)
-    		network_resume();
+    {
+        network_resume();
+    }
 }

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -49,7 +49,9 @@ static void network_suspend() {
     spark_cloud_socket_disconnect();
     spark_cloud_flag_disconnect();
 #endif
+#if Wiring_WiFi
     network_off(0, 0, 0, NULL);
+#endif
 }
 
 static void network_resume() {

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -36,7 +36,13 @@ test(system_api) {
 
     API_COMPILE(System.sleep(60));
 
-    API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60));
+}
+
+test(system_sleep)
+{
+    API_COMPILE(System.sleep(60));
+
+	API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60));
 
     API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60));
 
@@ -47,14 +53,30 @@ test(system_api) {
     API_COMPILE(System.sleep(A0, FALLING));
     API_COMPILE(System.sleep(A0, FALLING, 20));
 
+    // with network flags
+	API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60, SLEEP_NETWORK_STANDBY));
+
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_NETWORK_STANDBY));
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY, 60));
+
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY));
+
+    API_COMPILE(System.sleep(A0, CHANGE, SLEEP_NETWORK_STANDBY));
+    API_COMPILE(System.sleep(A0, RISING, SLEEP_NETWORK_STANDBY));
+    API_COMPILE(System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY));
+    API_COMPILE(System.sleep(A0, FALLING, 20, SLEEP_NETWORK_STANDBY));
+    API_COMPILE(System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY, 20));
+
+
+}
+
+test(system_mode) {
     API_COMPILE(System.mode());
     API_COMPILE(SystemClass(AUTOMATIC));
     API_COMPILE(SystemClass(SEMI_AUTOMATIC));
     API_COMPILE(SystemClass(MANUAL));
-}
 
-test(system_mode) {
-    // braces are required since the macro evaluates to a declaration
+	// braces are required since the macro evaluates to a declaration
     API_COMPILE({ SYSTEM_MODE(AUTOMATIC) });
     API_COMPILE({ SYSTEM_MODE(SEMI_AUTOMATIC) });
     API_COMPILE({ SYSTEM_MODE(MANUAL) });

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -42,7 +42,7 @@ test(system_sleep)
 {
     API_COMPILE(System.sleep(60));
 
-	API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60));
+    API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60));
 
     API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60));
 
@@ -54,7 +54,7 @@ test(system_sleep)
     API_COMPILE(System.sleep(A0, FALLING, 20));
 
     // with network flags
-	API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60, SLEEP_NETWORK_STANDBY));
+    API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60, SLEEP_NETWORK_STANDBY));
 
     API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_NETWORK_STANDBY));
     API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY, 60));
@@ -76,7 +76,7 @@ test(system_mode) {
     API_COMPILE(SystemClass(SEMI_AUTOMATIC));
     API_COMPILE(SystemClass(MANUAL));
 
-	// braces are required since the macro evaluates to a declaration
+    // braces are required since the macro evaluates to a declaration
     API_COMPILE({ SYSTEM_MODE(AUTOMATIC) });
     API_COMPILE({ SYSTEM_MODE(SEMI_AUTOMATIC) });
     API_COMPILE({ SYSTEM_MODE(MANUAL) });
@@ -165,6 +165,3 @@ test(system_events)
     API_COMPILE(System.on(my_events, handler_event_data_param));
     (void)clicks; // avoid unused variable warning
 }
-
-
-

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -48,6 +48,28 @@
 
 class Stream;
 
+class SleepNetworkFlag
+{
+public:
+	typedef uint8_t flag_t;
+	inline SleepNetworkFlag(SystemSleepNetwork f) : SleepNetworkFlag(static_cast<flag_t>(f)) {}
+
+	inline SleepNetworkFlag(flag_t flag) : flag_(flag) {}
+
+	inline explicit operator flag_t() const { return flag_; }
+
+	inline flag_t flag() const { return flag_; }
+
+private:
+	flag_t flag_;
+
+};
+
+// Bring the system enum into global scope
+const SleepNetworkFlag SLEEP_NETWORK_OFF(SystemSleepNetwork::Off);
+const SleepNetworkFlag SLEEP_NETWORK_STANDBY(SystemSleepNetwork::Standby);
+
+
 class SystemClass {
 public:
 
@@ -89,9 +111,17 @@ public:
     }
 #endif
 
-    static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0);
-    static void sleep(long seconds) { sleep(SLEEP_MODE_WLAN, seconds); }
-    static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0);
+    static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0, SleepNetworkFlag flag=SLEEP_NETWORK_OFF);
+    inline static void sleep(Spark_Sleep_TypeDef sleepMode, SleepNetworkFlag flag, long seconds=0) {
+    		sleep(sleepMode, seconds, flag);
+    }
+
+    inline static void sleep(long seconds) { sleep(SLEEP_MODE_WLAN, seconds); }
+    static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0, SleepNetworkFlag flag=SLEEP_NETWORK_OFF);
+    inline static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepNetworkFlag flag, long seconds=0) {
+    		sleep(wakeUpPin, edgeTriggerMode, seconds, flag);
+    }
+
     static String deviceID(void) { return spark_deviceID(); }
 
     static uint16_t buttonPushed(uint8_t button=0) {

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -21,7 +21,7 @@
  */
 
 #ifndef SPARK_WIRING_SYSTEM_H
-#define	SPARK_WIRING_SYSTEM_H
+#define SPARK_WIRING_SYSTEM_H
 #include "spark_wiring_ticks.h"
 #include "spark_wiring_string.h"
 #include "spark_wiring_version.h"
@@ -51,18 +51,17 @@ class Stream;
 class SleepNetworkFlag
 {
 public:
-	typedef uint8_t flag_t;
-	inline SleepNetworkFlag(SystemSleepNetwork f) : SleepNetworkFlag(static_cast<flag_t>(f)) {}
+    typedef uint8_t flag_t;
+    inline SleepNetworkFlag(SystemSleepNetwork f) : SleepNetworkFlag(static_cast<flag_t>(f)) {}
 
-	inline SleepNetworkFlag(flag_t flag) : flag_(flag) {}
+    inline SleepNetworkFlag(flag_t flag) : flag_(flag) {}
 
-	inline explicit operator flag_t() const { return flag_; }
+    inline explicit operator flag_t() const { return flag_; }
 
-	inline flag_t flag() const { return flag_; }
+    inline flag_t flag() const { return flag_; }
 
 private:
-	flag_t flag_;
-
+    flag_t flag_;
 };
 
 // Bring the system enum into global scope
@@ -113,13 +112,13 @@ public:
 
     static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0, SleepNetworkFlag flag=SLEEP_NETWORK_OFF);
     inline static void sleep(Spark_Sleep_TypeDef sleepMode, SleepNetworkFlag flag, long seconds=0) {
-    		sleep(sleepMode, seconds, flag);
+        sleep(sleepMode, seconds, flag);
     }
 
     inline static void sleep(long seconds) { sleep(SLEEP_MODE_WLAN, seconds); }
     static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0, SleepNetworkFlag flag=SLEEP_NETWORK_OFF);
     inline static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepNetworkFlag flag, long seconds=0) {
-    		sleep(wakeUpPin, edgeTriggerMode, seconds, flag);
+        sleep(wakeUpPin, edgeTriggerMode, seconds, flag);
     }
 
     static String deviceID(void) { return spark_deviceID(); }
@@ -281,5 +280,5 @@ extern SystemClass System;
 #define waitFor(condition, timeout) System.waitCondition([]{ return (condition)(); }, (timeout))
 #define waitUntil(condition) System.waitCondition([]{ return (condition)(); })
 
-#endif	/* SPARK_WIRING_SYSTEM_H */
+#endif /* SPARK_WIRING_SYSTEM_H */
 

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -30,14 +30,14 @@ void SystemClass::reset(void)
     HAL_Core_System_Reset();
 }
 
-void SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds)
+void SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, SleepNetworkFlag network)
 {
-    system_sleep(sleepMode, seconds, 0, NULL);
+    system_sleep(sleepMode, seconds, network.flag(), NULL);
 }
 
-void SystemClass::sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds)
+void SystemClass::sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds, SleepNetworkFlag network)
 {
-    system_sleep_pin(wakeUpPin, edgeTriggerMode, seconds, 0, NULL);
+    system_sleep_pin(wakeUpPin, edgeTriggerMode, seconds, network.flag(), NULL);
 }
 
 uint32_t SystemClass::freeMemory()


### PR DESCRIPTION
After System.sleep(pin, trigger, seconds) or System.sleep(pin, trigger) electron will enter STOP mode, modem will remain on and powered in this mode (Photon/P1 will still have the Wi-Fi module powered off). The reason for this is to maintain an active PDP context to keep our current DTLS session happy.  Upon waking, the system will immediately be able to Particle.publish() with the bare minimum amount of data transferred (TX/RX).  Current consumption in this mode is ~4mA for the most of the idle time with small peaks when the modem is maintaining a cellular network connection.  Current consumption should be further reduced when Low Power mode is enabled. (**NOTE:** Please measure and test these current readings yourself before deploying a product based on them, this is preliminary info)

Simple change, big impact :)