### PR TITLE
SPI.transfer() synchronous operation when callback is NULL

### DIFF
--- a/hal/inc/hal_dynalib_spi.h
+++ b/hal/inc/hal_dynalib_spi.h
@@ -53,7 +53,7 @@ DYNALIB_FN(10, hal_spi, HAL_SPI_DMA_Transfer, void(HAL_SPI_Interface, void*, voi
 DYNALIB_FN(11, hal_spi, HAL_SPI_Begin_Ext, void(HAL_SPI_Interface, SPI_Mode, uint16_t, void*))
 DYNALIB_FN(12, hal_spi, HAL_SPI_Set_Callback_On_Select, void(HAL_SPI_Interface, HAL_SPI_Select_UserCallback, void*))
 DYNALIB_FN(13, hal_spi, HAL_SPI_DMA_Transfer_Cancel, void(HAL_SPI_Interface))
-DYNALIB_FN(14, hal_spi, HAL_SPI_DMA_Last_Transfer_Length, int32_t(HAL_SPI_Interface))
+DYNALIB_FN(14, hal_spi, HAL_SPI_DMA_Transfer_Status, int32_t(HAL_SPI_Interface, HAL_SPI_TransferStatus*))
 
 DYNALIB_END(hal_spi)
 

--- a/hal/inc/spi_hal.h
+++ b/hal/inc/spi_hal.h
@@ -79,6 +79,14 @@ typedef struct hal_spi_info_t {
 
 } hal_spi_info_t;
 
+typedef struct HAL_SPI_TransferStatus {
+    uint8_t version;
+    uint32_t configured_transfer_length;
+    uint32_t transfer_length;
+    uint8_t transfer_ongoing    : 1;
+    uint8_t ss_state            : 1;
+} HAL_SPI_TransferStatus;
+
 void HAL_SPI_Init(HAL_SPI_Interface spi);
 void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin);
 void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void* reserved);
@@ -93,7 +101,7 @@ bool HAL_SPI_Is_Enabled(HAL_SPI_Interface spi);
 void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved);
 void HAL_SPI_Set_Callback_On_Select(HAL_SPI_Interface spi, HAL_SPI_Select_UserCallback cb, void* reserved);
 void HAL_SPI_DMA_Transfer_Cancel(HAL_SPI_Interface spi);
-int32_t HAL_SPI_DMA_Last_Transfer_Length(HAL_SPI_Interface spi);
+int32_t HAL_SPI_DMA_Transfer_Status(HAL_SPI_Interface spi, HAL_SPI_TransferStatus* st);
 
 #ifdef __cplusplus
 }

--- a/hal/src/core/spi_hal.c
+++ b/hal/src/core/spi_hal.c
@@ -209,7 +209,7 @@ void HAL_SPI_DMA_Transfer_Cancel(HAL_SPI_Interface spi)
 {
 }
 
-int32_t HAL_SPI_DMA_Last_Transfer_Length(HAL_SPI_Interface spi)
+int32_t HAL_SPI_DMA_Transfer_Status(HAL_SPI_Interface spi, HAL_SPI_TransferStatus* st)
 {
-    return 0;
+    return -1;
 }

--- a/hal/src/template/spi_hal.cpp
+++ b/hal/src/template/spi_hal.cpp
@@ -80,7 +80,7 @@ void HAL_SPI_DMA_Transfer_Cancel(HAL_SPI_Interface spi)
 {
 }
 
-int32_t HAL_SPI_DMA_Last_Transfer_Length(HAL_SPI_Interface spi)
+int32_t HAL_SPI_DMA_Transfer_Status(HAL_SPI_Interface spi, HAL_SPI_TransferStatus* st)
 {
     return 0;
 }

--- a/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
@@ -1,5 +1,6 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
+#include <functional>
 
 #define MASTER_TEST_MESSAGE "Hello from SPI Master!?"
 #define SLAVE_TEST_MESSAGE_1  "SPI Slave is doing good"
@@ -12,70 +13,11 @@
 static uint8_t SPI_Master_Tx_Buffer[TRANSFER_LENGTH_2];
 static uint8_t SPI_Master_Rx_Buffer[TRANSFER_LENGTH_2];
 static volatile uint8_t DMA_Completed_Flag = 0;
-static int SPI_Test_Counter = 2;
+static int SPI_Test_Counter = 3;
 
 static void SPI_Master_Configure()
 {
     SPI.begin(A2);
-}
-
-test(SPI_Master_Slave_Master_Variable_Length_Transfer_No_DMA)
-{
-    if (SPI_Test_Counter == 2)
-        Serial.println("This is Master");
-    SPI_Test_Counter--;
-    uint32_t requestedLength = TRANSFER_LENGTH_2;
-    SPI_Master_Configure();
-
-    while (requestedLength >= 0)
-    {
-        memset(SPI_Master_Tx_Buffer, 0, sizeof(SPI_Master_Tx_Buffer));
-        memset(SPI_Master_Rx_Buffer, 0, sizeof(SPI_Master_Rx_Buffer));
-
-        // Select
-        digitalWrite(A2, LOW);
-        delay(SPI_DELAY);
-
-        memcpy(SPI_Master_Tx_Buffer, MASTER_TEST_MESSAGE, sizeof(MASTER_TEST_MESSAGE));
-        memcpy(SPI_Master_Tx_Buffer + sizeof(MASTER_TEST_MESSAGE), (void*)&requestedLength, sizeof(uint32_t));
-
-        uint32_t count = 0;
-        while (count < TRANSFER_LENGTH_1)
-        {
-            SPI_Master_Rx_Buffer[count] = SPI.transfer(SPI_Master_Tx_Buffer[count]);
-            count++;
-        }
-        // Serial.print("< ");
-        // Serial.println((const char *)SPI_Master_Rx_Buffer);
-        assertTrue(strncmp((const char *)SPI_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_1, sizeof(SLAVE_TEST_MESSAGE_1)) == 0);
-
-        digitalWrite(A2, HIGH);
-        if (requestedLength == 0)
-            break;
-        delay(SPI_DELAY);
-        digitalWrite(A2, LOW);
-        delay(SPI_DELAY);
-
-        // Received a good first reply from Slave
-        // Now read out requestedLength bytes
-        memset(SPI_Master_Rx_Buffer, 0, sizeof(SPI_Master_Rx_Buffer));
-        count = 0;
-        while (count < requestedLength)
-        {
-            SPI_Master_Rx_Buffer[count++] = SPI.transfer(0xff);
-        }
-        // Serial.print("< ");
-        // Serial.println((const char *)SPI_Master_Rx_Buffer);
-        assertTrue(strncmp((const char *)SPI_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength) == 0);
-
-        // Deselect
-        digitalWrite(A2, HIGH);
-        delay(SPI_DELAY);
-
-        requestedLength--;
-    }
-
-    SPI.end();
 }
 
 static void SPI_DMA_Completed_Callback()
@@ -83,9 +25,29 @@ static void SPI_DMA_Completed_Callback()
     DMA_Completed_Flag = 1;
 }
 
-test(SPI_Master_Slave_Master_Variable_Length_Transfer_DMA)
-{
-    if (SPI_Test_Counter == 2)
+static void SPI_Master_Transfer_No_DMA(uint8_t* txbuf, uint8_t* rxbuf, int length) {
+    for(int count = 0; count < length; count++)
+    {
+        uint8_t tmp = SPI.transfer(txbuf ? txbuf[count] : 0xff);
+        if (rxbuf)
+            rxbuf[count] = tmp;
+    }
+}
+
+static void SPI_Master_Transfer_DMA(uint8_t* txbuf, uint8_t* rxbuf, int length, HAL_SPI_DMA_UserCallback cb) {
+    if (cb) {
+        DMA_Completed_Flag = 0;
+        SPI.transfer(txbuf, rxbuf, length, cb);
+        while(DMA_Completed_Flag == 0);
+        assertEqual(length, SPI.available());
+    } else {
+        SPI.transfer(txbuf, rxbuf, length, NULL);
+        assertEqual(length, SPI.available());
+    }
+}
+
+void SPI_Master_Slave_Master_Test_Routine(std::function<void(uint8_t*, uint8_t*, int)> transferFunc) {
+    if (SPI_Test_Counter == 3)
         Serial.println("This is Master");
     SPI_Test_Counter--;
 
@@ -109,9 +71,7 @@ test(SPI_Master_Slave_Master_Variable_Length_Transfer_DMA)
         memcpy(SPI_Master_Tx_Buffer, MASTER_TEST_MESSAGE, sizeof(MASTER_TEST_MESSAGE));
         memcpy(SPI_Master_Tx_Buffer + sizeof(MASTER_TEST_MESSAGE), (void*)&requestedLength, sizeof(uint32_t));
 
-        DMA_Completed_Flag = 0;
-        SPI.transfer(SPI_Master_Tx_Buffer, SPI_Master_Rx_Buffer, TRANSFER_LENGTH_1, SPI_DMA_Completed_Callback);
-        while(DMA_Completed_Flag == 0);
+        transferFunc(SPI_Master_Tx_Buffer, SPI_Master_Rx_Buffer, TRANSFER_LENGTH_1);
         // Serial.print("< ");
         // Serial.println((const char *)SPI_Master_Rx_Buffer);
         assertTrue(strncmp((const char *)SPI_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_1, sizeof(SLAVE_TEST_MESSAGE_1)) == 0);
@@ -128,9 +88,7 @@ test(SPI_Master_Slave_Master_Variable_Length_Transfer_DMA)
         // Received a good first reply from Slave
         // Now read out requestedLength bytes
         memset(SPI_Master_Rx_Buffer, 0, sizeof(SPI_Master_Rx_Buffer));
-        DMA_Completed_Flag = 0;
-        SPI.transfer(NULL, SPI_Master_Rx_Buffer, requestedLength, SPI_DMA_Completed_Callback);
-        while(DMA_Completed_Flag == 0);
+        transferFunc(NULL, SPI_Master_Rx_Buffer, requestedLength);
         // Serial.print("< ");
         // Serial.println((const char *)SPI_Master_Rx_Buffer);
         assertTrue(strncmp((const char *)SPI_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength) == 0);
@@ -143,4 +101,21 @@ test(SPI_Master_Slave_Master_Variable_Length_Transfer_DMA)
     }
 
     SPI.end();
+}
+
+test(SPI_Master_Slave_Master_Variable_Length_Transfer_No_DMA)
+{
+    SPI_Master_Slave_Master_Test_Routine(SPI_Master_Transfer_No_DMA);
+}
+
+test(SPI_Master_Slave_Master_Variable_Length_Transfer_DMA)
+{
+    using namespace std::placeholders;
+    SPI_Master_Slave_Master_Test_Routine(std::bind(SPI_Master_Transfer_DMA, _1, _2, _3, &SPI_DMA_Completed_Callback));
+}
+
+test(SPI_Master_Slave_Master_Variable_Length_Transfer_DMA_Synchronous)
+{
+    using namespace std::placeholders;
+    SPI_Master_Slave_Master_Test_Routine(std::bind(SPI_Master_Transfer_DMA, _1, _2, _3, (HAL_SPI_DMA_UserCallback)NULL));
 }

--- a/wiring/src/spark_wiring_spi.cpp
+++ b/wiring/src/spark_wiring_spi.cpp
@@ -159,6 +159,12 @@ byte SPIClass::transfer(byte _data)
 void SPIClass::transfer(void* tx_buffer, void* rx_buffer, size_t length, wiring_spi_dma_transfercomplete_callback_t user_callback)
 {
   HAL_SPI_DMA_Transfer(_spi, tx_buffer, rx_buffer, length, user_callback);
+  if (user_callback == NULL) {
+    HAL_SPI_TransferStatus st;
+    do {
+      HAL_SPI_DMA_Transfer_Status(_spi, &st);
+    } while(st.transfer_ongoing);
+  }
 }
 
 void SPIClass::attachInterrupt()
@@ -188,5 +194,5 @@ void SPIClass::transferCancel()
 
 int32_t SPIClass::available()
 {
-  return HAL_SPI_DMA_Last_Transfer_Length(_spi);
+  return HAL_SPI_DMA_Transfer_Status(_spi, NULL);
 }


### PR DESCRIPTION
Fixes behavior of SPI.transfer with NULL callback. According to docs:
> If a user callback function is passed then it will be called after completion of the DMA transfer. This results in asynchronous filling of RX buffer after which the DMA transfer is disabled till the transfer function is called again. **If NULL is passed as a callback then the result is synchronous i.e. the function will only return once the DMA transfer is complete.**

PR also includes tests in `user/tests/wiring/spi_master_slave` for the synchronous behavior.

---

- [x] Review code
- [x] Test on device
- [ ] Add documentation
- [ ] Add to changelog