### PR TITLE
Proof-of-concept to allow delay(1.5s) in user code

### DIFF
--- a/user/applications/time/application.cpp
+++ b/user/applications/time/application.cpp
@@ -1,0 +1,17 @@
+#include "application.h"
+
+void setup()
+{
+    pinMode(D7, OUTPUT);
+}
+
+void loop()
+{
+    static bool state = false;
+
+    // Use literals like 150ms, 1.5s or 1h in delay
+    delay(1.5s);
+
+    digitalWrite(D7, state);
+    state = !state;
+}

--- a/user/build.mk
+++ b/user/build.mk
@@ -43,7 +43,7 @@ endif
 INCLUDE_DIRS += $(MODULE_PATH)/libraries
 
 CFLAGS += -DSPARK_PLATFORM_NET=$(PLATFORM_NET)
-CPPFLAGS += -std=gnu++11
+CPPFLAGS += -std=gnu++14
 
 BUILTINS_EXCLUDE = malloc free realloc
 CFLAGS += $(addprefix -fno-builtin-,$(BUILTINS_EXCLUDE))

--- a/wiring/inc/spark_wiring_ticks.h
+++ b/wiring/inc/spark_wiring_ticks.h
@@ -35,13 +35,27 @@ extern "C" {
 
 inline system_tick_t millis(void) { return HAL_Timer_Get_Milli_Seconds(); }
 inline unsigned long micros(void) { return HAL_Timer_Get_Micro_Seconds(); }
-void delay(unsigned long ms);
 inline void delayMicroseconds(unsigned int us) { HAL_Delay_Microseconds(us); }
 
 #ifdef __cplusplus
 }
 #endif
 
+void delay(unsigned long ms);
+
+#ifdef __cplusplus
+#include <chrono>
+
+inline void delay(std::chrono::duration<double> duration)
+{
+    delay(std::min(std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(), (int64_t)UINT32_MAX));
+}
+
+#if __cplusplus > 201103L
+// Allow writing delay(1.5s) in user code
+using namespace std::literals::chrono_literals;
+#endif
+#endif
 
 #endif	/* SPARK_WIRING_TICKS_H */
 


### PR DESCRIPTION
C++11 adds user-defined literals and the C++14 standard library defines types for microseconds, milliseconds, seconds, hours. See http://en.cppreference.com/w/cpp/chrono/duration

It would be cool to allow users to use units in their time literals: `delay(1.5s)` or `System.sleep(SLEEP_MODE_DEEP, 1h);`

This is a proof of concept to modify `delay` to accept durations. It requires compiling the user code in C++14 mode.
