### PR TITLE
Changed DFU baud rate from 14400 to 19200

### DIFF
--- a/build/module-defaults.mk
+++ b/build/module-defaults.mk
@@ -1,5 +1,5 @@
 # Uncomment the following to enable serial bitrate specific dfu/ymodem flasher in code
-START_DFU_FLASHER_SERIAL_SPEED=14400
+START_DFU_FLASHER_SERIAL_SPEED=19200
 # Uncommenting this increase the size of the firmware image because of ymodem addition
 START_YMODEM_FLASHER_SERIAL_SPEED=28800
 


### PR DESCRIPTION
Linux Distributions only allow a specific range of baud rates for serial.  14400 baud is not accepted.  I propose that the baud rate to trigger DFU mode on the Photon and Electron to be 19200 baud, an acceptable rate for Linux Distributions that also works on OSX.

To trigger DFU mode on Linux, simply do:
```
stty -F /dev/ttyACM0 19200
```
Likewise on OSX, you would do:
```
stty -f /dev/cu.usbmodemXXXX 19200
```