### PR TITLE
Increased stack size and stack overflow detection for Electron

### DIFF
--- a/hal/src/electron/FreeRTOSConfig.h
+++ b/hal/src/electron/FreeRTOSConfig.h
@@ -154,6 +154,10 @@ configKERNEL_INTERRUPT_PRIORITY setting.  Here 15 corresponds to the lowest
 NVIC value of 255. */
 #define configLIBRARY_KERNEL_INTERRUPT_PRIORITY	15
 
+/* Enable stack overflow detection for debug builds (see rtos_hook.cpp) */
+#ifdef DEBUG_BUILD
+# define configCHECK_FOR_STACK_OVERFLOW 2
+#endif
 
 #define xPortPendSVHandler PendSV_Handler
 #define vPortSVCHandler SVC_Handler

--- a/hal/src/electron/rtos_hook.cpp
+++ b/hal/src/electron/rtos_hook.cpp
@@ -1,0 +1,13 @@
+#include "FreeRTOS.h"
+#include "task.h"
+#include "service_debug.h"
+
+extern "C" {
+
+#ifdef DEBUG_BUILD
+void vApplicationStackOverflowHook(TaskHandle_t, char*) {
+    PANIC(StackOverflow, "Stack overflow detected");
+}
+#endif
+
+} // extern "C"

--- a/hal/src/photon/rtos_hook.cpp
+++ b/hal/src/photon/rtos_hook.cpp
@@ -1,0 +1,11 @@
+#include "FreeRTOS.h"
+#include "task.h"
+#include "service_debug.h"
+
+extern "C" {
+
+void vApplicationStackOverflowHook(xTaskHandle, char*) {
+    PANIC(StackOverflow, "Stack overflow detected");
+}
+
+} // extern "C"

--- a/services/inc/panic_codes.h
+++ b/services/inc/panic_codes.h
@@ -26,3 +26,4 @@ def_panic_codes(Software,RGB_COLOR_RED,AssertionFailure)
 def_panic_codes(Software,RGB_COLOR_RED,InvalidCase)
 def_panic_codes(Software,RGB_COLOR_RED,PureVirtualCall)
 
+def_panic_codes(System,RGB_COLOR_RED,StackOverflow)

--- a/system/src/system_threading.cpp
+++ b/system/src/system_threading.cpp
@@ -7,6 +7,15 @@
 
 
 #if PLATFORM_THREADING
+
+#if HAL_PLATFORM_CLOUD_UDP
+// Electron uses larger stack size to workaround stack overflow problem that occurs during
+// handshake in multithreaded configuration
+#define THREAD_STACK_SIZE 4*1024
+#else
+#define THREAD_STACK_SIZE 3*1024
+#endif
+
 void system_thread_idle()
 {
     Spark_Idle_Events(true);
@@ -16,7 +25,7 @@ ActiveObjectThreadQueue SystemThread(ActiveObjectConfiguration(system_thread_idl
 			100, /* take timeout */
 			0x7FFFFFFF, /* put timeout - wait forever */
 			50, /* queue size */
-			3*1024 /* stack size */));
+			THREAD_STACK_SIZE /* stack size */)); // TODO: Use this value for threads spawned by ActiveObjectBase
 
 /**
  * Implementation to support gthread's concurrency primitives.
@@ -94,7 +103,7 @@ namespace std {
         thread_startup startup;
         startup.call = base.get();
         startup.started = false;
-        if (os_thread_create(&_M_id._M_thread, "std::thread", OS_THREAD_PRIORITY_DEFAULT, invoke_thread, &startup, 1024*4)) {
+        if (os_thread_create(&_M_id._M_thread, "std::thread", OS_THREAD_PRIORITY_DEFAULT, invoke_thread, &startup, THREAD_STACK_SIZE)) {
             PANIC(AssertionFailure, "%s %s", __FILE__, __LINE__);
         }
         else {  // C++ ensure the thread has started execution, as required by the standard

--- a/system/src/system_threading.cpp
+++ b/system/src/system_threading.cpp
@@ -94,7 +94,7 @@ namespace std {
         thread_startup startup;
         startup.call = base.get();
         startup.started = false;
-        if (os_thread_create(&_M_id._M_thread, "std::thread", OS_THREAD_PRIORITY_DEFAULT, invoke_thread, &startup, 1024*3)) {
+        if (os_thread_create(&_M_id._M_thread, "std::thread", OS_THREAD_PRIORITY_DEFAULT, invoke_thread, &startup, 1024*4)) {
             PANIC(AssertionFailure, "%s %s", __FILE__, __LINE__);
         }
         else {  // C++ ensure the thread has started execution, as required by the standard


### PR DESCRIPTION
This PR fixes #821 by increasing stack size for threads created via `std::thread` wrapper and adds FreeRTOS hook for stack overflow detection -- latter is enabled only for debug builds on Electron currently (thanks to @avtolstoy for pointing me out).