### PR TITLE
HAL_Interrupts_Suspend should also clear EXTI IRQs in NVIC

### DIFF
--- a/hal/src/stm32f2xx/interrupts_hal.c
+++ b/hal/src/stm32f2xx/interrupts_hal.c
@@ -228,6 +228,16 @@ void HAL_Interrupts_Suspend(void) {
   exti_saved_state.ftsr = EXTI->FTSR;
 
   EXTI_DeInit();
+
+#if PLATFORM_ID == 10 // Electron
+  NVIC_ClearPendingIRQ(EXTI0_IRQn);
+#endif
+  NVIC_ClearPendingIRQ(EXTI1_IRQn);
+  NVIC_ClearPendingIRQ(EXTI2_IRQn);
+  NVIC_ClearPendingIRQ(EXTI3_IRQn);
+  NVIC_ClearPendingIRQ(EXTI4_IRQn);
+  NVIC_ClearPendingIRQ(EXTI9_5_IRQn);
+  NVIC_ClearPendingIRQ(EXTI15_10_IRQn);
 }
 
 void HAL_Interrupts_Restore(void) {


### PR DESCRIPTION
Fixes #846 