### PR TITLE
LIN Bus support, USART hardware flow control configuration support

### DIFF
--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -73,9 +73,10 @@ DYNALIB_FN(BASE_IDX + 12, hal_usart, USB_USART_Flush_Data, void(void))
 #define BASE_IDX2 (BASE_IDX+11)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, hal_usart,HAL_USART_BeginConfig,void(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr))
-DYNALIB_FN(BASE_IDX2 + 1, hal_usart,HAL_USART_Write_NineBitData, uint32_t(HAL_USART_Serial serial, uint16_t data))
-
+DYNALIB_FN(BASE_IDX2 + 0, hal_usart, HAL_USART_BeginConfig, void(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr))
+DYNALIB_FN(BASE_IDX2 + 1, hal_usart, HAL_USART_Write_NineBitData, uint32_t(HAL_USART_Serial serial, uint16_t data))
+DYNALIB_FN(BASE_IDX2 + 2, hal_usart, HAL_USART_Send_Break, void(HAL_USART_Serial, void*))
+DYNALIB_FN(BASE_IDX2 + 3, hal_usart, HAL_USART_Break_Detected, uint8_t(HAL_USART_Serial))
 
 DYNALIB_END(hal_usart)
 

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -55,13 +55,13 @@
 #define SERIAL_STOP_BITS (uint8_t)0b00000011
 #define SERIAL_PARITY_BITS (uint8_t)0b00001100
 #define SERIAL_NINE_BITS (uint8_t)0b00010000
-#define SERIAL_FLOW_CONTROL ((uint8_t)0b01100000)
+#define SERIAL_FLOW_CONTROL ((uint8_t)0b11000000)
 
 // Flow control settings
 #define SERIAL_FLOW_CONTROL_NONE ((uint8_t)0b00000000)
-#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b00100000)
-#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b01000000)
-#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b01100000)
+#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b01000000)
+#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b10000000)
+#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b11000000)
 
 // LIN Configuration masks
 #define LIN_MODE ((uint32_t)0x0300)

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -55,6 +55,34 @@
 #define SERIAL_STOP_BITS (uint8_t)0b00000011
 #define SERIAL_PARITY_BITS (uint8_t)0b00001100
 #define SERIAL_NINE_BITS (uint8_t)0b00010000
+#define SERIAL_FLOW_CONTROL ((uint8_t)0b01100000)
+
+// Flow control settings
+#define SERIAL_FLOW_CONTROL_NONE ((uint8_t)0b00000000)
+#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b00100000)
+#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b01000000)
+#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b01100000)
+
+// LIN Configuration masks
+#define LIN_MODE ((uint32_t)0x0300)
+#define LIN_BREAK_BITS ((uint32_t)0x0C00)
+
+// LIN modes
+#define LIN_MODE_MASTER ((uint32_t)0x0100)
+#define LIN_MODE_SLAVE  ((uint32_t)0x0200)
+
+// LIN break settings
+// Supported only in Master mode
+#define LIN_BREAK_13 ((uint32_t)0x0400)
+// Supported only in Slave mode
+#define LIN_BREAK_10 ((uint32_t)0x0800)
+#define LIN_BREAK_11 ((uint32_t)0x0C00)
+
+// Pre-defined LIN configurations
+#define LIN_MASTER_13 (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13)
+#define LIN_SLAVE_10  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_10)
+#define LIN_SLAVE_11  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_11)
+
 
 /* Exported types ------------------------------------------------------------*/
 typedef struct Ring_Buffer
@@ -97,6 +125,8 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial);
 void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable);
 void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void*);
 uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data);
+void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved);
+uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -73,15 +73,15 @@
 
 // LIN break settings
 // Supported only in Master mode
-#define LIN_BREAK_13 ((uint32_t)0x0400)
+#define LIN_BREAK_13B ((uint32_t)0x0000)
 // Supported only in Slave mode
-#define LIN_BREAK_10 ((uint32_t)0x0800)
-#define LIN_BREAK_11 ((uint32_t)0x0C00)
+#define LIN_BREAK_10B ((uint32_t)0x0800)
+#define LIN_BREAK_11B ((uint32_t)0x0C00)
 
 // Pre-defined LIN configurations
-#define LIN_MASTER_13 (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13)
-#define LIN_SLAVE_10  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_10)
-#define LIN_SLAVE_11  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_11)
+#define LIN_MASTER_13B (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13B)
+#define LIN_SLAVE_10B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_10B)
+#define LIN_SLAVE_11B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_11B)
 
 
 /* Exported types ------------------------------------------------------------*/

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -450,13 +450,11 @@ void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 
 void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
 {
-  if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
-    int32_t state = HAL_disable_irq();
-    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-    USART_SendBreak(usartMap[serial]->usart_peripheral);
-    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-    HAL_enable_irq(state);
-  }
+  int32_t state = HAL_disable_irq();
+  while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+  USART_SendBreak(usartMap[serial]->usart_peripheral);
+  while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+  HAL_enable_irq(state);
 }
 
 uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -259,22 +259,25 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
     }
   }
 
+  // Disable LIN mode just in case
+  USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
+
   // Configure USART
   USART_Init(usartMap[serial]->usart_peripheral, &USART_InitStructure);
 
   // LIN configuration
-  if (config & LIN_MODE_MASTER) {
-    // Ignore break settings
-  } else if (config & LIN_MODE_SLAVE) {
+  if (config & LIN_MODE) {
+    // Enable break detection
     switch(config & LIN_BREAK_BITS) {
-      case LIN_BREAK_10:
+      case LIN_BREAK_10B:
         USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
         break;
-      case LIN_BREAK_11:
+      case LIN_BREAK_11B:
         USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
         break;
     }
   }
+
 
   // Enable USART Receive and Transmit interrupts
   USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, ENABLE);
@@ -299,6 +302,9 @@ void HAL_USART_End(HAL_USART_Serial serial)
 
   // Disable the USART
   USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
+
+  // Disable LIN mode
+  USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
 
   // Deinitialise USART
   USART_DeInit(usartMap[serial]->usart_peripheral);
@@ -445,7 +451,11 @@ void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
 {
   if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
+    int32_t state = HAL_disable_irq();
+    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
     USART_SendBreak(usartMap[serial]->usart_peripheral);
+    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+    HAL_enable_irq(state);
   }
 }
 

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -28,6 +28,7 @@
 #include "gpio_hal.h"
 #include "stm32f10x.h"
 #include <string.h>
+#include "interrupts_hal.h"
 
 /* Private typedef -----------------------------------------------------------*/
 typedef enum USART_Num_Def {

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -240,3 +240,12 @@ uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data)
 {
     return usartMap(serial).write((uint8_t) data);
 }
+
+void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
+{
+}
+
+uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)
+{
+  return 0;
+}

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -491,13 +491,11 @@ void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 
 void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
 {
-	if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
-		int32_t state = HAL_disable_irq();
-		while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-		USART_SendBreak(usartMap[serial]->usart_peripheral);
-		while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-		HAL_enable_irq(state);
-	}
+	int32_t state = HAL_disable_irq();
+	while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+	USART_SendBreak(usartMap[serial]->usart_peripheral);
+	while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+	HAL_enable_irq(state);
 }
 
 uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -63,12 +63,17 @@ typedef struct STM32_USART_Info {
 
 	uint8_t usart_af_map;
 
+	uint8_t usart_cts_pin;
+	uint8_t usart_rts_pin;
+
 	// Buffer pointers. These need to be global for IRQ handler access
 	Ring_Buffer* usart_tx_buffer;
 	Ring_Buffer* usart_rx_buffer;
 
 	bool usart_enabled;
 	bool usart_transmitting;
+
+	uint32_t usart_config;
 } STM32_USART_Info;
 
 /*
@@ -86,15 +91,17 @@ STM32_USART_Info USART_MAP[TOTAL_USARTS] =
 		 * TX pin source
 		 * RX pin source
 		 * GPIO AF map (GPIO_AF_USARTx/GPIO_AF_UARTx)
+		 * CTS pin
+		 * RTS pin
 		 * <tx_buffer pointer> used internally and does not appear below
 		 * <rx_buffer pointer> used internally and does not appear below
 		 * <usart enabled> used internally and does not appear below
 		 * <usart transmitting> used internally and does not appear below
 		 */
 		{ USART1, &RCC->APB2ENR, RCC_APB2Periph_USART1, USART1_IRQn, TX, RX, GPIO_PinSource9, GPIO_PinSource10, GPIO_AF_USART1 }, // USART 1
-		{ USART2, &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG, RGBB, GPIO_PinSource2, GPIO_PinSource3, GPIO_AF_USART2 } // USART 2
+		{ USART2, &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG, RGBB, GPIO_PinSource2, GPIO_PinSource3, GPIO_AF_USART2, A7, RGBR } // USART 2
 #if PLATFORM_ID == 10 // Electron
-		,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3 } // USART 3
+		,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3, CTS_UC, RTS_UC } // USART 3
 		,{ UART4, &RCC->APB1ENR, RCC_APB1Periph_UART4, UART4_IRQn, C3, C2, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_UART4 } // UART 4
 		,{ UART5, &RCC->APB1ENR, RCC_APB1Periph_UART5, UART5_IRQn, C1, C0, GPIO_PinSource12, GPIO_PinSource2, GPIO_AF_UART5 } // UART 5
 #endif
@@ -172,14 +179,6 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	// Configure USART Rx and Tx as alternate function push-pull, and enable GPIOA clock
 	HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, AF_OUTPUT_PUSHPULL);
 	HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
-#if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
-	if (serial == HAL_USART_SERIAL3)
-	{
-		// Configure USART RTS and CTS as alternate function push-pull
-		HAL_Pin_Mode(RTS_UC, AF_OUTPUT_PUSHPULL);
-		HAL_Pin_Mode(CTS_UC, AF_OUTPUT_PUSHPULL);
-	}
-#endif
 
 	// Enable USART Clock
 	*usartMap[serial]->usart_apbReg |=  usartMap[serial]->usart_clock_en;
@@ -188,13 +187,6 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
 	GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rx_pin].gpio_peripheral, usartMap[serial]->usart_rx_pinsource, usartMap[serial]->usart_af_map);
 	GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral, usartMap[serial]->usart_tx_pinsource, usartMap[serial]->usart_af_map);
-#if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
-	if (serial == HAL_USART_SERIAL3)
-	{
-		GPIO_PinAFConfig(PIN_MAP[RTS_UC].gpio_peripheral, PIN_MAP[RTS_UC].gpio_pin_source, usartMap[serial]->usart_af_map);
-		GPIO_PinAFConfig(PIN_MAP[CTS_UC].gpio_peripheral, PIN_MAP[CTS_UC].gpio_pin_source, usartMap[serial]->usart_af_map);
-	}
-#endif
 
 	// NVIC Configuration
 	NVIC_InitTypeDef NVIC_InitStructure;
@@ -217,14 +209,62 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	// USART configuration
 	USART_InitStructure.USART_BaudRate = baud;
 	USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-	USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
 
-  #if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
+	// Flow control configuration
+	switch (config & SERIAL_FLOW_CONTROL) {
+		case SERIAL_FLOW_CONTROL_CTS:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_CTS;
+			break;
+		case SERIAL_FLOW_CONTROL_RTS:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS;
+			break;
+		case SERIAL_FLOW_CONTROL_RTS_CTS:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
+			break;
+		case SERIAL_FLOW_CONTROL_NONE:
+		default:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+			break;
+	}
+
+	if (serial == HAL_USART_SERIAL1) {
+		// USART1 supports hardware flow control, but RTS and CTS pins are not exposed
+		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+	}
+
+#if PLATFORM_ID == 10 // Electron
+	if (serial == HAL_USART_SERIAL4 || serial == HAL_USART_SERIAL5) {
+		// UART4 and UART5 do not support hardware flow control
+		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+	}
+#endif // PLATFORM_ID == 10
+
+#if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
 	if (serial == HAL_USART_SERIAL3)
 	{
-	  USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
+		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
 	}
-  #endif
+#endif
+
+	switch (USART_InitStructure.USART_HardwareFlowControl) {
+		case USART_HardwareFlowControl_CTS:
+			HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			break;
+		case USART_HardwareFlowControl_RTS:
+			HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			break;
+		case USART_HardwareFlowControl_RTS_CTS:
+			HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
+			HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			break;
+		case USART_HardwareFlowControl_None:
+		default:
+			break;
+	}
 
 	// Stop bit configuration.
 	switch (config & SERIAL_STOP_BITS) {
@@ -268,9 +308,28 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	// Configure USART
 	USART_Init(usartMap[serial]->usart_peripheral, &USART_InitStructure);
 
+	// LIN configuration
+	if (config & LIN_MODE_MASTER) {
+		// Ignore break settings
+	} else if (config & LIN_MODE_SLAVE) {
+		switch(config & LIN_BREAK_BITS) {
+			case LIN_BREAK_10:
+				USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
+				break;
+			case LIN_BREAK_11:
+				USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
+				break;
+		}
+	}
+
 	// Enable the USART
 	USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
 
+	if (config & LIN_MODE) {
+		USART_LINCmd(usartMap[serial]->usart_peripheral, ENABLE);
+	}
+
+	usartMap[serial]->usart_config = config;
 	usartMap[serial]->usart_enabled = true;
 	usartMap[serial]->usart_transmitting = false;
 
@@ -422,6 +481,24 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
 void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 {
 	USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, Enable ? ENABLE : DISABLE);
+}
+
+void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
+{
+	if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
+		USART_SendBreak(usartMap[serial]->usart_peripheral);
+	}
+}
+
+uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)
+{
+	if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_LBD)) {
+		// Clear LBD flag
+		USART_ClearFlag(usartMap[serial]->usart_peripheral, USART_FLAG_LBD);
+		return 1;
+	}
+
+	return 0;
 }
 
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -88,6 +88,17 @@ test(api_wiring_usartserial) {
     API_COMPILE(Serial1.end());
     API_COMPILE(Serial1.begin(9600, SERIAL_9N2));
     API_COMPILE(Serial1.end());
+
+    // LIN mode
+    API_COMPILE(Serial1.begin(9600, LIN_MASTER_13B));
+    API_COMPILE(Serial1.breakTx());
+    API_COMPILE(Serial1.end());
+    API_COMPILE(Serial1.begin(9600, LIN_SLAVE_10B));
+    API_COMPILE(Serial1.breakRx());
+    API_COMPILE(Serial1.end());
+    API_COMPILE(Serial1.begin(9600, LIN_SLAVE_11B));
+    API_COMPILE(Serial1.breakRx());
+    API_COMPILE(Serial1.end());
 }
 
 test(api_wiring_usbserial) {

--- a/user/tests/wiring/serial_loopback/serial.cpp
+++ b/user/tests/wiring/serial_loopback/serial.cpp
@@ -50,8 +50,6 @@ test(SERIAL_ReadWriteSucceedsWithUserIntervention) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial.print("Type the following message and press Enter : ");
     Serial.println(test);
     serialReadLine(&Serial, message, 9, 10000);//10 sec timeout
@@ -65,8 +63,6 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -76,12 +72,10 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
 }
 
 test(SERIAL1_ReadWriteParity8N1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
+    //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8N1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -95,8 +89,6 @@ test(SERIAL1_ReadWriteParity8E1SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8E1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -110,8 +102,6 @@ test(SERIAL1_ReadWriteParity8O1SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8O1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -125,8 +115,6 @@ test(SERIAL1_ReadWriteParity8N2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8N2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -140,8 +128,6 @@ test(SERIAL1_ReadWriteParity8E2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8E2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -155,8 +141,6 @@ test(SERIAL1_ReadWriteParity8O2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8O2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -170,8 +154,6 @@ test(SERIAL1_ReadWriteParity9N1SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_9N1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -185,8 +167,6 @@ test(SERIAL1_ReadWriteParity9N2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_9N2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -202,8 +182,6 @@ test(SERIAL2_ReadWriteSucceedsInLoopbackWithD0D1Shorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial2.isEnabled())
-        Serial2.end();
     Serial2.begin(9600);
     Serial2.println(test);
     serialReadLine(&Serial2, message, 9, 1000);//1 sec timeout

--- a/user/tests/wiring/serial_loopback/serial.cpp
+++ b/user/tests/wiring/serial_loopback/serial.cpp
@@ -29,6 +29,8 @@
 #endif
 #include "unit-test/unit-test.h"
 
+SYSTEM_MODE(MANUAL);
+
 /*
  * Serial1 Test requires TX to be jumpered to RX as follows:
  * valid for both Core and Photon
@@ -48,6 +50,8 @@ test(SERIAL_ReadWriteSucceedsWithUserIntervention) {
     char test[] = "hello";
     char message[10];
     // when
+    if (Serial1.isEnabled())
+        Serial1.end();
     Serial.print("Type the following message and press Enter : ");
     Serial.println(test);
     serialReadLine(&Serial, message, 9, 10000);//10 sec timeout
@@ -61,6 +65,8 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
+    if (Serial1.isEnabled())
+        Serial1.end();
     Serial1.begin(9600);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -71,106 +77,122 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
 
 test(SERIAL1_ReadWriteParity8N1SucceedsInLoopbackWithTxRxShorted) {
         //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8N1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8N1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8E1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8E1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8E1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8O1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8O1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8O1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8N2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8N2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8N2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8E2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8E2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8E2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8O2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8O2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8O2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity9N1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_9N1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_9N1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity9N2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_9N2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_9N2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 
@@ -180,11 +202,15 @@ test(SERIAL2_ReadWriteSucceedsInLoopbackWithD0D1Shorted) {
     char test[] = "hello";
     char message[10];
     // when
+    if (Serial2.isEnabled())
+        Serial2.end();
     Serial2.begin(9600);
     Serial2.println(test);
     serialReadLine(&Serial2, message, 9, 1000);//1 sec timeout
     // then
     assertTrue(strncmp(test, message, 5)==0);
+
+    Serial2.end();
 }
 #endif
 
@@ -233,6 +259,69 @@ test(SERIAL1_AvailableForWriteWorksCorrectly) {
 
     // There should be SERIAL_BUFFER_SIZE available in TX buffer again
     assertEqual(Serial1.availableForWrite(), SERIAL_BUFFER_SIZE);
+
+    Serial1.end();
+}
+
+test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
+    // Test for LIN mode
+    // 1. The test will configure Serial1 in LIN Master mode (with 11 bit break detection
+    // enabled as in Slave mode)
+    // 2. Send and detect 2 consecutive breaks
+    // 3. Send/recv message
+    // 4. Send and detect a break
+    // 5. Send/recv message
+    // 6. Send and detect a break
+
+    char test[] = "hello";
+    char message[10];
+    memset(message, 0, sizeof(message));
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, LIN_MASTER_13B | LIN_BREAK_10B);
+    // then
+
+    // Send 2 consecutive breaks
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
+
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
+
+    // Send message
+    while(Serial1.available())
+        (void)Serial1.read();
+    Serial1.println(test);
+    Serial1.flush();
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    Serial1.println(message);
+    assertTrue(strncmp(test, message, 5)==0);
+
+    // Send break
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
+
+    // Send message
+    while(Serial1.available())
+        (void)Serial1.read();
+    Serial1.println(test);
+    Serial1.flush();
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    Serial1.println(message);
+    assertTrue(strncmp(test, message, 5)==0);
+
+    // Send break
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
 
     Serial1.end();
 }

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -54,6 +54,10 @@ public:
   size_t write(uint16_t);
   virtual size_t write(uint8_t);
 
+  // LIN
+  void breakTx(void);
+  bool breakRx(void);
+
   inline size_t write(unsigned long n) { return write((uint16_t)n); }
   inline size_t write(long n) { return write((uint16_t)n); }
   inline size_t write(unsigned int n) { return write((uint16_t)n); }

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -112,6 +112,14 @@ bool USARTSerial::isEnabled() {
   return HAL_USART_Is_Enabled(_serial);
 }
 
+void USARTSerial::breakTx() {
+  HAL_USART_Send_Break(_serial, NULL);
+}
+
+bool USARTSerial::breakRx() {
+  return (bool)HAL_USART_Break_Detected(_serial);
+}
+
 #ifndef SPARK_WIRING_NO_USART_SERIAL
 // Preinstantiate Objects //////////////////////////////////////////////////////
 static Ring_Buffer serial1_rx_buffer;


### PR DESCRIPTION
This PR implements #697 

Hardware USART serials can be configured in one of the following LIN modes:
- `LIN_MASTER_13B` - LIN Master mode with ability to send 13 bit breaks
- `LIN_SLAVE_10B` - LIN Slave mode with 10 bit break detection
- `LIN_SLAVE_11B` - LIN Slave mode with 11 bit break detection

Example: `Serial1.begin(9600, LIN_MASTER_13B);`

These are just convenient pre-defined configurations:
```C++
// Pre-defined LIN configurations
#define LIN_MASTER_13B (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13B)
#define LIN_SLAVE_10B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_10B)
#define LIN_SLAVE_11B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_11B)
```

LIN break detection can also be manually enabled in Master mode (this is a supported configuration in LIN, when Master can act as a Slave as well and respond to its own messages). This configuration was used in serial_loopback test `SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted`.
`Serial1.begin(9600, LIN_MASTER_13B | LIN_BREAK_10B);`

New Wiring methods:
- `void USARTSerial::breakTx(void);` - send break
- `bool USARTSerial::breakRx(void);` - checks if break was detected

This PR also includes support for hardware flow control settings on USARTs:
```C++
// Flow control settings
#define SERIAL_FLOW_CONTROL_NONE ((uint8_t)0b00000000)
#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b00100000)
#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b01000000)
#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b01100000)
```

Hardware flow control is available on:
- Core: Serial1 (CTS - A0, RTS - A1)
- Photon/Electron: Serial2 (CTS - A7, RTS - RGBR _(which will require some tinkering to access)_)

---

- [ ] Review code
- [ ] Test on device
- [x] Add documentation (added to #997)
- [ ] Add to CHANGELOG.md