### PR TITLE
Force socketFree() when the socket is remotely closed on Electron

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -288,9 +288,8 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                 } else if ((sscanf(cmd, "UUSOCL: %d", &a) == 1)) {
                     int socket = _findSocket(a);
                     DEBUG_D("Socket %d: handle %d closed by remote host\r\n", socket, a);
-                    if ((socket != MDM_SOCKET_ERROR) && _sockets[socket].connected) {
-                        _sockets[socket].open = false;
-                        _sockets[socket].connected = false;
+                    if (socket != MDM_SOCKET_ERROR) {
+                        _socketFree(socket);
                     }
                 }
 

--- a/user/tests/app/socket_create/socket_create.cpp
+++ b/user/tests/app/socket_create/socket_create.cpp
@@ -1,0 +1,74 @@
+/*
+ * Problem: On the Electron you can create TCP or UDP sockets and once you get to 7 total,
+ * the socket_create() function won’t return valid handles.  This will not knock
+ * the Electron off the cloud.  If you use disconnect from the cloud, then use up
+ * all the sockets, then try to reconnect, it attempts to recover, can’t, so it
+ * disconnects and resets the Cellular module which generates a URC for socket closed
+ * remotely, but the system did not free up the sockets because they were never set
+ * to a .connected status.  Each time the system then tries to allocate a new socket
+ * for the Cloud, it finds that they are all in use so the system is stuck with all
+ * sockets open (but not really, they were remotely closed).
+ *
+ * Solution: Force socketFree() when the socket is remotely closed.
+ *
+ * Test: disconnect from the Cloud, and use up all available sockets.  Then reconnect
+ * and watch the system attempt to recover by power cycling the modem which causes
+ * all sockets to be remotely disconnected.  They are freed and the Cloud socket can
+ * be created and connected.
+ */
+#include "application.h"
+#include "socket_hal.h"
+
+// ALL_LEVEL, TRACE_LEVEL, DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, PANIC_LEVEL, NO_LOG_LEVEL
+SerialDebugOutput debugOutput(9600, ALL_LEVEL);
+
+SYSTEM_MODE(AUTOMATIC);
+int port = 9000;
+
+void setup()
+{
+    Serial.begin(9600);
+    Serial.println("PRESS ENTER");
+    while (!Serial.available()) Particle.process();
+    while (Serial.available()) Serial.read(); // Flush the input buffer
+}
+
+void loop()
+{
+    if (Serial.available() > 0)
+    {
+        char c = Serial.read();
+        Serial.printf("Hey, you said \'%c\', so I'm gunna: ", c);
+        if (c == 't') {
+            Serial.print("Create a TCP socket: ");
+            int socket_handle = socket_create(AF_INET, SOCK_STREAM, IPPROTO_TCP, port++, NIF_DEFAULT);
+            if (socket_handle_valid(socket_handle)) {
+                Serial.printlnf("%d TCP socket created!", socket_handle);
+            }
+            else {
+                Serial.printlnf("%d TCP socket not created!", socket_handle);
+            }
+        }
+        if (c == 'u') {
+            Serial.print("Create a UDP socket: ");
+            int socket_handle = socket_create(AF_INET, SOCK_STREAM, IPPROTO_UDP, port++, NIF_DEFAULT);
+            if (socket_handle_valid(socket_handle)) {
+                Serial.printlnf("%d UDP socket created!", socket_handle);
+            }
+            else {
+                Serial.printlnf("%d UDP socket not created!", socket_handle);
+            }
+        }
+        else if(c == 'C') {
+            Particle.connect();
+        }
+        else if(c == 'c') {
+            Particle.disconnect();
+        }
+        else {
+            Serial.println("ignore you because you're not speaking my language!");
+        }
+        while (Serial.available()) Serial.read(); // Flush the input buffer
+    }
+
+}

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -1,0 +1,85 @@
+/**
+ ******************************************************************************
+  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "socket_hal.h"
+
+#if Wiring_Cellular == 1
+
+/* Scenario: The device will connect to the Cloud even when all
+ *           TCP socket types are consumed
+ *
+ * Given the device is currently disconnected from the Cloud
+ * When all available TCP sockets are consumed
+ * And the device attempts to connect to the Cloud
+ * Then the device overcomes this socket obstacle and connects to the Cloud
+ */
+void disconnect_from_cloud(system_tick_t timeout)
+{
+    Particle.disconnect();
+    waitFor(Particle.disconnected, timeout);
+}
+void connect_to_cloud(system_tick_t timeout)
+{
+    Particle.connect();
+    waitFor(Particle.connected, timeout);
+}
+void consume_all_sockets(uint8_t protocol)
+{
+    static int port = 9000;
+    int socket_handle;
+    do {
+        socket_handle = socket_create(AF_INET, SOCK_STREAM, protocol==IPPROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP, port++, NIF_DEFAULT);
+    } while(socket_handle_valid(socket_handle));
+}
+test(device_will_connect_to_the_cloud_when_all_tcp_sockets_consumed) {
+    //Serial.println("the device will connect to the cloud when all tcp sockets are consumed");
+    // Given the device is currently disconnected from the Cloud
+    disconnect_from_cloud(30*1000);
+    // When all available TCP sockets are consumed
+    consume_all_sockets(IPPROTO_TCP);
+    // And the device attempts to connect to the Cloud
+    Particle.connect();
+    // Then the device overcomes this socket obstacle and connects to the Cloud
+    connect_to_cloud(60*1000);
+    assertEqual(Particle.connected(), true);
+}
+/* Scenario: The device will connect to the Cloud even when all
+ *           UDP socket types are consumed
+ *
+ * Given the device is currently disconnected from the Cloud
+ * When all available UDP sockets are consumed
+ * And the device attempts to connect to the Cloud
+ * Then the device overcomes this socket obstacle and connects to the Cloud
+ */
+test(device_will_connect_to_the_cloud_when_all_udp_sockets_consumed) {
+    //Serial.println("the device will connect to the cloud when all udp sockets are consumed");
+    // Given the device is currently disconnected from the Cloud
+    disconnect_from_cloud(30*1000);
+    // When all available UDP sockets are consumed
+    consume_all_sockets(IPPROTO_UDP);
+    // And the device attempts to connect to the Cloud
+    Particle.connect();
+    // Then the device overcomes this socket obstacle and connects to the Cloud
+    connect_to_cloud(60*1000);
+    assertEqual(Particle.connected(), true);
+}
+
+#endif


### PR DESCRIPTION
```
/*
 * Problem: On the Electron you can create TCP or UDP sockets and once you get to 7 total,
 * the socket_create() function won’t return valid handles.  This will not knock
 * the Electron off the cloud.  If you use disconnect from the cloud, then use up
 * all the sockets, then try to reconnect, it attempts to recover, can’t, so it
 * disconnects and resets the Cellular module which generates a URC for socket closed
 * remotely, but the system did not free up the sockets because they were never set
 * to a .connected status.  Each time the system then tries to allocate a new socket
 * for the Cloud, it finds that they are all in use so the system is stuck with all
 * sockets open (but not really, they were remotely closed).
 *
 * Solution: Force socketFree() when the socket is remotely closed.
 *
 * Test: disconnect from the Cloud, and use up all available sockets.  Then reconnect
 * and watch the system attempt to recover by power cycling the modem which causes
 * all sockets to be remotely disconnected.  They are freed and the Cloud socket can
 * be created and connected.
 */
```
>See test app