### PR TITLE
Feature/cancel network connect on disconnect

### DIFF
--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -79,6 +79,7 @@ void HAL_System_Interrupt_Trigger(hal_irq_t irq, void* reserved);
 int HAL_disable_irq();
 void HAL_enable_irq(int mask);
 
+uint8_t HAL_IsISR();
 
 #ifdef __cplusplus
 }

--- a/hal/src/core/interrupts_hal.c
+++ b/hal/src/core/interrupts_hal.c
@@ -248,3 +248,16 @@ void HAL_enable_irq(int is) {
     }
 }
 
+
+inline bool isISR()
+{
+	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+
+uint8_t HAL_IsISR()
+{
+	return isISR();
+}
+
+
+

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -62,6 +62,7 @@ cellular_result_t  cellular_gprs_attach(CellularCredentials* connect, void* rese
 cellular_result_t  cellular_gprs_detach(void* reserved)
 {
     CHECK_SUCCESS(electronMDM.detach());
+    HAL_NET_notify_disconnected();
     return 0;
 }
 

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -35,6 +35,7 @@
 #include "service_debug.h"
 #include "device_config.h"
 #include "hal_platform.h"
+#include "interrupts_hal.h"
 #include <boost/crc.hpp>  // for boost::crc_32_type
 
 
@@ -345,3 +346,5 @@ int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, si
 }
 
 #endif
+
+uint8_t HAL_IsISR() { return false; }

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -346,5 +346,3 @@ int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, si
 }
 
 #endif
-
-uint8_t HAL_IsISR() { return false; }

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -30,12 +30,19 @@
 #include "semphr.h"
 #include "timers.h"
 #include "stm32f2xx.h"
+#include "interrupts_hal.h"
 #include <mutex>
 
 inline bool isISR()
 {
 	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
 }
+
+uint8_t HAL_IsISR()
+{
+	return isISR();
+}
+
 
 // For OpenOCD FreeRTOS support
 extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;

--- a/hal/src/template/interrupts_hal.cpp
+++ b/hal/src/template/interrupts_hal.cpp
@@ -72,3 +72,7 @@ void HAL_enable_irq(int is)
 {
 }
 
+uint8_t HAL_IsISR()
+{
+	return 0;
+}

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -179,7 +179,7 @@ void system_handle_button_click()
         break;
     case 2: // Double click
         SYSTEM_POWEROFF = 1;
-        network.connect_cancel(true, true);
+        network.connect_cancel(true);
         break;
     default:
         break;
@@ -440,7 +440,7 @@ extern "C" void HAL_SysTick_Handler(void)
     // determine if the button press needs to change the state (and hasn't done so already))
     else if(!network.listening() && HAL_Core_Mode_Button_Pressed(3000) && !wasListeningOnButtonPress)
     {
-        network.connect_cancel(true, true);
+        network.connect_cancel(true);
         // fire the button event to the user, then enter listening mode (so no more button notifications are sent)
         // there's a race condition here - the HAL_notify_button_state function should
         // be thread safe, but currently isn't.

--- a/system/src/system_network.cpp
+++ b/system/src/system_network.cpp
@@ -98,6 +98,7 @@ void network_connect(network_handle_t network, uint32_t flags, uint32_t param, v
 
 void network_disconnect(network_handle_t network, uint32_t param, void* reserved)
 {
+	nif(network).connect_cancel(true);
     SYSTEM_THREAD_CONTEXT_ASYNC_CALL(nif(network).disconnect());
 }
 

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -21,6 +21,7 @@
 
 #include "system_network_internal.h"
 #include "cellular_hal.h"
+#include "interrupts_hal.h"
 
 
 class CellularNetworkInterface : public ManagedIPNetworkInterface<CellularConfig, CellularNetworkInterface>
@@ -108,7 +109,7 @@ public:
         return cellular_sim_ready(NULL);
     }
     int set_credentials(NetworkCredentials* creds) override { /* n/a */ return -1; }
-    void connect_cancel(bool cancel, bool calledFromISR) override { cellular_cancel(cancel, calledFromISR, NULL);  }
+    void connect_cancel(bool cancel) override { cellular_cancel(cancel, HAL_IsISR(), NULL);  }
 
     void set_error_count(unsigned count) override { /* n/a */ }
 };

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -83,7 +83,7 @@ struct NetworkInterface
     virtual void connect(bool listen_enabled=true)=0;
     virtual bool connecting()=0;
     virtual bool connected()=0;
-    virtual void connect_cancel(bool cancel, bool calledFromISR)=0;
+    virtual void connect_cancel(bool cancel)=0;
     /**
      * Force a manual disconnct.
      */

--- a/system/src/system_network_wifi.h
+++ b/system/src/system_network_wifi.h
@@ -21,6 +21,7 @@
 
 #include "system_network_internal.h"
 #include "wlan_hal.h"
+#include "interrupts_hal.h"
 
 
 class WiFiNetworkInterface : public ManagedIPNetworkInterface<WLanConfig, WiFiNetworkInterface>
@@ -129,10 +130,10 @@ public:
     }
 
 
-    void connect_cancel(bool cancel, bool calledFromISR) override
+    void connect_cancel(bool cancel) override
     {
         if (cancel)
-            wlan_connect_cancel(calledFromISR);
+            wlan_connect_cancel(HAL_IsISR());
     }
 
     bool has_credentials() override

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -157,7 +157,7 @@ void system_lineCodingBitRateHandler(uint32_t bitrate)
 #ifdef START_DFU_FLASHER_SERIAL_SPEED
     if (bitrate == start_dfu_flasher_serial_speed)
     {
-        network.connect_cancel(true, true);
+        network.connect_cancel(true);
         //Reset device and briefly enter DFU bootloader mode
         System.dfu(false);
     }

--- a/wiring/inc/spark_wiring_cellular.h
+++ b/wiring/inc/spark_wiring_cellular.h
@@ -49,6 +49,10 @@ public:
     void connect(unsigned flags=0) {
         network_connect(*this, flags, 0, NULL);
     }
+    bool connecting(void) {
+        return network_connecting(*this, 0, NULL);
+    }
+
     void disconnect() {
         network_disconnect(*this, 0, NULL);
     }


### PR DESCRIPTION
Implementation for Issue #886

### Todo
- [x] Because this PR is primarily valuable for use with Multi-Threaded mode on the Electron, we need to solve the lockup issue before it should be merged.
- [x] <s>We should also look into what can be done to make Soft Power down function immediately with this PR while Connecting to the tower, i.e. It should cancel the connect.  Some suggestions below.</s>

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

