### PR TITLE
Blinking Cyan bugfix

### DIFF
--- a/communication/src/buffer_message_channel.h
+++ b/communication/src/buffer_message_channel.h
@@ -46,7 +46,7 @@ public:
 			return INSUFFICIENT_STORAGE;
         }
 		message.clear();
-		message.set_buffer(queue+suffix, sizeof(queue)-suffix-prefix);
+		message.set_buffer(queue+prefix, sizeof(queue)-suffix-prefix);
 		message.set_length(0);
 		return NO_ERROR;
 	}


### PR DESCRIPTION
The Message is instanciated with a prefix and a suffix to be able to
store the message length in the prefix, and a padding in the suffix.
The prefix is 2 bytes long, and the padding is 16 bytes long.

The buffer was pointing to queue+suffix instead of queue+prefix, leading
to possible corruption when the queue was full (sending more than one
message per second).