### PR TITLE
cloud sleep - waits for all outgoing confirmable UDP messages to be sent

### DIFF
--- a/communication/src/build.mk
+++ b/communication/src/build.mk
@@ -22,6 +22,7 @@ CPPSRC += $(TARGET_SRC_PATH)/eckeygen.cpp
 CPPSRC += $(TARGET_SRC_PATH)/lightssl_message_channel.cpp
 CPPSRC += $(TARGET_SRC_PATH)/dtls_message_channel.cpp
 CPPSRC += $(TARGET_SRC_PATH)/dtls_protocol.cpp
+CPPSRC += $(TARGET_SRC_PATH)/lightssl_protocol.cpp
 CPPSRC += $(TARGET_SRC_PATH)/protocol.cpp
 CPPSRC += $(TARGET_SRC_PATH)/messages.cpp
 CPPSRC += $(TARGET_SRC_PATH)/chunked_transfer.cpp

--- a/communication/src/coap_channel.h
+++ b/communication/src/coap_channel.h
@@ -29,7 +29,10 @@ namespace particle
 namespace protocol
 {
 
-
+/**
+ * Decorates a MessageChannel with message ID management as required by CoAP.
+ * When a message is sent that doesn't have an assigned ID, it is assigned the next available ID.
+ */
 template <typename T>
 class CoAPChannel : public T
 {
@@ -338,6 +341,11 @@ public:
 		clear();
 	}
 
+	bool has_messages()
+	{
+		return head!=nullptr;
+	}
+
 	/**
 	 * Retrieves the current confirmable message that is still
 	 * waiting acknowledgement.
@@ -606,16 +614,48 @@ public:
 	 */
 	ProtocolError receive(Message& msg) override
 	{
+		return receive(msg, true);
+	}
+
+	/**
+	 * Pulls messages from the message channel
+	 */
+	ProtocolError receive_confirmations()
+	{
+		Message msg;
+		channel::create(msg);
+		return receive(msg, false);
+	}
+
+	bool has_unacknowledged_requests()
+	{
+		return client.has_messages();
+	}
+
+	/**
+	 * Pulls messages from the channel and stores it in a message store for
+	 * reliable receipt and retransmission.
+	 *
+	 * @param msg			The message received
+	 * @param requests		When true, both requests and responses are retreived. When false, only responses are retrieved.
+	 */
+	ProtocolError receive(Message& msg, bool requests)
+	{
 		ProtocolError error = channel::receive(msg);
 		if (!error && msg.length())
 		{
+			// is it a request from the server or a response from the server?
+			// responses are paired with the original client request
 			CoAPMessageStore& store = msg.is_request() ? server : client;
-			error = store.receive(msg, delegateChannel, millis());
+			if (!msg.is_request() || requests) {
+				error = store.receive(msg, delegateChannel, millis());
+			}
 		}
 		client.process(millis(), delegateChannel);
 		server.process(millis(), delegateChannel);
 		return error;
 	}
+
 };
 
 

--- a/communication/src/communication_dynalib.h
+++ b/communication/src/communication_dynalib.h
@@ -26,7 +26,7 @@
 #include "protocol_selector.h"
 #include "hal_platform.h"
 
-#ifdef  __cplusplus
+#ifdef	__cplusplus
 extern "C" {
 #endif
 
@@ -63,7 +63,11 @@ DYNALIB_FN(BASE_IDX + 0, communication, spark_protocol_remove_event_handlers, vo
 #if defined(PARTICLE_PROTOCOL) && HAL_PLATFORM_CLOUD_UDP
 DYNALIB_FN(BASE_IDX + 1, communication, gen_ec_key, int(uint8_t*, size_t, int(*)(void*, uint8_t*, size_t), void*))
 DYNALIB_FN(BASE_IDX + 2, communication, extract_public_ec_key, int(uint8_t*, size_t, const uint8_t*))
+#define BASE_IDX2 (BASE_IDX+3)
+#else
+#define BASE_IDX2 (BASE_IDX+1)
 #endif
+DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_command, int(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved))
 
 DYNALIB_END(communication)
 

--- a/communication/src/dtls_protocol.cpp
+++ b/communication/src/dtls_protocol.cpp
@@ -50,4 +50,21 @@ void DTLSProtocol::init(const char *id,
 }
 
 
+void DTLSProtocol::sleep(uint32_t timeout)
+{
+	system_tick_t start = millis();
+	INFO("waiting for Confirmed messages to be sent.");
+	while (channel.has_unacknowledged_requests() && (millis()-start)<timeout)
+	{
+		ProtocolError error = channel.receive_confirmations();
+		if (error)
+		{
+			WARN("error receiving acknowledgements: %d", error);
+			break;
+		}
+	}
+	INFO("all Confirmed messages sent.");
+}
+
+
 }}

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -52,7 +52,7 @@ public:
 	void init(const char *id,
 	          const SparkKeys &keys,
 	          const SparkCallbacks &callbacks,
-	          const SparkDescriptor &descriptor);
+	          const SparkDescriptor &descriptor) override;
 
 	size_t build_hello(Message& message, bool ota_updated) override
 	{

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -54,7 +54,7 @@ public:
 	          const SparkCallbacks &callbacks,
 	          const SparkDescriptor &descriptor);
 
-	size_t build_hello(Message& message, bool ota_updated)
+	size_t build_hello(Message& message, bool ota_updated) override
 	{
 		product_details_t deets;
 		deets.size = sizeof(deets);
@@ -66,7 +66,7 @@ public:
 		return len;
 	}
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data)
+	virtual void command(ProtocolCommands::Enum command, uint32_t data) override
 	{
 		switch (command)
 		{
@@ -84,15 +84,7 @@ public:
 	/**
 	 * Ensures that all outstanding sent coap messages have been acknowledged.
 	 */
-	void sleep(uint32_t timeout=60000)
-	{
-		system_tick_t start = millis();
-		while (channel.has_unacknowledged_requests() && (millis()-start)<timeout)
-		{
-			if (channel.receive_confirmations())
-				break;
-		}
-	}
+	void sleep(uint32_t timeout=60000);
 
 	void wake()
 	{

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -66,6 +66,38 @@ public:
 		return len;
 	}
 
+	virtual void command(ProtocolCommands::Enum command, uint32_t data)
+	{
+		switch (command)
+		{
+		case ProtocolCommands::SLEEP:
+			sleep();
+			break;
+		case ProtocolCommands::WAKE:
+			wake();
+			break;
+		}
+	}
+
+
+
+	/**
+	 * Ensures that all outstanding sent coap messages have been acknowledged.
+	 */
+	void sleep(uint32_t timeout=60000)
+	{
+		system_tick_t start = millis();
+		while (channel.has_unacknowledged_requests() && (millis()-start)<timeout)
+		{
+			if (channel.receive_confirmations())
+				break;
+		}
+	}
+
+	void wake()
+	{
+		ping();
+	}
 };
 
 

--- a/communication/src/lightssl_protocol.cpp
+++ b/communication/src/lightssl_protocol.cpp
@@ -1,0 +1,25 @@
+/**
+ ******************************************************************************
+ Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation, either
+ version 3 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#include "lightssl_protocol.h"
+
+namespace particle { namespace protocol {
+	void LightSSLProtocol::command(ProtocolCommands::Enum command, uint32_t data) { }
+
+}}

--- a/communication/src/lightssl_protocol.h
+++ b/communication/src/lightssl_protocol.h
@@ -50,7 +50,7 @@ public:
 	void init(const char *id,
 	          const SparkKeys &keys,
 	          const SparkCallbacks &callbacks,
-	          const SparkDescriptor &descriptor)
+	          const SparkDescriptor &descriptor) override
 	{
 		set_protocol_flags(REQUIRE_HELLO_RESPONSE);
 
@@ -76,9 +76,7 @@ public:
 		return len;
 	}
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data)
-	{
-	}
+	virtual void command(ProtocolCommands::Enum command, uint32_t data) override;
 
 };
 

--- a/communication/src/lightssl_protocol.h
+++ b/communication/src/lightssl_protocol.h
@@ -64,7 +64,7 @@ public:
         initialize_ping(15000,10000);
 	}
 
-	size_t build_hello(Message& message, bool ota_updated)
+	size_t build_hello(Message& message, bool ota_updated) override
 	{
 		product_details_t deets;
 		deets.size = sizeof(deets);
@@ -74,6 +74,10 @@ public:
 				ota_updated, PLATFORM_ID, deets.product_id,
 				deets.product_version, false, nullptr, 0);
 		return len;
+	}
+
+	virtual void command(ProtocolCommands::Enum command, uint32_t data)
+	{
 	}
 
 };

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -392,7 +392,7 @@ public:
 
 	system_tick_t millis() { return callbacks.millis(); }
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data);
+	virtual void command(ProtocolCommands::Enum command, uint32_t data)=0;
 
 };
 

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -390,6 +390,10 @@ public:
 		return -1;
 	}
 
+	inline system_tick_t millis() { return callbacks.millis(); }
+
+	virtual void command(ProtocolCommands::Enum command, uint32_t data) {}
+
 };
 
 }

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -390,9 +390,9 @@ public:
 		return -1;
 	}
 
-	inline system_tick_t millis() { return callbacks.millis(); }
+	system_tick_t millis() { return callbacks.millis(); }
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data) {}
+	virtual void command(ProtocolCommands::Enum command, uint32_t data);
 
 };
 

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -132,7 +132,11 @@ void spark_protocol_get_product_details(ProtocolFacade* protocol, product_detail
     protocol->get_product_details(*details);
 }
 
-
+int spark_protocol_command(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved)
+{
+	protocol->command(cmd, data);
+	return 0;
+}
 
 
 #else
@@ -217,5 +221,11 @@ void spark_protocol_get_product_details(SparkProtocol* protocol, product_details
     (void)reserved;
     protocol->get_product_details(*details);
 }
+
+int spark_protocol_command(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved)
+{
+	return 0;
+}
+
 
 #endif

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -169,6 +169,17 @@ void spark_protocol_set_product_id(ProtocolFacade* protocol, product_id_t produc
 void spark_protocol_set_product_firmware_version(ProtocolFacade* protocol, product_firmware_version_t product_firmware_version, unsigned int param=0, void* reserved = NULL);
 void spark_protocol_get_product_details(ProtocolFacade* protocol, product_details_t* product_details, void* reserved=NULL);
 
+namespace ProtocolCommands {
+	enum Enum {
+		SLEEP,
+		WAKE
+	};
+};
+
+
+int spark_protocol_command(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data=0, void* reserved=NULL);
+
+
 /**
  * Decrypt a buffer using the given public key.
  * @param ciphertext        The ciphertext to decrypt

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1107,3 +1107,13 @@ bool system_cloud_active()
 #endif
     return true;
 }
+
+void Spark_Sleep(void)
+{
+	spark_protocol_command(sp, ProtocolCommands::SLEEP);
+}
+
+void Spark_Wake(void)
+{
+	spark_protocol_command(sp, ProtocolCommands::WAKE);
+}

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -39,7 +39,8 @@ void Multicast_Presence_Announcement(void);
 void Spark_Signal(bool on, unsigned, void*);
 void Spark_SetTime(unsigned long dateTime);
 void Spark_Process_Events();
-
+void Spark_Sleep();
+void Spark_Wake();
 extern volatile uint8_t LED_Spark_Signal;
 void LED_Signaling_Override(void);
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -47,7 +47,8 @@ static void network_suspend() {
 #ifndef SPARK_NO_CLOUD
     wakeupState.cloud = spark_connected();
     Spark_Sleep();
-    spark_disconnect();
+    Spark_Disconnect();	// actually disconnect the cloud
+    spark_disconnect();	// flag the system to not automatically connect the cloud
 #endif
     network_off(0, 0, 0, NULL);
 }

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -28,6 +28,7 @@
 #include "rgbled.h"
 #include <stddef.h>
 #include "spark_wiring_fuel.h"
+#include "spark_wiring_system.h"
 #include "spark_wiring_platform.h"
 
 struct WakeupState
@@ -113,6 +114,15 @@ void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds
     network_suspend();
     LED_Off(LED_RGB);
     HAL_Core_Enter_Stop_Mode(wakeUpPin, edgeTriggerMode, seconds);
-    network_resume();
-    Spark_Wake();
+    network_resume();		// asynchronously bring up the network/cloud
+
+    // if single-threaded, managed mode then reconnect to the cloud (for up to 30 seconds)
+    auto mode = system_mode();
+    if (system_thread_get_state(nullptr)==spark::feature::DISABLED && (mode==AUTOMATIC || mode==SEMI_AUTOMATIC) && SPARK_CLOUD_CONNECT) {
+    		waitFor(spark_connected, 60000);
+    }
+
+    if (spark_connected()) {
+    		Spark_Wake();
+    }
 }


### PR DESCRIPTION
protocol sleep/wake commands which allow the caller to wait for all coap confirmable requests to be acknowledged, and allows the comms layer to take action when waking up after sleep.

This is used as part of system sleep to ensure confirmable messages are confirmed before entering sleep.