### PR TITLE
add pgm_read_word() macro for easier porting

### DIFF
--- a/wiring/inc/spark_wiring_arduino.h
+++ b/wiring/inc/spark_wiring_arduino.h
@@ -29,8 +29,10 @@
 #define vsnprintf_P vsnprintf
 #define PROGMEM
 #define PSTR(x) (x)
-#define pgm_read_byte(x)  (*(x))
-#define pgm_read_word(x)  ((uint16_t)(*(x)))
+#define pgm_read_byte(x)      (*(x))
+#define pgm_read_word(x)      ((uint16_t)(*(x)))
+#define pgm_read_byte_near(x) (*(x))
+#define pgm_read_word_near(x) ((uint16_t)(*(x)))
 
 
 

--- a/wiring/inc/spark_wiring_arduino.h
+++ b/wiring/inc/spark_wiring_arduino.h
@@ -30,6 +30,7 @@
 #define PROGMEM
 #define PSTR(x) (x)
 #define pgm_read_byte(x)  (*(x))
+#define pgm_read_word(x)  ((uint16_t)(*(x)))
 
 
 


### PR DESCRIPTION
It has been a few times members couldn't understand why `pgm_read_byte()` worked but `pgm_read_word()` not.