### PR TITLE
Feature/app watchdog

### DIFF
--- a/hal/src/electron/include.mk
+++ b/hal/src/electron/include.mk
@@ -19,13 +19,9 @@ ifdef UBLOX_PHONE_NUM
 CFLAGS += -DUBLOX_PHONE_NUM='"$(UBLOX_PHONE_NUM)"'
 endif
 
-# if we are being compiled with platform as a dependency, then also include
-# implementation headers.
-ifneq (,$(findstring platform,$(DEPENDENCIES)))
 INCLUDE_DIRS += $(HAL_SRC_ELECTRON_INCL_PATH)
 INCLUDE_DIRS += $(HAL_INCL_STM32F2XX_PATH)
 INCLUDE_DIRS += $(HAL_INCL_STM32_PATH)
-endif
 
 HAL_LINK ?= $(findstring hal,$(MAKE_DEPENDENCIES))
 

--- a/hal/src/stm32/concurrent_hal_impl.h
+++ b/hal/src/stm32/concurrent_hal_impl.h
@@ -6,7 +6,6 @@
 extern "C" {
 #endif
 
-
 // This code is used by HAL-clients which don't have access to the FreeRTOS sources
 // so we cannot directly define __gthread_t as TaskHandle_t, however, we define it
 // here and statically assert that it is the same size.
@@ -18,6 +17,7 @@ typedef int32_t os_result_t;
 typedef uint8_t os_thread_prio_t;
 /* Default priority is the same as the application thread */
 const os_thread_prio_t OS_THREAD_PRIORITY_DEFAULT = 2;
+const os_thread_prio_t OS_THREAD_PRIORITY_CRITICAL = 9;
 const size_t OS_THREAD_STACK_SIZE_DEFAULT = 3*1024;
 
 typedef void* os_mutex_t;

--- a/modules/shared/stm32f2xx/inc/user_part_export.c
+++ b/modules/shared/stm32f2xx/inc/user_part_export.c
@@ -74,7 +74,7 @@ void module_user_setup() {
 
 void module_user_loop() {
     loop();
-    serialEventRun();
+    _post_loop();
 }
 
 #include "user_dynalib.h"

--- a/system/inc/system_user.h
+++ b/system/inc/system_user.h
@@ -28,6 +28,7 @@ extern "C" {
 void setup();
 void loop();
 
+void _post_loop();
 void serialEventRun();
 
 /**

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -500,6 +500,9 @@ void app_loop(bool threaded)
                 if (system_mode()!=SAFE_MODE)
                  setup();
                 SPARK_WIRING_APPLICATION = 1;
+#if !MODULAR_FIRMWARE
+                _post_loop();
+#endif
             }
 
             //Execute user application loop
@@ -508,7 +511,7 @@ void app_loop(bool threaded)
                 loop();
                 DECLARE_SYS_HEALTH(RAN_Loop);
 #if !MODULAR_FIRMWARE
-                serialEventRun();
+                _post_loop();
 #endif
 #if Wiring_Cellular == 1
                 system_power_management_update();

--- a/system/src/system_threading.cpp
+++ b/system/src/system_threading.cpp
@@ -94,9 +94,6 @@ namespace std {
         thread_startup startup;
         startup.call = base.get();
         startup.started = false;
-        // FIXME: if the priority of the new thread is low enough not to cause `os_thread_create` to
-        // preempt the current thread to run the thread start function, by the time `invoke_thread`
-        // executes `call->_M_run()` will cause a pure virtual error
         if (os_thread_create(&_M_id._M_thread, "std::thread", OS_THREAD_PRIORITY_DEFAULT, invoke_thread, &startup, 1024*3)) {
             PANIC(AssertionFailure, "%s %s", __FILE__, __LINE__);
         }

--- a/user/inc/application.h
+++ b/user/inc/application.h
@@ -60,6 +60,7 @@
 #include "spark_wiring_tone.h"
 #include "spark_wiring_eeprom.h"
 #include "spark_wiring_version.h"
+#include "spark_wiring_watchdog.h"
 #include "spark_wiring_thread.h"
 #include "fast_pin.h"
 #include "string_convert.h"

--- a/user/tests/wiring/api/thread.cpp
+++ b/user/tests/wiring/api/thread.cpp
@@ -30,4 +30,13 @@ test(api_atomic_section) {
     API_COMPILE(AtomicSection as);
 }
 
+test(api_application_watchdog)
+{
+	unsigned stack_size = 512;
+	application_checkin();
+	ApplicationWatchdog wd(30000, System.reset);
+	ApplicationWatchdog wd2(30000, System.reset, stack_size);
+}
+
+
 #endif

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -28,6 +28,7 @@
 #include "system_sleep.h"
 #include "spark_protocol_functions.h"
 #include "spark_wiring_system.h"
+#include "spark_wiring_watchdog.h"
 #include "interrupts_hal.h"
 #include <functional>
 
@@ -241,7 +242,10 @@ public:
     static bool disconnected(void) { return !connected(); }
     static void connect(void) { spark_connect(); }
     static void disconnect(void) { spark_disconnect(); }
-    static void process(void) { spark_process(); }
+    static void process(void) {
+    		application_checkin();
+    		spark_process();
+    }
     static String deviceID(void) { return SystemClass::deviceID(); }
 
 private:

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -102,7 +102,8 @@ private:
 
     static os_thread_return_t call_wiring_handler(void *param) {
         auto wrapper = (wiring_thread_fn_t*)(param);
-        return (*wrapper)();
+        (*wrapper)();
+        os_thread_cleanup(nullptr);
     }
 };
 

--- a/wiring/inc/spark_wiring_watchdog.h
+++ b/wiring/inc/spark_wiring_watchdog.h
@@ -1,0 +1,90 @@
+/**
+ ******************************************************************************
+  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#pragma once
+
+#include "spark_wiring_thread.h"
+#include "delay_hal.h"
+#include "timer_hal.h"
+
+#if PLATFORM_THREADING
+
+
+class ApplicationWatchdog
+{
+	volatile system_tick_t timeout;
+	static volatile system_tick_t last_checkin;
+
+	std::function<void(void)> timeout_fn;
+
+	Thread thread;
+
+	static void start(void* pointer);
+
+	void loop();
+
+public:
+
+	ApplicationWatchdog(unsigned timeout_ms, std::function<void(void)> fn, unsigned stack_size=512) : timeout(timeout_ms), timeout_fn(fn),
+		thread("appwdt", start, this, OS_THREAD_PRIORITY_CRITICAL, stack_size)
+	{
+		checkin();
+	}
+
+	bool isComplete()
+	{
+		return !timeout_fn;
+	}
+
+	static inline system_tick_t current_time()
+	{
+		return HAL_Timer_Get_Milli_Seconds();
+	}
+
+	bool has_timedout()
+	{
+		return (current_time()-last_checkin)>=timeout;
+	}
+
+	/**
+	 * Dispose of this thread next time it wakes up.
+	 */
+	void dispose()
+	{
+		timeout = 0;
+	}
+
+	/**
+	 * Lifesign that the application is still working normally.
+	 */
+	static void checkin()
+	{
+		last_checkin = current_time();
+	}
+
+};
+
+inline void application_checkin() { ApplicationWatchdog::checkin(); }
+
+#else
+
+inline void application_checkin() {  }
+
+#endif
+

--- a/wiring/src/user.cpp
+++ b/wiring/src/user.cpp
@@ -27,6 +27,7 @@
 #include "spark_wiring_platform.h"
 #include "spark_wiring_usbserial.h"
 #include "spark_wiring_usartserial.h"
+#include "spark_wiring_watchdog.h"
 #include "rng_hal.h"
 
 
@@ -86,6 +87,7 @@ void serialEvent5() __attribute__((weak));
 void _post_loop()
 {
 	serialEventRun();
+	application_checkin();
 }
 
 /**

--- a/wiring/src/user.cpp
+++ b/wiring/src/user.cpp
@@ -83,6 +83,10 @@ void serialEvent4() __attribute__((weak));
 void serialEvent5() __attribute__((weak));
 #endif
 
+void _post_loop()
+{
+	serialEventRun();
+}
 
 /**
  * Provides background processing of serial data.

--- a/wiring_globals/src/spark_wiring_watchdog.cpp
+++ b/wiring_globals/src/spark_wiring_watchdog.cpp
@@ -1,0 +1,32 @@
+
+#include "spark_wiring_watchdog.h"
+
+#if PLATFORM_THREADING
+
+volatile system_tick_t ApplicationWatchdog::last_checkin;
+
+os_thread_return_t ApplicationWatchdog::start(void* pointer)
+{
+	ApplicationWatchdog& wd = *(ApplicationWatchdog*)pointer;
+	wd.loop();
+	os_thread_cleanup(nullptr);
+}
+
+void ApplicationWatchdog::loop()
+{
+	bool done = false;
+	system_tick_t now;
+	while (!done) {
+		HAL_Delay_Milliseconds(timeout);
+		now = current_time();
+		done = (now-last_checkin)>=timeout;
+	}
+
+	if (timeout>0 && timeout_fn) {
+		timeout_fn();
+		timeout_fn = std::function<void(void)>();
+	}
+}
+
+
+#endif


### PR DESCRIPTION
Provides a critical-priority thread that wakes up at a given timeout interval to see if the application has checked in.

API:


```
// declare a global instance
ApplicationWatchdog wd(timeout_milli_seconds, timeout_function_to_call, stack_size=512);
```
- if the application has not exited loop, or called Particle.process() within the given timeout, the watchdog calls the given timeout function.
- A default stack size of 512 is used for the thread. The stack can be made larger or smaller as needed.

Example:

```
ApplicationWatchdog wd(60000, System.reset);
// reset the system after 60 seconds if the application is unresponsive
```

The application watchdog requires interrupts to be active in order to function.  Enabling the hardware watchdog in tandem with this is advised to detect when interrupts are not firing. 