### PR TITLE
cloud sleep - waits for all outgoing confirmable UDP messages to be sent (rebased)

### DIFF
--- a/communication/src/build.mk
+++ b/communication/src/build.mk
@@ -22,6 +22,7 @@ CPPSRC += $(TARGET_SRC_PATH)/eckeygen.cpp
 CPPSRC += $(TARGET_SRC_PATH)/lightssl_message_channel.cpp
 CPPSRC += $(TARGET_SRC_PATH)/dtls_message_channel.cpp
 CPPSRC += $(TARGET_SRC_PATH)/dtls_protocol.cpp
+CPPSRC += $(TARGET_SRC_PATH)/lightssl_protocol.cpp
 CPPSRC += $(TARGET_SRC_PATH)/protocol.cpp
 CPPSRC += $(TARGET_SRC_PATH)/messages.cpp
 CPPSRC += $(TARGET_SRC_PATH)/chunked_transfer.cpp

--- a/communication/src/coap_channel.h
+++ b/communication/src/coap_channel.h
@@ -29,7 +29,10 @@ namespace particle
 namespace protocol
 {
 
-
+/**
+ * Decorates a MessageChannel with message ID management as required by CoAP.
+ * When a message is sent that doesn't have an assigned ID, it is assigned the next available ID.
+ */
 template <typename T>
 class CoAPChannel : public T
 {
@@ -338,6 +341,11 @@ public:
 		clear();
 	}
 
+	bool has_messages()
+	{
+		return head!=nullptr;
+	}
+
 	/**
 	 * Retrieves the current confirmable message that is still
 	 * waiting acknowledgement.
@@ -606,16 +614,48 @@ public:
 	 */
 	ProtocolError receive(Message& msg) override
 	{
+		return receive(msg, true);
+	}
+
+	/**
+	 * Pulls messages from the message channel
+	 */
+	ProtocolError receive_confirmations()
+	{
+		Message msg;
+		channel::create(msg);
+		return receive(msg, false);
+	}
+
+	bool has_unacknowledged_requests()
+	{
+		return client.has_messages();
+	}
+
+	/**
+	 * Pulls messages from the channel and stores it in a message store for
+	 * reliable receipt and retransmission.
+	 *
+	 * @param msg			The message received
+	 * @param requests		When true, both requests and responses are retreived. When false, only responses are retrieved.
+	 */
+	ProtocolError receive(Message& msg, bool requests)
+	{
 		ProtocolError error = channel::receive(msg);
 		if (!error && msg.length())
 		{
+			// is it a request from the server or a response from the server?
+			// responses are paired with the original client request
 			CoAPMessageStore& store = msg.is_request() ? server : client;
-			error = store.receive(msg, delegateChannel, millis());
+			if (!msg.is_request() || requests) {
+				error = store.receive(msg, delegateChannel, millis());
+			}
 		}
 		client.process(millis(), delegateChannel);
 		server.process(millis(), delegateChannel);
 		return error;
 	}
+
 };
 
 

--- a/communication/src/communication_dynalib.h
+++ b/communication/src/communication_dynalib.h
@@ -26,7 +26,7 @@
 #include "protocol_selector.h"
 #include "hal_platform.h"
 
-#ifdef  __cplusplus
+#ifdef	__cplusplus
 extern "C" {
 #endif
 
@@ -70,6 +70,7 @@ DYNALIB_FN(BASE_IDX + 2, communication, extract_public_ec_key, int(uint8_t*, siz
 
 DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property,
            int(ProtocolFacade*, unsigned, unsigned, void*, void*))
+DYNALIB_FN(BASE_IDX2 + 1, communication, spark_protocol_command, int(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved))
 
 DYNALIB_END(communication)
 

--- a/communication/src/dtls_protocol.cpp
+++ b/communication/src/dtls_protocol.cpp
@@ -50,4 +50,21 @@ void DTLSProtocol::init(const char *id,
 }
 
 
+void DTLSProtocol::sleep(uint32_t timeout)
+{
+	system_tick_t start = millis();
+	INFO("waiting for Confirmed messages to be sent.");
+	while (channel.has_unacknowledged_requests() && (millis()-start)<timeout)
+	{
+		ProtocolError error = channel.receive_confirmations();
+		if (error)
+		{
+			WARN("error receiving acknowledgements: %d", error);
+			break;
+		}
+	}
+	INFO("all Confirmed messages sent.");
+}
+
+
 }}

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -52,7 +52,7 @@ public:
 	void init(const char *id,
 	          const SparkKeys &keys,
 	          const SparkCallbacks &callbacks,
-	          const SparkDescriptor &descriptor);
+	          const SparkDescriptor &descriptor) override;
 
 	size_t build_hello(Message& message, bool ota_updated) override
 	{

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -54,7 +54,7 @@ public:
 	          const SparkCallbacks &callbacks,
 	          const SparkDescriptor &descriptor);
 
-	size_t build_hello(Message& message, bool ota_updated)
+	size_t build_hello(Message& message, bool ota_updated) override
 	{
 		product_details_t deets;
 		deets.size = sizeof(deets);
@@ -66,7 +66,7 @@ public:
 		return len;
 	}
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data)
+	virtual void command(ProtocolCommands::Enum command, uint32_t data) override
 	{
 		switch (command)
 		{
@@ -84,15 +84,7 @@ public:
 	/**
 	 * Ensures that all outstanding sent coap messages have been acknowledged.
 	 */
-	void sleep(uint32_t timeout=60000)
-	{
-		system_tick_t start = millis();
-		while (channel.has_unacknowledged_requests() && (millis()-start)<timeout)
-		{
-			if (channel.receive_confirmations())
-				break;
-		}
-	}
+	void sleep(uint32_t timeout=60000);
 
 	void wake()
 	{

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -66,6 +66,38 @@ public:
 		return len;
 	}
 
+	virtual void command(ProtocolCommands::Enum command, uint32_t data)
+	{
+		switch (command)
+		{
+		case ProtocolCommands::SLEEP:
+			sleep();
+			break;
+		case ProtocolCommands::WAKE:
+			wake();
+			break;
+		}
+	}
+
+
+
+	/**
+	 * Ensures that all outstanding sent coap messages have been acknowledged.
+	 */
+	void sleep(uint32_t timeout=60000)
+	{
+		system_tick_t start = millis();
+		while (channel.has_unacknowledged_requests() && (millis()-start)<timeout)
+		{
+			if (channel.receive_confirmations())
+				break;
+		}
+	}
+
+	void wake()
+	{
+		ping();
+	}
 };
 
 

--- a/communication/src/lightssl_protocol.cpp
+++ b/communication/src/lightssl_protocol.cpp
@@ -1,0 +1,25 @@
+/**
+ ******************************************************************************
+ Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation, either
+ version 3 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#include "lightssl_protocol.h"
+
+namespace particle { namespace protocol {
+	void LightSSLProtocol::command(ProtocolCommands::Enum command, uint32_t data) { }
+
+}}

--- a/communication/src/lightssl_protocol.h
+++ b/communication/src/lightssl_protocol.h
@@ -50,7 +50,7 @@ public:
 	void init(const char *id,
 	          const SparkKeys &keys,
 	          const SparkCallbacks &callbacks,
-	          const SparkDescriptor &descriptor)
+	          const SparkDescriptor &descriptor) override
 	{
 		set_protocol_flags(REQUIRE_HELLO_RESPONSE);
 
@@ -76,9 +76,7 @@ public:
 		return len;
 	}
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data)
-	{
-	}
+	virtual void command(ProtocolCommands::Enum command, uint32_t data) override;
 
 };
 

--- a/communication/src/lightssl_protocol.h
+++ b/communication/src/lightssl_protocol.h
@@ -64,7 +64,7 @@ public:
         initialize_ping(15000,10000);
 	}
 
-	size_t build_hello(Message& message, bool ota_updated)
+	size_t build_hello(Message& message, bool ota_updated) override
 	{
 		product_details_t deets;
 		deets.size = sizeof(deets);
@@ -74,6 +74,10 @@ public:
 				ota_updated, PLATFORM_ID, deets.product_id,
 				deets.product_version, false, nullptr, 0);
 		return len;
+	}
+
+	virtual void command(ProtocolCommands::Enum command, uint32_t data)
+	{
 	}
 
 };

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -395,6 +395,10 @@ public:
 		return -1;
 	}
 
+	inline system_tick_t millis() { return callbacks.millis(); }
+
+	virtual void command(ProtocolCommands::Enum command, uint32_t data) {}
+
 };
 
 }

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -395,9 +395,9 @@ public:
 		return -1;
 	}
 
-	inline system_tick_t millis() { return callbacks.millis(); }
+	system_tick_t millis() { return callbacks.millis(); }
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data) {}
+	virtual void command(ProtocolCommands::Enum command, uint32_t data);
 
 };
 

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -397,7 +397,7 @@ public:
 
 	system_tick_t millis() { return callbacks.millis(); }
 
-	virtual void command(ProtocolCommands::Enum command, uint32_t data);
+	virtual void command(ProtocolCommands::Enum command, uint32_t data)=0;
 
 };
 

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -141,6 +141,11 @@ int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned pr
     }
     return 0;
 }
+int spark_protocol_command(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved)
+{
+	protocol->command(cmd, data);
+	return 0;
+}
 
 #else
 
@@ -229,6 +234,11 @@ int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned pr
                                            unsigned data, void* datap, void* reserved)
 {
     return 0;
+}
+
+int spark_protocol_command(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved)
+{
+	return 0;
 }
 
 #endif

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -172,6 +172,16 @@ void spark_protocol_get_product_details(ProtocolFacade* protocol, product_detail
 int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id,
                                            unsigned data, void* datap, void* reserved);
 
+namespace ProtocolCommands {
+	enum Enum {
+		SLEEP,
+		WAKE
+	};
+};
+
+
+int spark_protocol_command(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data=0, void* reserved=NULL);
+
 /**
  * Decrypt a buffer using the given public key.
  * @param ciphertext        The ciphertext to decrypt

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1107,3 +1107,13 @@ bool system_cloud_active()
 #endif
     return true;
 }
+
+void Spark_Sleep(void)
+{
+	spark_protocol_command(sp, ProtocolCommands::SLEEP);
+}
+
+void Spark_Wake(void)
+{
+	spark_protocol_command(sp, ProtocolCommands::WAKE);
+}

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -39,7 +39,8 @@ void Multicast_Presence_Announcement(void);
 void Spark_Signal(bool on, unsigned, void*);
 void Spark_SetTime(unsigned long dateTime);
 void Spark_Process_Events();
-
+void Spark_Sleep();
+void Spark_Wake();
 extern volatile uint8_t LED_Spark_Signal;
 void LED_Signaling_Override(void);
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -23,6 +23,7 @@
 #include "system_task.h"
 #include "system_cloud.h"
 #include "system_cloud_internal.h"
+#include "system_threading.h"
 #include "rtc_hal.h"
 #include "core_hal.h"
 #include "rgbled.h"
@@ -120,13 +121,11 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
     }
 }
 
-void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
+
+int system_sleep_pin_impl(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
 {
-    bool network_sleep = network_sleep_flag(param);
-    if (network_sleep)
-    {
-        network_suspend();
-    }
+	SYSTEM_THREAD_CONTEXT_SYNC_CALL(system_sleep_pin_impl(wakeUpPin, edgeTriggerMode, seconds, param, reserved));
+    network_suspend();
     LED_Off(LED_RGB);
     HAL_Core_Enter_Stop_Mode(wakeUpPin, edgeTriggerMode, seconds);
     network_resume();		// asynchronously bring up the network/cloud
@@ -140,4 +139,13 @@ void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds
     if (spark_connected()) {
     		Spark_Wake();
     }
+    return 0;
+}
+
+/**
+ * Wraps the actual implementation, which has to return a value as part of the threaded implementation.
+ */
+void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
+{
+	system_sleep_pin_impl(wakeUpPin, edgeTriggerMode, seconds, param, reserved);
 }

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -121,8 +121,9 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
     }
 }
 
-int _system_sleep_pin_impl(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
+int system_sleep_pin_impl(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
 {
+    SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_pin_impl(wakeUpPin, edgeTriggerMode, seconds, param, reserved));
     if (spark_cloud_flag_connected()) {
         Spark_Sleep();
     }
@@ -147,12 +148,6 @@ int _system_sleep_pin_impl(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long se
     if (spark_cloud_flag_connected()) {
         Spark_Wake();
     }
-    return 0;
-}
-
-int system_sleep_pin_impl(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
-{
-    SYSTEM_THREAD_CONTEXT_SYNC_CALL(_system_sleep_pin_impl(wakeUpPin, edgeTriggerMode, seconds, param, reserved));
     return 0;
 }
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -47,7 +47,6 @@ static void network_suspend() {
     wakeupState.wifiConnected = wakeupState.cloud | network_ready(0, 0, NULL) | network_connecting(0, 0, NULL);
 #ifndef SPARK_NO_CLOUD
     wakeupState.cloud = spark_cloud_flag_auto_connect();
-    Spark_Sleep();
     // disconnect the cloud now, and clear the auto connect status
     spark_cloud_socket_disconnect();
     spark_cloud_flag_disconnect();
@@ -124,6 +123,10 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
 
 int _system_sleep_pin_impl(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
 {
+    if (spark_cloud_flag_connected()) {
+        Spark_Sleep();
+    }
+
     bool network_sleep = network_sleep_flag(param);
     if (network_sleep)
     {

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -53,6 +53,7 @@ static void network_suspend() {
 }
 
 static void network_resume() {
+	// Set the system flags that triggers the wifi/cloud reconnection in the background loop
     if (wakeupState.wifiConnected || wakeupState.wifi)  // at present, no way to get the background loop to only turn on wifi.
         SPARK_WLAN_SLEEP = 0;
     if (wakeupState.cloud)
@@ -91,10 +92,11 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
     if (seconds)
         HAL_RTC_Set_UnixAlarm((time_t) seconds);
 
+    network_suspend();
+
     switch (sleepMode)
     {
         case SLEEP_MODE_WLAN:
-            network_suspend();
             break;
 
         case SLEEP_MODE_DEEP:
@@ -130,4 +132,5 @@ void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds
     {
         network_resume();
     }
+    Spark_Wake();
 }


### PR DESCRIPTION
This PR is a rebase against develop of PR #909
* It fixes a lockup issue observed on the Photon and Electron
* If resolves merge conflicts with PR #909 and develop
* It changes the behavior a bit for the new NETWORK_STANDBY flag so that messages are still confirmed before going to sleep while the nework remains on.

Original PR #909 descriptions:
>protocol sleep/wake commands which allow the caller to wait for all coap confirmable requests to be acknowledged, and allows the comms layer to take action when waking up after sleep.

>This is used as part of system sleep to ensure confirmable messages are confirmed before entering sleep.

>https://github.com/spark/firmware/commit/3014dd53bee31f89222d25276504657e608b575d addresses issue #894 - the system will reconnect to the cloud before returning control back to the application loop after waking up. 

* To note, this only affects the Electron currently but could be adapted for Photon at a later time.
* Also only effective for Stop mode Sleep currently.
* Should this be implemented for Deep Sleep as well :question: See notes here: https://github.com/spark/firmware/pull/918/commits/fe44f22abe313a392a26775cbc1d188e88dc5fed
* Tested on the Electron with Sleep modes seen below.
* Tested with multi-threading enabled, however multi-threading is still in beta on Electron.

- [ ] Review code
- [x] Test on device
- [ ] Add documentation
- [ ] Add to changelog

## Test app
```c++
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

// ALL_LEVEL, TRACE_LEVEL, DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, PANIC_LEVEL, NO_LOG_LEVEL
Serial1DebugOutput debugOutput(9600, ALL_LEVEL);

retained int count = 0;

STARTUP(System.enableFeature(FEATURE_RETAINED_MEMORY));

void spinWait(uint32_t timeout) {
	uint32_t start = millis();
	while (millis() - start < timeout) Particle.process();
}

void setup() {
	pinMode(D1, INPUT_PULLDOWN);
	pinMode(D7, OUTPUT);
	Particle.connect();
	DEBUG_D("\r\n[ Particle.connect ]\r\n\r\n");
	waitUntil(Particle.connected);
	DEBUG_D("\r\n[ Particle.connected ]\r\n\r\n");
}

void loop() {

	digitalWrite(D7, LOW);
	DEBUG_D("\r\n[ Waking up and publishing once! ]\r\n\r\n");
    waitUntil(Particle.connected);
	Particle.publish("b", String(++count));

	// Does not require a delay between Publish and Sleep Stop mode anymore
	//spinWait(6000);

	DEBUG_D("\r\n[ Going to sleep ]\r\n\r\n");
	digitalWrite(D7, HIGH);

	// These all will restore and resume sessions after the first full handshake (fairly low data usage)
	//
	// System.sleep(D1, RISING, 30); // SLEEP_NETWORK_OFF is default
	// System.sleep(D1, RISING, 30, SLEEP_NETWORK_OFF); // Turns off network

	// These all require full handshakes (higher data usage)
	//
	// System.sleep(SLEEP_MODE_DEEP, 30); // SLEEP_NETWORK_OFF is default
	// System.sleep(SLEEP_MODE_DEEP, 30, SLEEP_NETWORK_STANDBY); // Does not turn off network
	// System.sleep(SLEEP_MODE_DEEP, 30, SLEEP_NETWORK_OFF); // Turns off network

	// This is the only one that doesn't require another
	// session resume or handshake upon waking (lowest data usage)
	//
	System.sleep(D1, RISING, 30, SLEEP_NETWORK_STANDBY); // Does not turn off network
}
```