### PR TITLE
Fixes flush() semantics for UDP and TCPClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## v0.6.0-rc.1
 
+### BREAKING CHANGES
+- `UDP.flush()` and `TCP.flush()`  now conform to the `Stream.flush()` behavior from Arduino 1.0 Wiring. The current (correct) behavior is to wait
+  until all data has been transmitted. Previous behavior discarded data in the buffer. [#469](https://github.com/spark/firmware/issues/469)
+
 ### FEATURES
 
 - [Electron] Reduced data consumption connecting to the cloud with deep sleep. (NB: see the docs for how to gain the full data reduction.) [#953](https://github.com/spark/firmware/pull/953)

--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -3332,10 +3332,6 @@ so to that subsequent output appears on the next line.
 
 Waits for the transmission of outgoing serial data to complete.
 
-**NOTE:** That this function does nothing at present, in particular it doesn't
-wait for the data to be sent, since this causes the application to wait indefinitely
-when there is no serial monitor connected.
-
 ```C++
 // SYNTAX
 Serial.flush();
@@ -4667,7 +4663,9 @@ Returns the next byte (or character), or -1 if none is available.
 
 ### flush()
 
-Discard any bytes that have been written to the client but not yet read.
+Waits until all outgoing data in buffer has been sent.
+
+**NOTE:** That this function does nothing at present.
 
 ```C++
 // SYNTAX
@@ -4767,7 +4765,8 @@ void loop() {
     char c = Udp.read();
 
     // Ignore other chars
-    Udp.flush();
+    while(Udp.available())
+      Udp.read();
 
     // Store sender ip and port
     IPAddress ipAddress = Udp.remoteIP();
@@ -4913,6 +4912,16 @@ Returns:
 
  - `int`: returns the character in the buffer or -1 if no character is available
 
+### flush()
+
+Waits until all outgoing data in buffer has been sent.
+
+**NOTE:** That this function does nothing at present.
+
+```C++
+// SYNTAX
+Udp.flush();
+```
 
 ### stop()
 

--- a/wiring/inc/spark_wiring_udp.h
+++ b/wiring/inc/spark_wiring_udp.h
@@ -201,9 +201,15 @@ public:
 	virtual int peek();
 
         /**
-         * Discards the currently read packet.
+         * Blocks until all data has been sent out
          */
 	virtual void flush();
+
+
+    /**
+     * Discards the currently read packet.
+     */
+    void flush_buffer();
 
 
 	virtual IPAddress remoteIP() { return _remoteIP; };

--- a/wiring/src/spark_wiring_tcpclient.cpp
+++ b/wiring/src/spark_wiring_tcpclient.cpp
@@ -182,8 +182,6 @@ void TCPClient::flush_buffer()
 
 void TCPClient::flush()
 {
-  while (available())
-    read();
 }
 
 

--- a/wiring/src/spark_wiring_udp.cpp
+++ b/wiring/src/spark_wiring_udp.cpp
@@ -67,7 +67,7 @@ void UDP::releaseBuffer()
     _buffer = NULL;
     _buffer_allocated = false;
     _buffer_size = 0;
-    flush();
+    flush_buffer();
 }
 
 uint8_t UDP::begin(uint16_t port, network_interface_t nif)
@@ -234,6 +234,10 @@ int UDP::peek()
 }
 
 void UDP::flush()
+{
+}
+
+void UDP::flush_buffer()
 {
   _offset = 0;
   _total = 0;


### PR DESCRIPTION
Closes #469 

---

- [x] Review code
- [ ] Test on device
- [x] Add documentation
- [x] Add to CHANGELOG.md