### PR TITLE
Give a compiler error for long names in Particle.variable/function

### DIFF
--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -64,12 +64,24 @@ test(api_spark_variable) {
     API_COMPILE(Particle.variable("mystring", valueString));
     API_COMPILE(Particle.variable("mystring", constValueString));
     API_COMPILE(Particle.variable("mystring", valueSmartString));
+    
+    // This should gives a compiler error about too long name
+    //API_COMPILE(Particle.variable("mystring123456789", valueString));
 
 }
 
 test(api_spark_function) {
     int (*handler)(String) = NULL;
+
     API_COMPILE(Particle.function("name", handler));
+
+    // This should gives a compiler error about too long name
+    //API_COMPILE(Particle.function("superlongfunctionname", handler));
+
+    // Length not checked until run time
+    API_COMPILE(Particle.function(String("name"), handler));
+    const char *longname = "superlongfunctionname";
+    API_COMPILE(Particle.function(longname, handler));
 
     class MyClass {
       public:

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -41,6 +41,11 @@ typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 #define CLOUD_FN(x,y) (x)
 #endif
 
+#ifndef __XSTRING
+#define	__STRING(x)	#x		/* stringify without expanding x */
+#define	__XSTRING(x)	__STRING(x)	/* expand x, then stringify */
+#endif
+
 class PublishFlag
 {
 public:
@@ -67,90 +72,101 @@ class CloudClass {
 
 public:
 
-
-    static inline bool variable(const char* varKey, const bool& var)
+    template <typename T, class ... Types>
+    static inline bool variable(const T &name, Types ... args)
     {
-        return variable(varKey, &var, BOOLEAN);
+        static_assert(!IsStringLiteral(name) || sizeof(name) <= USER_VAR_KEY_LENGTH + 1,
+            "\n\nIn Particle.variable, name must be less than " __XSTRING(USER_VAR_KEY_LENGTH) " characters\n\n");
+
+        return _variable(name, args...);
     }
 
-    static inline bool variable(const char* varKey, const int& var)
+
+    static inline bool _variable(const char* varKey, const bool& var)
     {
-        return variable(varKey, &var, INT);
+        return _variable(varKey, &var, BOOLEAN);
     }
+
+    static inline bool _variable(const char* varKey, const int& var)
+    {
+        return _variable(varKey, &var, INT);
+    }
+
 #if PLATFORM_ID!=3
     // compiling with gcc this function duplicates the previous one.
-    static inline bool variable(const char* varKey, const int32_t& var)
+    static inline bool _variable(const char* varKey, const int32_t& var)
     {
-        return variable(varKey, &var, INT);
+        return _variable(varKey, &var, INT);
     }
 #endif
-    static inline bool variable(const char* varKey, const uint32_t& var)
+
+    static inline bool _variable(const char* varKey, const uint32_t& var)
     {
-        return variable(varKey, &var, INT);
+        return _variable(varKey, &var, INT);
     }
 
 #if PLATFORM_ID!=3
-    static bool variable(const char* varKey, const float& var)
+    static bool _variable(const char* varKey, const float& var)
     __attribute__((error("Please change the variable from type `float` to `double` for use with Particle.variable().")));
 #endif
 
-    static inline bool variable(const char* varKey, const double& var)
+    static inline bool _variable(const char* varKey, const double& var)
     {
-        return variable(varKey, &var, DOUBLE);
+        return _variable(varKey, &var, DOUBLE);
     }
 
-    static inline bool variable(const char* varKey, const String& var)
+    static inline bool _variable(const char* varKey, const String& var)
     {
-        return variable(varKey, &var, STRING);
+        return _variable(varKey, &var, STRING);
     }
 
-    static inline bool variable(const char* varKey, const char* var)
+    static inline bool _variable(const char* varKey, const char* var)
     {
-        return variable(varKey, var, STRING);
-    }
-
-    template<std::size_t N>
-    static inline bool variable(const char* varKey, const char var[N])
-    {
-        return variable(varKey, var, STRING);
+        return _variable(varKey, var, STRING);
     }
 
     template<std::size_t N>
-    static inline bool variable(const char* varKey, const unsigned char var[N])
+    static inline bool _variable(const char* varKey, const char var[N])
     {
-        return variable(varKey, var, STRING);
+        return _variable(varKey, var, STRING);
     }
 
-    static inline bool variable(const char *varKey, const uint8_t* userVar, const CloudVariableTypeString& userVarType)
+    template<std::size_t N>
+    static inline bool _variable(const char* varKey, const unsigned char var[N])
     {
-        return variable(varKey, (const char*)userVar, userVarType);
+        return _variable(varKey, var, STRING);
     }
 
-    template<typename T> static inline bool variable(const char *varKey, const typename T::varref userVar, const T& userVarType)
+    static inline bool _variable(const char *varKey, const uint8_t* userVar, const CloudVariableTypeString& userVarType)
+    {
+        return _variable(varKey, (const char*)userVar, userVarType);
+    }
+
+    template<typename T> static inline bool _variable(const char *varKey, const typename T::varref userVar, const T& userVarType)
     {
         return CLOUD_FN(spark_variable(varKey, (const void*)userVar, T::value(), NULL), false);
     }
 
-    static inline bool variable(const char *varKey, const int32_t* userVar, const CloudVariableTypeInt& userVarType)
+    static inline bool _variable(const char *varKey, const int32_t* userVar, const CloudVariableTypeInt& userVarType)
     {
         return CLOUD_FN(spark_variable(varKey, (const void*)userVar, CloudVariableTypeInt::value(), NULL), false);
     }
 
-    static inline bool variable(const char *varKey, const uint32_t* userVar, const CloudVariableTypeInt& userVarType)
+    static inline bool _variable(const char *varKey, const uint32_t* userVar, const CloudVariableTypeInt& userVarType)
     {
         return CLOUD_FN(spark_variable(varKey, (const void*)userVar, CloudVariableTypeInt::value(), NULL), false);
     }
 
     // Return clear errors for common misuses of Particle.variable()
     template<typename T, std::size_t N>
-    static inline bool variable(const char *varKey, const T (*userVar)[N], const CloudVariableTypeString& userVarType)
+    static inline bool _variable(const char *varKey, const T (*userVar)[N], const CloudVariableTypeString& userVarType)
     {
         static_assert(sizeof(T)==0, "\n\nUse Particle.variable(\"name\", myVar, STRING); without & in front of myVar\n\n");
         return false;
     }
 
     template<typename T>
-    static inline bool variable(const T *varKey, const String *userVar, const CloudVariableTypeString& userVarType)
+    static inline bool _variable(const T *varKey, const String *userVar, const CloudVariableTypeString& userVarType)
     {
         spark_variable_t extra;
         extra.size = sizeof(extra);
@@ -159,18 +175,27 @@ public:
     }
 
     template<typename T>
-    static inline bool variable(const T *varKey, const String &userVar, const CloudVariableTypeString& userVarType)
+    static inline bool _variable(const T *varKey, const String &userVar, const CloudVariableTypeString& userVarType)
     {
         static_assert(sizeof(T)==0, "\n\nIn Particle.variable(\"name\", myVar, STRING); myVar must be declared as char myVar[] not String myVar\n\n");
         return false;
     }
 
-    static bool function(const char *funcKey, user_function_int_str_t* func)
+    template <typename T, class ... Types>
+    static inline bool function(const T &name, Types ... args)
+    {
+        static_assert(!IsStringLiteral(name) || sizeof(name) <= USER_FUNC_KEY_LENGTH + 1,
+            "\n\nIn Particle.function, name must be less than " __XSTRING(USER_FUNC_KEY_LENGTH) " characters\n\n");
+
+        return _function(name, args...);
+    }
+
+    static bool _function(const char *funcKey, user_function_int_str_t* func)
     {
         return CLOUD_FN(register_function(call_raw_user_function, (void*)func, funcKey), false);
     }
 
-    static bool function(const char *funcKey, user_std_function_int_str_t func, void* reserved=NULL)
+    static bool _function(const char *funcKey, user_std_function_int_str_t func, void* reserved=NULL)
     {
 #ifdef SPARK_NO_CLOUD
         return false;
@@ -188,9 +213,9 @@ public:
     }
 
     template <typename T>
-    static void function(const char *funcKey, int (T::*func)(String), T *instance) {
+    static bool _function(const char *funcKey, int (T::*func)(String), T *instance) {
       using namespace std::placeholders;
-      function(funcKey, std::bind(func, instance, _1));
+      return _function(funcKey, std::bind(func, instance, _1));
     }
 
     inline bool publish(const char *eventName, PublishFlag eventType=PUBLIC)
@@ -306,6 +331,12 @@ private:
     {
         const String* s = (const String*)var;
         return s->c_str();
+    }
+
+    // Test if the paramater a regular C "string" literal
+    template <typename T>
+    constexpr static bool IsStringLiteral(const T& param) {
+      return std::is_array<T>::value && std::is_same<typename std::remove_extent<T>::type, char>::value;
     }
 };
 


### PR DESCRIPTION
A common error is to call `Particle.function("mylongfunction", ...)` with a name longer than 12 characters and overlook to check the return value. It will compile and silently ignore the call at run time.

This PR adds a compile-time check for the length of the name parameter of `Particle.function()` and `Particle.variable()` when the name is a static string literal (type `char [N]`). If the parameter is a dynamic string (type `char *`) or `String` then no check will be done at compile time.