### PR TITLE
Minor fixes for I2C in Slave mode with clock stretching enabled

### DIFF
--- a/user/tests/wiring/i2c_master_slave/i2c_master/application.cpp
+++ b/user/tests/wiring/i2c_master_slave/i2c_master/application.cpp
@@ -1,0 +1,6 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+UNIT_TEST_APP();

--- a/user/tests/wiring/i2c_master_slave/i2c_master/i2c_master.cpp
+++ b/user/tests/wiring/i2c_master_slave/i2c_master/i2c_master.cpp
@@ -1,0 +1,137 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+#define MASTER_TEST_MESSAGE "Hello from I2C Master!?"
+//#define SLAVE_TEST_MESSAGE_1  "I2C Slave is doing good"
+#define SLAVE_TEST_MESSAGE_2  "All work and no play makes Jack a dull boy"
+#define TRANSFER_LENGTH_1 (sizeof(MASTER_TEST_MESSAGE) + sizeof(uint32_t))
+#define TRANSFER_LENGTH_2 sizeof(SLAVE_TEST_MESSAGE_2)
+
+#define I2C_DELAY 0
+#define I2C_ADDRESS 0x32
+
+static uint8_t I2C_Master_Tx_Buffer[TRANSFER_LENGTH_2];
+static uint8_t I2C_Master_Rx_Buffer[TRANSFER_LENGTH_2];
+static int I2C_Test_Counter = 2;
+
+static void I2C_Master_Configure()
+{
+    Wire.setSpeed(400000);
+    Wire.begin();
+}
+
+test(I2C_Master_Slave_Master_Variable_Length_Transfer)
+{
+    if (I2C_Test_Counter == 2)
+        Serial.println("This is Master");
+    I2C_Test_Counter--;
+    uint32_t requestedLength = I2C_BUFFER_LENGTH;
+    I2C_Master_Configure();
+
+    while (requestedLength >= 0)
+    {
+        if (requestedLength == 0 && I2C_Test_Counter != 0)
+        {
+            /* Zero-length request instructs Slave to finish running its own test. */
+            break;
+        }
+        memset(I2C_Master_Tx_Buffer, 0, sizeof(I2C_Master_Tx_Buffer));
+        memset(I2C_Master_Rx_Buffer, 0, sizeof(I2C_Master_Rx_Buffer));
+
+        // delay(I2C_DELAY);
+
+        memcpy(I2C_Master_Tx_Buffer, MASTER_TEST_MESSAGE, sizeof(MASTER_TEST_MESSAGE));
+        memcpy(I2C_Master_Tx_Buffer + sizeof(MASTER_TEST_MESSAGE), (void*)&requestedLength, sizeof(uint32_t));
+
+        Wire.beginTransmission(I2C_ADDRESS);
+        Wire.write(I2C_Master_Tx_Buffer, TRANSFER_LENGTH_1);
+        
+        // End with STOP
+        Wire.endTransmission(true);
+        // delay(I2C_DELAY);
+
+        if (requestedLength == 0)
+            break;
+
+        // Now read out requestedLength bytes
+        memset(I2C_Master_Rx_Buffer, 0, sizeof(I2C_Master_Rx_Buffer));
+        Wire.requestFrom(I2C_ADDRESS, requestedLength);
+        assertEqual(requestedLength, Wire.available());
+
+        uint32_t count = 0;
+        while(Wire.available()) {
+            I2C_Master_Rx_Buffer[count++] = Wire.read();
+        }
+        // Serial.print("< ");
+        // Serial.println((const char *)I2C_Master_Rx_Buffer);
+        assertTrue(strncmp((const char *)I2C_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength) == 0);
+
+        requestedLength--;
+    }
+
+    Wire.end();
+}
+
+test(I2C_Master_Slave_Master_Variable_Length_Transfer_Slave_Tx_Buffer_Underflow)
+{
+    /* This test requests the slave to prepare N bytes for transmission, but the actual
+     * number of bytes clocked by the Master is N + 1. This will cause tx buffer underrun on the Slave.
+     * When clock stretching is enabled, the I2C peripheral in Slave mode by default will continue pulling SCL low,
+     * until the data is loaded into the DR register. This might cause the bus to enter an unrecoverable state.
+     */
+    if (I2C_Test_Counter == 2)
+        Serial.println("This is Master");
+    I2C_Test_Counter--;
+    uint32_t requestedLength = I2C_BUFFER_LENGTH - 1;
+    I2C_Master_Configure();
+
+    while (requestedLength >= 0)
+    {
+        if (requestedLength == 0 && I2C_Test_Counter != 0)
+        {
+            /* Zero-length request instructs Slave to finish running its own test. */
+            break;
+        }
+        memset(I2C_Master_Tx_Buffer, 0, sizeof(I2C_Master_Tx_Buffer));
+        memset(I2C_Master_Rx_Buffer, 0, sizeof(I2C_Master_Rx_Buffer));
+
+        // delay(I2C_DELAY);
+
+        memcpy(I2C_Master_Tx_Buffer, MASTER_TEST_MESSAGE, sizeof(MASTER_TEST_MESSAGE));
+        memcpy(I2C_Master_Tx_Buffer + sizeof(MASTER_TEST_MESSAGE), (void*)&requestedLength, sizeof(uint32_t));
+
+        Wire.beginTransmission(I2C_ADDRESS);
+        Wire.write(I2C_Master_Tx_Buffer, TRANSFER_LENGTH_1);
+        
+        // End with STOP
+        Wire.endTransmission(true);
+        // delay(I2C_DELAY);
+
+        if (requestedLength == 0)
+            break;
+
+        // Now read out requestedLength bytes
+        memset(I2C_Master_Rx_Buffer, 0, sizeof(I2C_Master_Rx_Buffer));
+        Wire.requestFrom(I2C_ADDRESS, requestedLength + (requestedLength & 0x01));
+        if (Wire.available() != 0) {
+            assertEqual(requestedLength + (requestedLength & 0x01), Wire.available());
+
+            uint32_t count = 0;
+            while(Wire.available()) {
+                I2C_Master_Rx_Buffer[count++] = Wire.read();
+            }
+            // Serial.print("< ");
+            // Serial.println((const char *)I2C_Master_Rx_Buffer);
+            assertTrue(strncmp((const char *)I2C_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength) == 0);
+        } else if (requestedLength & 0x01) {
+            Serial.println("Error reading from Slave, checking if we can recover");
+        } else {
+            Serial.println("Failed to recover");
+            assertTrue(false);
+        }
+
+        requestedLength--;
+    }
+
+    Wire.end();
+}

--- a/user/tests/wiring/i2c_master_slave/i2c_slave/application.cpp
+++ b/user/tests/wiring/i2c_master_slave/i2c_slave/application.cpp
@@ -1,0 +1,6 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+UNIT_TEST_APP();

--- a/user/tests/wiring/i2c_master_slave/i2c_slave/i2c_slave.cpp
+++ b/user/tests/wiring/i2c_master_slave/i2c_slave/i2c_slave.cpp
@@ -1,0 +1,66 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+#define MASTER_TEST_MESSAGE "Hello from I2C Master!?"
+//#define SLAVE_TEST_MESSAGE_1  "I2C Slave is doing good"
+#define SLAVE_TEST_MESSAGE_2  "All work and no play makes Jack a dull boy"
+#define TRANSFER_LENGTH_1 (sizeof(MASTER_TEST_MESSAGE) + sizeof(uint32_t))
+#define TRANSFER_LENGTH_2 sizeof(SLAVE_TEST_MESSAGE_2)
+
+#define I2C_ADDRESS 0x32
+
+static uint8_t I2C_Slave_Tx_Buffer[TRANSFER_LENGTH_2];
+static uint8_t I2C_Slave_Rx_Buffer[TRANSFER_LENGTH_2];
+
+static uint8_t done = 0;
+static uint32_t requestedLength = 0;
+
+static int random_range(int minVal, int maxVal)
+{
+    return rand() % (maxVal - minVal + 1) + minVal;
+}
+
+void I2C_Slave_On_Request_Callback(void) {
+    // Random delay.
+    // Just to be on a safe side delay between 0 and 50ms (I2C EVENT_TIMEOUT / 2)
+    delayMicroseconds(random_range(0, 50000));
+    memset(I2C_Slave_Tx_Buffer, 0, sizeof(I2C_Slave_Tx_Buffer));
+    memcpy(I2C_Slave_Tx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength);
+    Wire.write((const uint8_t*)I2C_Slave_Tx_Buffer, requestedLength);   
+}
+
+void I2C_Slave_On_Receive_Callback(int) {
+    assertEqual(Wire.available(), TRANSFER_LENGTH_1);
+    int count = 0;
+    while(Wire.available()) {
+        I2C_Slave_Rx_Buffer[count++] = Wire.read();
+    }
+    I2C_Slave_Rx_Buffer[count] = 0x00;
+
+    // Serial.print("< ");
+    // Serial.println((const char *)I2C_Slave_Rx_Buffer);
+
+    assertTrue(strncmp((const char *)I2C_Slave_Rx_Buffer, MASTER_TEST_MESSAGE, sizeof(MASTER_TEST_MESSAGE)) == 0);
+
+    requestedLength = *((uint32_t *)(I2C_Slave_Rx_Buffer + sizeof(MASTER_TEST_MESSAGE)));
+    assertTrue((requestedLength >= 0 && requestedLength <= TRANSFER_LENGTH_2));
+
+    if (requestedLength == 0)
+        done = 1;
+}
+
+test(I2C_Master_Slave_Slave_Transfer)
+{
+    Serial.println("This is Slave");
+    Serial.blockOnOverrun(false);
+    Wire.begin(I2C_ADDRESS);
+    Wire.stretchClock(true);
+    Wire.onRequest(I2C_Slave_On_Request_Callback);
+    Wire.onReceive(I2C_Slave_On_Receive_Callback);
+
+    while(done == 0) {
+        delay(100);
+    }
+
+    Wire.end();
+}


### PR DESCRIPTION
Related to #402. Minor fixes for I2C in Slave mode with clock stretching enabled.

PR also includes I2C Master/Slave test applications similar to wiring/spi_master_slave in wiring/i2c_master_slave/i2c_master and wiring/i2c_master_slave/i2c_slave.

The PR in particular fixes:
- Possible overflow of I2C RX buffer when operating in I2C Slave mode
- Possible bus lockup when clock stretching is enabled in I2C Slave mode (see https://github.com/spark/firmware/commit/4018e7d2b10135a91187ad551b6866b4663c8db2#diff-4657e1c7c22d248c72382fb3eb9c0c9dR75 for some explanation)

---

- [x] Review code
- [x] Test on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md