### PR TITLE
Fix return value from WiFi.scan() and WiFi.getCredentials() from exce…

### DIFF
--- a/wiring/src/spark_wiring_wifi.cpp
+++ b/wiring/src/spark_wiring_wifi.cpp
@@ -37,7 +37,7 @@ namespace spark {
     class APArrayPopulator
     {
         WiFiAccessPoint* results;
-        int count;
+
         int index;
 
         void addResult(WiFiAccessPoint* result) {
@@ -52,6 +52,7 @@ namespace spark {
             ((APArrayPopulator*)cookie)->addResult(result);
         }
 
+        int count;
     public:
         APArrayPopulator(WiFiAccessPoint* results, int size) {
             this->results = results;

--- a/wiring/src/spark_wiring_wifi.cpp
+++ b/wiring/src/spark_wiring_wifi.cpp
@@ -66,7 +66,7 @@ namespace spark {
 
         int start()
         {
-            return wlan_scan(callback, this);
+            return std::min(count, wlan_scan(callback, this));
         }
     };
 
@@ -76,7 +76,7 @@ namespace spark {
 
         int start()
         {
-            return wlan_get_credentials(callback, this);
+            return std::min(count, wlan_get_credentials(callback, this));
         }
     };
 


### PR DESCRIPTION
…eding passed in count.

Current examples in the docs for [getCredentials()](https://docs.particle.io/reference/firmware/photon/#getcredentials-) and [scan()](https://docs.particle.io/reference/firmware/photon/#scan-) will overrun the array of WiFiAccessPoint structs since the return value of these functions can exceed the passed in `result_count` parameter. The intuitive behavior (in my opinion, i.e. what I interpreted it would be from the docs before I read the HAL driver source) would be for the `scan()` and `getCredentials()` calls to limit the return value to min(actual number of APs, result_count).