### PR TITLE
Cellular: Add basic support for ublox File System AT-commands

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -182,8 +182,8 @@ int cellular_file_write(const char* filename, const char* buf, int len, void* re
  * Read a file from the cellular module
  *
  * @param filename: the filename of the file to be downloaded.
- *        buf: buffer into which the file is written
- *        len: lnumber of bytes that should be read. 
+ *        buf: buffer into which the file is written.
+ *        len: number of bytes that should be read.
  *        reserved: pass NULL. Allows future expansion.
  *
  * @returns number of bytes read

--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -158,9 +158,49 @@ cellular_result_t cellular_signal(CellularSignalHal &signal, void* reserved);
 
 /**
  * Send an AT command and wait for response, optionally specify a callback function to parse the results
+ *
+ * @note maxmimal length of the resulting command is currently 256 bytes
  */
 cellular_result_t cellular_command(_CALLBACKPTR_MDM cb, void* param,
                          system_tick_t timeout_ms, const char* format, ...);
+
+/** 
+ * Write a file to the cellular module
+ *
+ * @param filename: the filename used to store the file. Max length is 47 for SARA-Gxxx and the currently used SARA-U modules
+ *        buf: buffer that is written
+ *        len: len of buf
+ *        reserved: pass NULL. Allows future expansion.
+ *
+ * @returns number of bytes written
+ *
+ * @note if an existing file is overwritten depends on the module. SARA-[GU]xxx does not overwrite files.
+ */
+int cellular_file_write(const char* filename, const char* buf, int len, void* reserved);
+
+/** 
+ * Read a file from the cellular module
+ *
+ * @param filename: the filename of the file to be downloaded.
+ *        buf: buffer into which the file is written
+ *        len: lnumber of bytes that should be read. 
+ *        reserved: pass NULL. Allows future expansion.
+ *
+ * @returns number of bytes read
+ * 
+ * @note there is currently no way to get the file size of the file, but to use +ULSTFILE directly
+ */
+int cellular_file_read(const char* filename, char* buf, int len, void* reserved);
+
+/** 
+ * Delete a file from the cellular module
+ *
+ * @param filename: the filename of the file to be deleted
+ *        reserved: pass NULL. Allows future expansion.
+ * 
+ */
+cellular_result_t cellular_file_delete(const char* filename, void* reserved);
+
 
 #ifdef __cplusplus
 }

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -51,6 +51,9 @@ DYNALIB_FN(hal_cellular, inet_gethostbyname)
 DYNALIB_FN(hal_cellular, inet_ping)
 DYNALIB_FN(hal_cellular, cellular_signal)
 DYNALIB_FN(hal_cellular, cellular_command)
+DYNALIB_FN(hal_cellular, cellular_file_write)
+DYNALIB_FN(hal_cellular, cellular_file_read)
+DYNALIB_FN(hal_cellular, cellular_file_delete)
 
 DYNALIB_END(hal_cellular)
 

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -137,3 +137,18 @@ cellular_result_t cellular_command(_CALLBACKPTR_MDM cb, void* param,
 
     return electronMDM.waitFinalResp((MDMParser::_CALLBACKPTR)cb, (void*)param, timeout_ms);
 }
+
+int cellular_file_write(const char* filename, const char* buf, int len, void* reserved) 
+{
+    return electronMDM.writeFile(filename, buf, len);
+}
+
+int cellular_file_read(const char* filename, char* buf, int len, void* reserved) 
+{
+    return electronMDM.readFile(filename, buf, len);
+}
+
+cellular_result_t cellular_file_delete(const char* filename, void* reserved) 
+{
+    return electronMDM.delFile(filename);
+}

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -140,15 +140,27 @@ cellular_result_t cellular_command(_CALLBACKPTR_MDM cb, void* param,
 
 int cellular_file_write(const char* filename, const char* buf, int len, void* reserved) 
 {
+    if (!filename || !buf || !len) {
+        return -1;
+    }
+
     return electronMDM.writeFile(filename, buf, len);
 }
 
 int cellular_file_read(const char* filename, char* buf, int len, void* reserved) 
 {
+    if (!filename || !buf || !len) {
+        return -1;
+    }
+
     return electronMDM.readFile(filename, buf, len);
 }
 
 cellular_result_t cellular_file_delete(const char* filename, void* reserved) 
 {
+    if (!filename) {
+        return -1;
+    }
+    
     return electronMDM.delFile(filename);
 }


### PR DESCRIPTION
Export file read/write/del functions from `mdm_hal` through the `cellular` dynalib, as the AT commands are quite cumbersome to work with (especially `+UDWNFILE` with its prompt)

---
- [ ] Check CLA for signature
- [ ] Review code
- [ ] Test on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md
