### PR TITLE
configurable keepalive

### DIFF
--- a/communication/src/communication_dynalib.h
+++ b/communication/src/communication_dynalib.h
@@ -63,12 +63,13 @@ DYNALIB_FN(BASE_IDX + 0, communication, spark_protocol_remove_event_handlers, vo
 #if defined(PARTICLE_PROTOCOL) && HAL_PLATFORM_CLOUD_UDP
 DYNALIB_FN(BASE_IDX + 1, communication, gen_ec_key, int(uint8_t*, size_t, int(*)(void*, uint8_t*, size_t), void*))
 DYNALIB_FN(BASE_IDX + 2, communication, extract_public_ec_key, int(uint8_t*, size_t, const uint8_t*))
-#define BASE_IDX2 (BASE_IDX+3)
+#define BASE_IDX2 (BASE_IDX + 3)
 #else
-#define BASE_IDX2 (BASE_IDX+1)
+#define BASE_IDX2 (BASE_IDX + 1)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property, int(ProtocolFacade*, unsigned, unsigned, void*, void*))
+DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property,
+           int(ProtocolFacade*, unsigned, unsigned, void*, void*))
 
 DYNALIB_END(communication)
 

--- a/communication/src/communication_dynalib.h
+++ b/communication/src/communication_dynalib.h
@@ -63,11 +63,17 @@ DYNALIB_FN(BASE_IDX + 0, communication, spark_protocol_remove_event_handlers, vo
 #if defined(PARTICLE_PROTOCOL) && HAL_PLATFORM_CLOUD_UDP
 DYNALIB_FN(BASE_IDX + 1, communication, gen_ec_key, int(uint8_t*, size_t, int(*)(void*, uint8_t*, size_t), void*))
 DYNALIB_FN(BASE_IDX + 2, communication, extract_public_ec_key, int(uint8_t*, size_t, const uint8_t*))
+#define BASE_IDX2 (BASE_IDX+3)
+#else
+#define BASE_IDX2 (BASE_IDX+1)
 #endif
+
+DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property, int(ProtocolFacade*, unsigned, unsigned, void*, void*))
 
 DYNALIB_END(communication)
 
 #undef BASE_IDX
+#undef BASE_IDX2
 
 #ifdef	__cplusplus
 }

--- a/communication/src/ping.h
+++ b/communication/src/ping.h
@@ -22,7 +22,13 @@ public:
 		this->ping_timeout = timeout;
 	}
 
-	void reset() {
+	void set_interval(system_tick_t interval)
+	{
+		this->ping_interval = interval;
+	}
+
+	void reset()
+	{
 		expecting_ping_ack = false;
 	}
 

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -264,6 +264,11 @@ public:
 		pinger.init(interval, timeout);
 	}
 
+	void set_keepalive(system_tick_t interval)
+	{
+		pinger.set_interval(interval);
+	}
+
 	void set_handlers(CommunicationsHandlers& handlers)
 	{
 		copy_and_init(&this->handlers, sizeof(this->handlers), &handlers, handlers.size);

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -69,12 +69,13 @@ enum DescriptionType {
 	DESCRIBE_ALL = DESCRIBE_SYSTEM | DESCRIBE_APPLICATION
 };
 
-namespace Connection {
-	enum Enum {
-		PING = 0
-	};
+namespace Connection
+{
+enum Enum
+{
+    PING = 0
+};
 }
-
 
 typedef std::function<system_tick_t()> millis_callback;
 typedef std::function<int()> callback;

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -69,6 +69,11 @@ enum DescriptionType {
 	DESCRIBE_ALL = DESCRIBE_SYSTEM | DESCRIBE_APPLICATION
 };
 
+namespace Connection {
+	enum Enum {
+		PING = 0
+	};
+}
 
 
 typedef std::function<system_tick_t()> millis_callback;

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -132,16 +132,15 @@ void spark_protocol_get_product_details(ProtocolFacade* protocol, product_detail
     protocol->get_product_details(*details);
 }
 
-int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, void* datap, void* reserved)
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id,
+                                           unsigned data, void* datap, void* reserved)
 {
-	if (property_id==particle::protocol::Connection::PING)
-	{
-		protocol->set_keepalive(data);
-	}
-	return 0;
+    if (property_id == particle::protocol::Connection::PING)
+    {
+        protocol->set_keepalive(data);
+    }
+    return 0;
 }
-
-
 
 #else
 
@@ -226,10 +225,10 @@ void spark_protocol_get_product_details(SparkProtocol* protocol, product_details
     protocol->get_product_details(*details);
 }
 
-int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, void* datap, void* reserved)
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id,
+                                           unsigned data, void* datap, void* reserved)
 {
-	return 0;
+    return 0;
 }
-
 
 #endif

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -132,6 +132,14 @@ void spark_protocol_get_product_details(ProtocolFacade* protocol, product_detail
     protocol->get_product_details(*details);
 }
 
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, void* datap, void* reserved)
+{
+	if (property_id==particle::protocol::Connection::PING)
+	{
+		protocol->set_keepalive(data);
+	}
+	return 0;
+}
 
 
 
@@ -217,5 +225,11 @@ void spark_protocol_get_product_details(SparkProtocol* protocol, product_details
     (void)reserved;
     protocol->get_product_details(*details);
 }
+
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, void* datap, void* reserved)
+{
+	return 0;
+}
+
 
 #endif

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -169,6 +169,8 @@ void spark_protocol_set_product_id(ProtocolFacade* protocol, product_id_t produc
 void spark_protocol_set_product_firmware_version(ProtocolFacade* protocol, product_firmware_version_t product_firmware_version, unsigned int param=0, void* reserved = NULL);
 void spark_protocol_get_product_details(ProtocolFacade* protocol, product_details_t* product_details, void* reserved=NULL);
 
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, void* datap, void* reserved);
+
 /**
  * Decrypt a buffer using the given public key.
  * @param ciphertext        The ciphertext to decrypt

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -169,7 +169,8 @@ void spark_protocol_set_product_id(ProtocolFacade* protocol, product_id_t produc
 void spark_protocol_set_product_firmware_version(ProtocolFacade* protocol, product_firmware_version_t product_firmware_version, unsigned int param=0, void* reserved = NULL);
 void spark_protocol_get_product_details(ProtocolFacade* protocol, product_details_t* product_details, void* reserved=NULL);
 
-int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, void* datap, void* reserved);
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id,
+                                           unsigned data, void* datap, void* reserved);
 
 /**
  * Decrypt a buffer using the given public key.

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -187,7 +187,7 @@ test(api_spark_connection) {
     API_COMPILE(Particle.process());
 
 #if HAL_PLATFORM_CLOUD_UDP
-    API_COMPILE(Particle.keepAlive(20*60));
+    API_COMPILE(Particle.keepAlive(20 * 60));
 #endif
 }
 

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -185,6 +185,10 @@ test(api_spark_connection) {
     API_COMPILE(Particle.connect());
     API_COMPILE(Particle.disconnect());
     API_COMPILE(Particle.process());
+
+#if HAL_PLATFORM_CLOUD_UDP
+    API_COMPILE(Particle.keepAlive(20*60));
+#endif
 }
 
 test(api_spark_deviceID) {

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -147,21 +147,20 @@ void handler_event_data_param(system_event_t event, int data, void* param)
 
 test(system_events)
 {
-    int clicks = system_button_clicks(123);
+	int clicks = system_button_clicks(123);
+	system_event_t my_events =
+			wifi_listen_begin+wifi_listen_end+wifi_listen_update+
+			setup_begin+setup_end+setup_update+
+			network_credentials+
+			network_status+
+			button_status+button_click+button_final_click+
+			reset+reset_pending+
+			firmware_update+firmware_update_pending+
+			all_events;
 
-    system_event_t my_events =
-        wifi_listen_begin+wifi_listen_end+wifi_listen_update+
-        setup_begin+setup_end+setup_update+
-        network_credentials+
-        network_status+
-        button_status+button_click+button_final_click+
-        reset+reset_pending+
-        firmware_update+firmware_update_pending+
-        all_events;
-
-    API_COMPILE(System.on(my_events, handler));
-    API_COMPILE(System.on(my_events, handler_event));
-    API_COMPILE(System.on(my_events, handler_event_data));
-    API_COMPILE(System.on(my_events, handler_event_data_param));
+	API_COMPILE(System.on(my_events, handler));
+	API_COMPILE(System.on(my_events, handler_event));
+	API_COMPILE(System.on(my_events, handler_event_data));
+	API_COMPILE(System.on(my_events, handler_event_data_param));
     (void)clicks; // avoid unused variable warning
 }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -147,20 +147,16 @@ void handler_event_data_param(system_event_t event, int data, void* param)
 
 test(system_events)
 {
-	int clicks = system_button_clicks(123);
-	system_event_t my_events =
-			wifi_listen_begin+wifi_listen_end+wifi_listen_update+
-			setup_begin+setup_end+setup_update+
-			network_credentials+
-			network_status+
-			button_status+button_click+button_final_click+
-			reset+reset_pending+
-			firmware_update+firmware_update_pending+
-			all_events;
+    int clicks = system_button_clicks(123);
+    system_event_t my_events = wifi_listen_begin + wifi_listen_end + wifi_listen_update +
+                               setup_begin + setup_end + setup_update + network_credentials +
+                               network_status + button_status + button_click + button_final_click +
+                               reset + reset_pending + firmware_update + firmware_update_pending +
+                               all_events;
 
-	API_COMPILE(System.on(my_events, handler));
-	API_COMPILE(System.on(my_events, handler_event));
-	API_COMPILE(System.on(my_events, handler_event_data));
-	API_COMPILE(System.on(my_events, handler_event_data_param));
+    API_COMPILE(System.on(my_events, handler));
+    API_COMPILE(System.on(my_events, handler_event));
+    API_COMPILE(System.on(my_events, handler_event_data));
+    API_COMPILE(System.on(my_events, handler_event_data_param));
     (void)clicks; // avoid unused variable warning
 }

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -301,6 +301,12 @@ public:
     }
     static String deviceID(void) { return SystemClass::deviceID(); }
 
+#if HAL_PLATFORM_CLOUD_UDP
+    static void keepAlive(unsigned sec) {
+        CLOUD_FN(spark_protocol_set_connection_property(sp(), particle::protocol::Connection::PING, sec*1000, nullptr, nullptr),(void)0);
+    }
+#endif
+
 private:
 
     static bool register_function(cloud_function_t fn, void* data, const char* funcKey);
@@ -309,7 +315,7 @@ private:
 
     static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
 
-    ProtocolFacade* sp() { return spark_protocol_instance(); }
+    static ProtocolFacade* sp() { return spark_protocol_instance(); }
 
     bool subscribe_wiring(const char *eventName, wiring_event_handler_t handler, Spark_Subscription_Scope_TypeDef scope, const char *deviceID = NULL)
     {

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -302,8 +302,11 @@ public:
     static String deviceID(void) { return SystemClass::deviceID(); }
 
 #if HAL_PLATFORM_CLOUD_UDP
-    static void keepAlive(unsigned sec) {
-        CLOUD_FN(spark_protocol_set_connection_property(sp(), particle::protocol::Connection::PING, sec*1000, nullptr, nullptr),(void)0);
+    static void keepAlive(unsigned sec)
+    {
+        CLOUD_FN(spark_protocol_set_connection_property(sp(), particle::protocol::Connection::PING,
+                                                        sec * 1000, nullptr, nullptr),
+                 (void)0);
     }
 #endif
 
@@ -315,7 +318,10 @@ private:
 
     static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
 
-    static ProtocolFacade* sp() { return spark_protocol_instance(); }
+    static ProtocolFacade* sp()
+    {
+        return spark_protocol_instance();
+    }
 
     bool subscribe_wiring(const char *eventName, wiring_event_handler_t handler, Spark_Subscription_Scope_TypeDef scope, const char *deviceID = NULL)
     {


### PR DESCRIPTION
adds `Particle.keepAlive(seconds)` for UDP comms platforms (Electron) to allow the application to set the frequency that ping keep-alives are sent.

Example:

```
void setup()
{
   Particle.keepAlive(60*23);  // send keep alive ping every 23 minutes
}
```

A keepalive ping uses ca. 100 bytes of data. 

--

Provides a solution for issue that users with 3rd party SIM's were seeing, certain carriers may have slightly quicker network timeouts, requiring a more frequent ping interval than every 23 minutes (which is the default). 

- [x] Review code
- [x] Test on device
- [x] Add documentation https://github.com/spark/docs/commit/df650146
- [x] Add to changelog