### PR TITLE
added write-verify-retry-fail logic to DFU writes

### DIFF
--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/usbd_dfu_mal.h
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/usbd_dfu_mal.h
@@ -44,6 +44,7 @@ typedef struct _DFU_MAL_PROP
   uint16_t (*pMAL_Erase)    (uint32_t Add);
   uint16_t (*pMAL_Write)    (uint32_t Add, uint32_t Len);
   const uint8_t  *(*pMAL_Read)    (uint32_t Add, uint32_t Len);
+  uint16_t (*pMAL_Verify)   (uint32_t Add, uint32_t Len);
   uint16_t (*pMAL_CheckAdd) (uint32_t Add);
   const uint32_t EraseTiming;
   const uint32_t WriteTiming;

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_dct_if.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_dct_if.c
@@ -20,6 +20,7 @@ uint16_t DCT_If_Init(void);
 uint16_t DCT_If_Erase (uint32_t Add);
 uint16_t DCT_If_Write (uint32_t Add, uint32_t Len);
 const uint8_t *DCT_If_Read  (uint32_t Add, uint32_t Len);
+uint16_t DCT_If_Verify (uint32_t Add, uint32_t Len);
 uint16_t DCT_If_DeInit(void);
 uint16_t DCT_If_CheckAdd(uint32_t Add);
 
@@ -32,6 +33,7 @@ DFU_MAL_Prop_TypeDef DFU_DCT_cb =
     DCT_If_Erase,
     DCT_If_Write,
     DCT_If_Read,
+    DCT_If_Verify,
     DCT_If_CheckAdd,
     1, /* Erase Time in ms */
     500  /* Programming Time in ms */
@@ -52,6 +54,10 @@ uint16_t DCT_If_Write (uint32_t Add, uint32_t Len) {
 
 const uint8_t *DCT_If_Read  (uint32_t Add, uint32_t Len) {
     return dct_read_app_data(Add);
+}
+
+uint16_t DCT_If_Verify (uint32_t Add, uint32_t Len) {
+    return MAL_OK; /* unimplemented, todo */
 }
 
 uint16_t DCT_If_DeInit(void) {

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
@@ -40,6 +40,7 @@ uint16_t FLASH_If_Init(void);
 uint16_t FLASH_If_Erase (uint32_t Add);
 uint16_t FLASH_If_Write (uint32_t Add, uint32_t Len);
 const uint8_t *FLASH_If_Read  (uint32_t Add, uint32_t Len);
+uint16_t FLASH_If_Verify  (uint32_t Add, uint32_t Len);
 uint16_t FLASH_If_DeInit(void);
 uint16_t FLASH_If_CheckAdd(uint32_t Add);
 
@@ -53,6 +54,7 @@ DFU_MAL_Prop_TypeDef DFU_Flash_cb =
     FLASH_If_Erase,
     FLASH_If_Write,
     FLASH_If_Read,
+    FLASH_If_Verify,
     FLASH_If_CheckAdd,
     50, /* Erase Time in ms */
     50  /* Programming Time in ms */
@@ -176,7 +178,30 @@ const uint8_t *FLASH_If_Read (uint32_t Add, uint32_t Len)
   return (uint8_t*)(MAL_Buffer);
 #else
   return  (const uint8_t *)(Add);
-#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+#endif // USB_OTG_HS_INTERNAL_DMA_ENABLED
+}
+
+/**
+  * @brief  FLASH_If_Verify
+  *         Memory verify routine. Assumes FLASH_If_Write was
+  *         called just prior, with same Add and Len.
+  * @param  Add: Address to be read/verified from.
+  * @param  Len: Number of data to be read/verified (in bytes).
+  * @retval MAL_OK if operation is successeful, MAL_FAIL else.
+  */
+uint16_t FLASH_If_Verify (uint32_t Add, uint32_t Len)
+{
+  uint16_t status = MAL_OK;
+  uint32_t idx = 0;
+  for (idx = 0; idx < Len; idx += 4)
+  {
+    if ( (*(uint32_t*)(MAL_Buffer + idx)) != (*(uint32_t *)(Add + idx)) )
+    {
+      status = MAL_FAIL;
+      break;
+    }
+  }
+  return status;
 }
 
 /**

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_sflash_if.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_sflash_if.c
@@ -24,6 +24,7 @@ uint16_t sFLASH_If_Init(void);
 uint16_t sFLASH_If_Erase (uint32_t Add);
 uint16_t sFLASH_If_Write (uint32_t Add, uint32_t Len);
 const uint8_t *sFLASH_If_Read  (uint32_t Add, uint32_t Len);
+uint16_t sFLASH_If_Verify (uint32_t Add, uint32_t Len);
 uint16_t sFLASH_If_DeInit(void);
 uint16_t sFLASH_If_CheckAdd(uint32_t Add);
 
@@ -36,6 +37,7 @@ DFU_MAL_Prop_TypeDef DFU_sFlash_cb =
         sFLASH_If_Erase,
         sFLASH_If_Write,
         sFLASH_If_Read,
+        sFLASH_If_Verify,
         sFLASH_If_CheckAdd,
         50, /* Erase Time in ms */
         50  /* Programming Time in ms */
@@ -103,6 +105,18 @@ const uint8_t *sFLASH_If_Read (uint32_t Add, uint32_t Len)
 {
     sFLASH_ReadBuffer(MAL_Buffer, Add, (uint16_t)Len);
     return MAL_Buffer;
+}
+
+/**
+ * @brief  sFLASH_If_Verify
+ *         Memory verify routine.
+ * @param  Add: Address to be verified to.
+ * @param  Len: Number of data to be verified (in bytes).
+ * @retval MAL_OK if operation is successeful, MAL_FAIL else.
+ */
+uint16_t sFLASH_If_Verify(uint32_t Add, uint32_t Len)
+{
+    return MAL_OK; /* unimplemented, todo */
 }
 
 /**


### PR DESCRIPTION
Tested by making several special versions that inject failures after 15 seconds of runtime, one modified the flash Address that was used in the verify routine.  Typical time to write v0.4.8-rc.6 system part 1 and 2 for electron via `particle update` is about 16.2 seconds before and after new verification process (i.e., it doesn't appear to lengthen the process, most likely due to overall lengthy delays in the DFU process padding the overhead - more on this later...).