### PR TITLE
Add System.benchmark to measure durations in microseconds

### DIFF
--- a/user/tests/wiring/api/platform.cpp
+++ b/user/tests/wiring/api/platform.cpp
@@ -24,5 +24,9 @@ test(system_ticks)
     API_COMPILE(value=System.ticks());
     API_COMPILE(value=System.ticksPerMicrosecond());
     API_COMPILE(System.ticksDelay(30));
+    API_COMPILE(value = System.benchmark([] {
+      for(volatile int i = 0; i < 10000; i++) {}
+    }));
+
     (void)value;
 }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -126,6 +126,7 @@ void handler_event_data_param(system_event_t event, int data, void* param)
 test(system_events)
 {
 	int clicks = system_button_clicks(123);
+	(void)clicks;
 
 	system_event_t my_events =
 			wifi_listen_begin+wifi_listen_end+wifi_listen_update+

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -87,6 +87,13 @@ public:
         uint32_t start = ticks();
         while ((ticks()-start)<duration) {}
     }
+
+    template<typename Work> static uint32_t benchmark(Work _work) {
+      uint32_t start = ticks();
+      _work();
+      return (ticks() - start) / ticksPerMicrosecond();
+    }
+
 #endif
 
     static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0);


### PR DESCRIPTION
I found myself writing code over and over to read System.ticks() before and after a task to benchmark it so I suggest adding `System.benchmark` to do just that.

Example usage:

```
uint32_t duration = System.benchmark([] {
  logFile.flush();
});
Serial.printlnf("SD card flush took %d us", duration);
```
