### PR TITLE
Feature/publish noack

### DIFF
--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -428,6 +428,7 @@ ProtocolError DTLSMessageChannel::receive(Message& message)
 	}
 	message.set_length(ret);
 	if (ret>0) {
+		cancel_move_session();
 #if defined(DEBUG_BUILD) && 0
 		if (LOG_LEVEL_ACTIVE(DEBUG_LEVEL)) {
 		  DEBUG("message length %d", message.length());

--- a/communication/src/events.h
+++ b/communication/src/events.h
@@ -34,6 +34,9 @@ namespace EventType {
     PRIVATE = 'E',			// 0x45
   };
 
+  /**
+   * These flags are encoded into the same 32-bit integer that alredy holds EventType::Enum
+   */
   enum Flags {
 	  EMPTY_FLAGS = 0,
 	   NO_ACK = 0x2,
@@ -44,14 +47,16 @@ namespace EventType {
   static_assert((PUBLIC & NO_ACK)==0, "flags should be distinct from event type");
   static_assert((PRIVATE & NO_ACK)==0, "flags should be distinct from event type");
 
-
-  inline int extract_flags(Enum& et)
+/**
+ * The flags are encoded in with the event type.
+ */
+  inline Enum extract_event_type(uint32_t& value)
   {
-	  int flags = et & ALL_FLAGS;
-	  et = Enum(et & ~ALL_FLAGS);
-	  return flags;
+	  Enum et = Enum(value & ~ALL_FLAGS);
+	  value = value & ALL_FLAGS;
+	  return et;
   }
-}
+} // namespace EventType
 
 #if PLATFORM_ID!=3
 static_assert(sizeof(EventType::Enum)==1, "EventType size is 1");

--- a/communication/src/events.h
+++ b/communication/src/events.h
@@ -30,10 +30,32 @@
 
 namespace EventType {
   enum Enum {
-    PUBLIC = 'e',
-    PRIVATE = 'E'
+    PUBLIC = 'e',			// 0x65
+    PRIVATE = 'E',			// 0x45
   };
+
+  enum Flags {
+	  EMPTY_FLAGS = 0,
+	   NO_ACK = 0x2,
+
+	   ALL_FLAGS = NO_ACK
+  };
+
+  static_assert((PUBLIC & NO_ACK)==0, "flags should be distinct from event type");
+  static_assert((PRIVATE & NO_ACK)==0, "flags should be distinct from event type");
+
+
+  inline int extract_flags(Enum& et)
+  {
+	  int flags = et & ALL_FLAGS;
+	  et = Enum(et & ~ALL_FLAGS);
+	  return flags;
+  }
 }
+
+#if PLATFORM_ID!=3
+static_assert(sizeof(EventType::Enum)==1, "EventType size is 1");
+#endif
 
 namespace SubscriptionScope {
   enum Enum {

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -302,13 +302,13 @@ public:
 
 	// Returns true on success, false on sending timeout or rate-limiting failure
 	bool send_event(const char *event_name, const char *data, int ttl,
-			EventType::Enum event_type)
+			EventType::Enum event_type, int flags)
 	{
 		if (chunkedTransfer.is_updating())
 		{
 			return false;
 		}
-		return !publisher.send_event(channel, event_name, data, ttl, event_type,
+		return !publisher.send_event(channel, event_name, data, ttl, event_type, flags,
 				callbacks.millis());
 	}
 

--- a/communication/src/publisher.h
+++ b/communication/src/publisher.h
@@ -97,8 +97,9 @@ public:
 		Message message;
 		channel.create(message);
 		bool noack = flags & EventType::NO_ACK;
+		bool confirmable = channel.is_unreliable() && !noack;
 		size_t msglen = Messages::event(message.buf(), 0, event_name, data, ttl,
-				event_type, channel.is_unreliable() && !noack);
+				event_type, confirmable);
 		message.set_length(msglen);
 		return channel.send(message);
 	}

--- a/communication/src/publisher.h
+++ b/communication/src/publisher.h
@@ -86,7 +86,7 @@ public:
 public:
 
 	ProtocolError send_event(MessageChannel& channel, const char* event_name,
-			const char* data, int ttl, EventType::Enum event_type,
+			const char* data, int ttl, EventType::Enum event_type, int flags,
 			system_tick_t time)
 	{
 		bool is_system_event = is_system(event_name);
@@ -96,8 +96,9 @@ public:
 
 		Message message;
 		channel.create(message);
+		bool noack = flags & EventType::NO_ACK;
 		size_t msglen = Messages::event(message.buf(), 0, event_name, data, ttl,
-				event_type, channel.is_unreliable());
+				event_type, channel.is_unreliable() && !noack);
 		message.set_length(msglen);
 		return channel.send(message);
 	}

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -86,8 +86,8 @@ int spark_protocol_presence_announcement(ProtocolFacade* protocol, uint8_t *buf,
 }
 
 bool spark_protocol_send_event(ProtocolFacade* protocol, const char *event_name, const char *data,
-                int ttl, EventType::Enum event_type, void*) {
-	int flags = extract_flags(event_type);
+                int ttl, uint32_t flags, void*) {
+	EventType::Enum event_type = EventType::extract_event_type(flags);
 	return protocol->send_event(event_name, data, ttl, event_type, flags);
 }
 
@@ -172,7 +172,8 @@ int spark_protocol_presence_announcement(SparkProtocol* protocol, unsigned char 
 }
 
 bool spark_protocol_send_event(SparkProtocol* protocol, const char *event_name, const char *data,
-                int ttl, EventType::Enum event_type, void*) {
+                int ttl, uint32_t flags, void*) {
+	EventType::Enum event_type = EventType::extract_event_type(flags);
     return protocol->send_event(event_name, data, ttl, event_type);
 }
 

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -87,7 +87,8 @@ int spark_protocol_presence_announcement(ProtocolFacade* protocol, uint8_t *buf,
 
 bool spark_protocol_send_event(ProtocolFacade* protocol, const char *event_name, const char *data,
                 int ttl, EventType::Enum event_type, void*) {
-    return protocol->send_event(event_name, data, ttl, event_type);
+	int flags = extract_flags(event_type);
+	return protocol->send_event(event_name, data, ttl, event_type, flags);
 }
 
 bool spark_protocol_send_subscription_device(ProtocolFacade* protocol, const char *event_name, const char *device_id, void*) {

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -158,7 +158,7 @@ bool spark_protocol_event_loop(ProtocolFacade* protocol, void* reserved=NULL);
 bool spark_protocol_is_initialized(ProtocolFacade* protocol);
 int spark_protocol_presence_announcement(ProtocolFacade* protocol, unsigned char *buf, const unsigned char *id, void* reserved=NULL);
 bool spark_protocol_send_event(ProtocolFacade* protocol, const char *event_name, const char *data,
-                int ttl, EventType::Enum event_type, void* reserved);
+                int ttl, uint32_t flags, void* reserved);
 bool spark_protocol_send_subscription_device(ProtocolFacade* protocol, const char *event_name, const char *device_id, void* reserved=NULL);
 bool spark_protocol_send_subscription_scope(ProtocolFacade* protocol, const char *event_name, SubscriptionScope::Enum scope, void* reserved=NULL);
 bool spark_protocol_add_event_handler(ProtocolFacade* protocol, const char *event_name, EventHandler handler, SubscriptionScope::Enum scope, const char* id, void* handler_data=NULL);

--- a/communication/tests/catch/coap_reliability.cpp
+++ b/communication/tests/catch/coap_reliability.cpp
@@ -89,10 +89,11 @@ SCENARIO("message IDs monotinically increment from 1")
 
 				AND_WHEN("300 more messages are sent")
 				{
-					Message msg;
 					for (int i=0; i<300; i++)
 					{
+						Message msg;
 						channel.create(msg, 5);
+						msg.set_length(4);
 						channel.send(msg);
 					}
 					THEN("the encoded message ID is 302")
@@ -503,6 +504,7 @@ SCENARIO("a Confirmable message is pending until acknowledged, reset or timeout"
 				msg.set_buffer(buf, 10); return NO_ERROR;
 			});
 		When(Method(mock,send)).AlwaysReturn(NO_ERROR);
+		build_message_channel_mock(mock);
 
 		Message m;
 		channel.create(m, 5);
@@ -548,7 +550,6 @@ SCENARIO("a Confirmable message is pending until acknowledged, reset or timeout"
 							REQUIRE(m.length()==0);
 						}
 					}
-
 				}
 
 				AND_WHEN("the message is reset")
@@ -596,7 +597,7 @@ SCENARIO("retransmit delay is exponential with randomness")
 		for (unsigned u = 0; u<500; u++)
 		{
 			system_tick_t timeout = CoAPMessage::transmit_timeout(i);
-			system_tick_t min = 2000 << i;
+			system_tick_t min = 4000 << i;
 			system_tick_t max = min * 1.5;
 			if (timeout<min)
 				REQUIRE(timeout>=min);

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -89,11 +89,11 @@ STATIC_ASSERT(spark_data_typedef_is_1_byte, sizeof(Spark_Data_TypeDef)==1);
 
 #endif
 
+const uint32_t PUBLISH_EVENT_FLAG_PUBLIC = 0;
+const uint32_t PUBLISH_EVENT_FLAG_PRIVATE = 1;
+const uint32_t PUBLISH_EVENT_FLAG_NO_ACK = 2;
 
-typedef enum
-{
-	PUBLIC = 0, PRIVATE = 1
-} Spark_Event_TypeDef;
+STATIC_ASSERT(publish_no_ack_flag_matches, PUBLISH_EVENT_FLAG_NO_ACK==EventType::NO_ACK);
 
 typedef void (*EventHandler)(const char* name, const char* data);
 
@@ -138,7 +138,7 @@ bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef 
  * @param reserved  For future expansion, set to NULL.
  */
 bool spark_function(const char *funcKey, p_user_function_int_str_t pFunc, void* reserved);
-bool spark_send_event(const char* name, const char* data, int ttl, Spark_Event_TypeDef eventType, void* reserved);
+bool spark_send_event(const char* name, const char* data, int ttl, uint32_t flags, void* reserved);
 bool spark_subscribe(const char *eventName, EventHandler handler, void* handler_data,
         Spark_Subscription_Scope_TypeDef scope, const char* deviceID, void* reserved);
 

--- a/user/tests/app/pub_no_ack/app.cpp
+++ b/user/tests/app/pub_no_ack/app.cpp
@@ -1,0 +1,108 @@
+#include "application.h"
+
+struct DataUsage : public Printable {
+    int cid = 0;
+    int tx_sess_bytes = 0;
+    int rx_sess_bytes = 0;
+    int tx_total_bytes = 0;
+    int rx_total_bytes = 0;
+
+
+    static inline int _cbUGCNTRD(int type, const char* buf, int len, DataUsage* data)
+    {
+        if ((type == TYPE_PLUS) && data) {
+            int a,b,c,d,e;
+            // +UGCNTRD: 31,2704,1819,2724,1839\r\n
+            // +UGCNTRD: <cid>,<tx_sess_bytes>,<rx_sess_bytes>,<tx_total_bytes>,<rx_total_bytes>
+            if (sscanf(buf, "\r\n+UGCNTRD: %d,%d,%d,%d,%d\r\n", &a,&b,&c,&d,&e) == 5) {
+                data->cid = a;
+                data->tx_sess_bytes = b;
+                data->rx_sess_bytes = c;
+                data->tx_total_bytes = d;
+                data->rx_total_bytes = e;
+            }
+        }
+        return WAIT;
+    }
+
+    static bool sample_usage(DataUsage& _data_usage)
+    {
+    		return (RESP_OK == Cellular.command(_cbUGCNTRD, &_data_usage, 10000, "AT+UGCNTRD\r\n"));
+    }
+
+    DataUsage(bool sample=true)
+    {
+    		if (sample)
+    			sample_usage(*this);
+    }
+
+    size_t printTo(Print& p) const override
+    {
+        return p.printlnf("CID: %d SESSION TX: %d RX: %d TOTAL TX: %d RX: %d\r\n",
+            cid,
+            tx_sess_bytes, rx_sess_bytes,
+            tx_total_bytes, rx_total_bytes);
+    }
+
+    void subtract(DataUsage& usage)
+    {
+    	    tx_total_bytes -= usage.tx_total_bytes;
+        rx_total_bytes -= usage.rx_total_bytes;
+    }
+
+    int total() { return rx_total_bytes + tx_total_bytes; }
+};
+
+
+
+template <typename T> int measure(T t, int timeout, Print& stream)
+{
+	DataUsage before;
+	t();
+	delay(timeout);
+	DataUsage after;
+	after.subtract(before);
+	return after.total();
+}
+
+
+void publish_ack()
+{
+	Particle.publish("a","b");
+}
+
+void publish_nack()
+{
+	Particle.publish("a","b", NO_ACK);
+}
+
+void setup()
+{
+	Serial.begin(9600);
+	Serial.println("Publish data use tester.");
+	Serial.println("Press 'p' to publish with ACK");
+	Serial.println("Press 'P' to publish without ACK");
+	Serial.println("Press 'D' to print data usage counters.");
+	Serial.println("Each publish waits 30s before collecting the data count.");
+}
+
+void loop()
+{
+	const int timeout = 30*1000;
+	char c = Serial.read();
+	switch (c)
+	{
+	case 'p':
+		Serial.print("Publishing with ACK...");
+		Serial.printlnf("%d bytes", measure(publish_ack, timeout, Serial));
+		break;
+	case 'P':
+		Serial.print("Publishing with NACK...");
+		Serial.printlnf("%d bytes", measure(publish_nack, timeout, Serial));
+		break;
+	case 'D':
+		Serial.println(DataUsage());
+		break;
+	}
+}
+

--- a/user/tests/wiring/cloud/cloud.cpp
+++ b/user/tests/wiring/cloud/cloud.cpp
@@ -24,6 +24,8 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
+uint32_t publish_timeout = 90000;
+
 void idle()
 {
     Particle.process();
@@ -77,7 +79,7 @@ test(Spark_Subscribe_When_Not_Connected_Recieves_Events_When_Connected) {
     Particle.publish(eventName, deviceID.c_str());
 
     long start = millis();
-    while ((millis()-start)<30000 && !not_connected_handler_count)
+    while ((millis()-start)<publish_timeout && !not_connected_handler_count)
         idle();
 
     assertEqual(not_connected_handler_count, 1);
@@ -128,7 +130,7 @@ test(Spark_Unsubscribe) {
     Particle.publish(eventName, deviceID.c_str());
 
     long start = millis();
-    while ((millis()-start)<30000 && !not_connected_handler_count)
+    while ((millis()-start)<publish_timeout && !not_connected_handler_count)
         idle();
 
     assertEqual(not_connected_handler_count, 1);
@@ -137,7 +139,7 @@ test(Spark_Unsubscribe) {
     Particle.unsubscribe();
     Particle.publish(eventName, deviceID.c_str());
     start = millis();
-    while ((millis()-start)<10000 && !not_connected_handler_count)
+    while ((millis()-start)<publish_timeout && !not_connected_handler_count)
         idle();
 
     // no further events received
@@ -164,7 +166,7 @@ test(Spark_Second_Event_Handler_Not_Matched) {
 
     // now wait for published event to be received
     long start = millis();
-    while ((millis()-start)<30000 && !not_connected_handler_count)
+    while ((millis()-start)<publish_timeout && !not_connected_handler_count)
         idle();
 
     assertEqual(not_connected_handler_count, 1);
@@ -207,7 +209,7 @@ test(Subscribe_With_Object) {
 
     // now wait for published event to be received
     long start = millis();
-    while ((millis()-start)<30000 && !subscriber.receivedCount)
+    while ((millis()-start)<publish_timeout && !subscriber.receivedCount)
         idle();
 
     assertEqual(subscriber.receivedCount, 2);
@@ -225,12 +227,12 @@ test(all_events_subscription)
 	// public events
     subscriber.subscribe();
 
-    Particle.publish("test/event4");	// my devices subscription
+    Particle.publish("test/eventmine");	// my devices subscription
     Particle.publish("test/event3");
 
     // now wait for published event to be received
     long start = millis();
-    while ((millis()-start)<30000 && !subscriber.receivedCount)
+    while ((millis()-start)<publish_timeout && !subscriber.receivedCount)
         idle();
 
     // the public test/event3 is received by ALL_DEVICES subscription
@@ -251,12 +253,12 @@ test(mine_events_subscription)
 
     subscriber.subscribe();
 
-    Particle.publish("test/event4", "", PRIVATE);	// my devices subscription
+    Particle.publish("test/eventmine", "", PRIVATE);	// my devices subscription
     Particle.publish("test/event3", "", PRIVATE);
 
     // now wait for published event to be received
     long start = millis();
-    while ((millis()-start)<30000 && !subscriber.mineCount)
+    while ((millis()-start)<publish_timeout && !subscriber.mineCount)
         idle();
 
     // the private test/event3 is not received by ALL_DEVICES subscription

--- a/user/tests/wiring/cloud/cloud.cpp
+++ b/user/tests/wiring/cloud/cloud.cpp
@@ -60,11 +60,11 @@ void Spark_Subscribe_When_Not_Connected_Handler(const char* topic, const char* d
     Serial.println("event ***");
     if (data) Serial.println(data);
     if (data && !strcmp(data, deviceId.c_str())) {
-        not_connected_handler_count++;
+    		not_connected_handler_count++;
     }
 }
 
-test(Spark_Subscribe_When_Not_Connected) {
+test(Spark_Subscribe_When_Not_Connected_Recieves_Events_When_Connected) {
     disconnect();
     Particle.unsubscribe();
     not_connected_handler_count = 0;
@@ -176,7 +176,7 @@ class Subscriber {
       assertTrue(Particle.subscribe("test/event3", &Subscriber::handler, this));
       // To make sure calling subscribe with a different handler is not a no op
       assertTrue(Particle.subscribe("test/event3", &Subscriber::handler2, this));
-      assertTrue(Particle.subscribe("test/eventmine", &Subscriber::handler3, this), MY_DEVICES);
+      assertTrue(Particle.subscribe("test/eventmine", &Subscriber::handler3, this, MY_DEVICES));
 
       receivedCount = 0;
       mineCount = 0;
@@ -202,7 +202,7 @@ test(Subscribe_With_Object) {
 
     subscriber.subscribe();
 
-    String deviceID = Spark.deviceID();
+    String deviceID = Particle.deviceID();
     Particle.publish("test/event3");
 
     // now wait for published event to be received

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -42,13 +42,18 @@ typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 
 class PublishFlag
 {
-	typedef uint8_t flag_t;
-	flag_t flag_;
-
 public:
+	typedef uint8_t flag_t;
 	PublishFlag(flag_t flag) : flag_(flag) {}
 
-	operator flag_t() const { return flag_; }
+	explicit operator flag_t() const { return flag_; }
+
+	flag_t flag() const { return flag_; }
+
+private:
+	flag_t flag_;
+
+
 };
 
 const PublishFlag PUBLIC(PUBLISH_EVENT_FLAG_PUBLIC);
@@ -187,27 +192,33 @@ public:
       function(funcKey, std::bind(func, instance, _1));
     }
 
-    bool publish(const char *eventName, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, PublishFlag eventType=PUBLIC)
     {
-        return CLOUD_FN(spark_send_event(eventName, NULL, 60, eventType, NULL), false);
+        return CLOUD_FN(spark_send_event(eventName, NULL, 60, PublishFlag::flag_t(eventType), NULL), false);
     }
 
-    bool publish(const char *eventName, const char *eventData, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, const char *eventData, PublishFlag eventType=PUBLIC)
     {
-        return CLOUD_FN(spark_send_event(eventName, eventData, 60, eventType, NULL), false);
+        return CLOUD_FN(spark_send_event(eventName, eventData, 60, PublishFlag::flag_t(eventType), NULL), false);
     }
 
-    bool publish(const char *eventName, const char *eventData, int ttl, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, const char *eventData, PublishFlag f1, PublishFlag f2)
     {
-        return CLOUD_FN(spark_send_event(eventName, eventData, ttl, eventType, NULL), false);
+        return CLOUD_FN(spark_send_event(eventName, eventData, 60, f1.flag()+f2.flag(), NULL), false);
     }
 
-    bool subscribe(const char *eventName, EventHandler handler, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES)
+
+    inline bool publish(const char *eventName, const char *eventData, int ttl, PublishFlag eventType=PUBLIC)
+    {
+        return CLOUD_FN(spark_send_event(eventName, eventData, ttl, PublishFlag::flag_t(eventType), NULL), false);
+    }
+
+    inline bool subscribe(const char *eventName, EventHandler handler, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES)
     {
         return CLOUD_FN(spark_subscribe(eventName, handler, NULL, scope, NULL, NULL), false);
     }
 
-    bool subscribe(const char *eventName, EventHandler handler, const char *deviceID)
+    inline bool subscribe(const char *eventName, EventHandler handler, const char *deviceID)
     {
         return CLOUD_FN(spark_subscribe(eventName, handler, NULL, MY_DEVICES, deviceID, NULL), false);
     }

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -40,6 +40,22 @@ typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 #define CLOUD_FN(x,y) (x)
 #endif
 
+class PublishFlag
+{
+	typedef uint8_t flag_t;
+	flag_t flag_;
+
+public:
+	PublishFlag(flag_t flag) : flag_(flag) {}
+
+	operator flag_t() const { return flag_; }
+};
+
+const PublishFlag PUBLIC(PUBLISH_EVENT_FLAG_PUBLIC);
+const PublishFlag PRIVATE(PUBLISH_EVENT_FLAG_PRIVATE);
+const PublishFlag NO_ACK(PUBLISH_EVENT_FLAG_NO_ACK);
+
+
 class CloudClass {
 
 
@@ -171,17 +187,17 @@ public:
       function(funcKey, std::bind(func, instance, _1));
     }
 
-    bool publish(const char *eventName, Spark_Event_TypeDef eventType=PUBLIC)
+    bool publish(const char *eventName, PublishFlag eventType=PUBLIC)
     {
         return CLOUD_FN(spark_send_event(eventName, NULL, 60, eventType, NULL), false);
     }
 
-    bool publish(const char *eventName, const char *eventData, Spark_Event_TypeDef eventType=PUBLIC)
+    bool publish(const char *eventName, const char *eventData, PublishFlag eventType=PUBLIC)
     {
         return CLOUD_FN(spark_send_event(eventName, eventData, 60, eventType, NULL), false);
     }
 
-    bool publish(const char *eventName, const char *eventData, int ttl, Spark_Event_TypeDef eventType=PUBLIC)
+    bool publish(const char *eventName, const char *eventData, int ttl, PublishFlag eventType=PUBLIC)
     {
         return CLOUD_FN(spark_send_event(eventName, eventData, ttl, eventType, NULL), false);
     }


### PR DESCRIPTION
Adds NO_ACK as a flag to Publish for non-acknowledged publishes. 

Usage:

```
Particle.publish("a","b",NO_ACK);
```

A test app showing the measured data use for different types of publish can be built by running

```
make PLATFORM=electron TEST=app/pub_no_ack all program-dfu
```

Run the app, connect to serial and push some keys. 

Output from the test app:

```
Publish data use tester.
Press 'p' to publish with ACK
Press 'P' to publish without ACK
Press 'D' to print data usage counters.
Each publish waits 30s before collecting the data count.
Publishing with ACK...141 bytes
Publishing with NACK...80 bytes
```