### PR TITLE
don't block application when OTA happens and updates are disabled. 

### DIFF
--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -113,4 +113,4 @@ void system_unsubscribe_event(system_event_t events, system_event_handler_t* han
  * @param data
  * @param pointer
  */
-void system_notify_event(system_event_t event, uint32_t data=0, void* pointer=nullptr, void (*fn)()=nullptr);
+void system_notify_event(system_event_t event, uint32_t data=0, void* pointer=nullptr, void (*fn)(void* data)=nullptr, void* fndata=nullptr);

--- a/system/src/system_event.cpp
+++ b/system/src/system_event.cpp
@@ -87,9 +87,9 @@ void system_unsubscribe_event(system_event_t events, system_event_handler_t* han
  * @param data
  * @param pointer
  */
-void system_notify_event(system_event_t event, uint32_t data, void* pointer, void (*fn)())
+void system_notify_event(system_event_t event, uint32_t data, void* pointer, void (*fn)(void* data), void* fndata)
 {
-    APPLICATION_THREAD_CONTEXT_ASYNC(system_notify_event(event, data, pointer, fn));
+    APPLICATION_THREAD_CONTEXT_ASYNC(system_notify_event(event, data, pointer, fn, fndata));
     // run event notifications on the application thread
 
     for (const SystemEventSubscription& subscription : subscriptions)
@@ -97,7 +97,7 @@ void system_notify_event(system_event_t event, uint32_t data, void* pointer, voi
         subscription.notify(event, data, pointer);
     }
     if (fn)
-        fn();
+        fn(fndata);
 }
 
 

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <stddef.h>
+#include "spark_wiring_cloud.h"
 #include "spark_wiring_system.h"
 #include "spark_wiring_stream.h"
 #include "spark_wiring_rgb.h"
@@ -180,6 +181,12 @@ uint32_t timeRemaining(uint32_t start, uint32_t duration)
     return (elapsed>=duration) ? 0 : duration-elapsed;
 }
 
+void set_flag(void* flag)
+{
+	volatile uint8_t* p = (volatile uint8_t*)flag;
+	*p = true;
+}
+
 int Spark_Prepare_For_Firmware_Update(FileTransfer::Descriptor& file, uint32_t flags, void* reserved)
 {
     if (file.store==FileTransfer::Store::FIRMWARE)
@@ -200,10 +207,15 @@ int Spark_Prepare_For_Firmware_Update(FileTransfer::Descriptor& file, uint32_t f
     else {
         uint32_t start = HAL_Timer_Milliseconds();
         system_set_flag(SYSTEM_FLAG_OTA_UPDATE_PENDING, 1, nullptr);
-        system_notify_event(firmware_update_pending);
-        if (waitFor(System.updatesEnabled, timeRemaining(start, 30000)))
+
+        volatile bool flag = false;
+        system_notify_event(firmware_update_pending, 0, nullptr, set_flag, (void*)&flag);
+
+        System.waitCondition([&flag]{return flag;}, timeRemaining(start, 30000));
+
+        system_set_flag(SYSTEM_FLAG_OTA_UPDATE_PENDING, 0, nullptr);
+        	if (System.updatesEnabled())		// application event is handled asynchronously
         {
-            system_set_flag(SYSTEM_FLAG_OTA_UPDATE_PENDING, 0, nullptr);
             RGB.control(true);
             RGB.color(RGB_COLOR_MAGENTA);
             SPARK_FLASH_UPDATE = 1;
@@ -212,7 +224,9 @@ int Spark_Prepare_For_Firmware_Update(FileTransfer::Descriptor& file, uint32_t f
             HAL_FLASH_Begin(file.file_address, file.file_length, NULL);
         }
         else
+        {
             result = 1;     // updates disabled
+        }
     }
     return result;
 }
@@ -232,7 +246,7 @@ inline bool canShutdown()
 	return (System.resetPending() && System.resetEnabled());
 }
 
-void system_shutdown_if_enabled()
+void system_shutdown_if_enabled(void* data=nullptr)
 {
     // shutdown if user initiated poweroff or system reset is allowed
     if (canShutdown())


### PR DESCRIPTION
extend system event notification to allow a data argument to be passed to the func…tion. This is used to stall the system thread waiting for the application (but not indefinitely, as that would create a potential deadlock.)  The system thread only blocks until the application event has been handled. Previously it would block until system updates were enabled, for a maximum of 30 seconds.

https://community.particle.io/t/dashboard-disableupdates-causes-user-code-to-stop-running/19731/7