### PR TITLE
wifi country

### DIFF
--- a/hal/src/photon/platforms/BCM9WCDUSI09/wifi_nvram_image.h
+++ b/hal/src/photon/platforms/BCM9WCDUSI09/wifi_nvram_image.h
@@ -76,18 +76,18 @@ static const char wifi_ltxp_nvram_image[] =
         "ag0=2"                                                     "\x00"
 
 #if !WIFI_NVRAM_LTXP
-		"maxp2ga0=74"                                               "\x00"
+        "maxp2ga0=74"                                               "\x00"
         "ofdm2gpo=0x44111111"                                       "\x00"
         "mcs2gpo0=0x4444"                                           "\x00"
         "mcs2gpo1=0x6444"                                           "\x00"
 #else
-		"maxp2ga0=62"                                               "\x00"
+        "maxp2ga0=62"                                               "\x00"
         "ofdm2gpo=0xCCCCCCCC"                                       "\x00"
         "mcs2gpo0=0xCCCC"                                           "\x00"
         "mcs2gpo1=0xCCCC"                                           "\x00"
 #endif
 
-		"pa0maxpwr=80"                                              "\x00"
+        "pa0maxpwr=80"                                              "\x00"
         "pa0b0=5264"                                                "\x00"  /*PA params*/
         "pa0b1=64897"                                               "\x00"
         "pa0b2=65359"                                               "\x00"
@@ -125,8 +125,8 @@ static const char wifi_ltxp_nvram_image[] =
         "rfreg033_cck=0x1f"                                         "\x00"
         "cckPwrIdxCorr=-8"                                          "\x00"
         "spuravoid_enable2g=1"                                      "\x00"
-		"edonthd=-70" 												"\x00"
-		"edoffthd=-76"												"\x00"
+        "edonthd=-70"                                               "\x00"
+        "edoffthd=-76"                                              "\x00"
         "\x00\x00";
 
 #else /* ifndef INCLUDED_NVRAM_IMAGE_H_ */

--- a/hal/src/photon/platforms/BCM9WCDUSI09/wifi_nvram_image.h
+++ b/hal/src/photon/platforms/BCM9WCDUSI09/wifi_nvram_image.h
@@ -36,6 +36,7 @@
 /** @file
  *
  *  BCM43362 NVRAM variables for WM-N-BM-09 USI SiP
+ * 20151216 modify maxp2ga0 from 74 to 62(3dBm deduced);ofdm2gpo from 0x44111111 to all C; mcs2gpo0 from all 4 to all C ; mcs2gpo1=0x6444 to ALL C
  *
  */
 
@@ -46,11 +47,19 @@
 #include <stdint.h>
 #include "../generated_mac_address.txt"
 
+#ifndef WIFI_NVRAM_LTXP
+#define WIFI_NVRAM_LTXP 0
+#endif
+
 /**
  * Character array of NVRAM image
  */
 
-static const char wifi_nvram_image[] =
+#if !WIFI_NVRAM_LTXP
+static const char wifi_main_nvram_image[] =
+#else
+static const char wifi_ltxp_nvram_image[] =
+#endif
         "manfid=0x2d0"                                              "\x00"
         "prodid=0x492"                                              "\x00"
         "vendid=0x14e4"                                             "\x00"
@@ -65,11 +74,20 @@ static const char wifi_nvram_image[] =
         NVRAM_GENERATED_MAC_ADDRESS                                 "\x00"
         "aa2g=3"                                                    "\x00"
         "ag0=2"                                                     "\x00"
-        "maxp2ga0=74"                                               "\x00"
+
+#if !WIFI_NVRAM_LTXP
+		"maxp2ga0=74"                                               "\x00"
         "ofdm2gpo=0x44111111"                                       "\x00"
         "mcs2gpo0=0x4444"                                           "\x00"
         "mcs2gpo1=0x6444"                                           "\x00"
-        "pa0maxpwr=80"                                              "\x00"
+#else
+		"maxp2ga0=62"                                               "\x00"
+        "ofdm2gpo=0xCCCCCCCC"                                       "\x00"
+        "mcs2gpo0=0xCCCC"                                           "\x00"
+        "mcs2gpo1=0xCCCC"                                           "\x00"
+#endif
+
+		"pa0maxpwr=80"                                              "\x00"
         "pa0b0=5264"                                                "\x00"  /*PA params*/
         "pa0b1=64897"                                               "\x00"
         "pa0b2=65359"                                               "\x00"

--- a/hal/src/photon/platforms/BCM9WCDUSI14/wifi_nvram_image.h
+++ b/hal/src/photon/platforms/BCM9WCDUSI14/wifi_nvram_image.h
@@ -37,6 +37,9 @@
  *
  *  BCM43362 NVRAM variables for WICED Module (USI WM-N-BM-14)
  *  Created : 18 April 2012, ssamson
+ *  BCM43362 NVRAM variables for WM-N-BM-09 USI SiP
+ * 20151216 modify maxp2ga0 from 74 to 62(3dBm deduced);ofdm2gpo from 0x44111111 to all C; mcs2gpo0 from all 4 to all C ; mcs2gpo1=0x6444 to ALL C
+ *
  */
 
 #ifndef INCLUDED_NVRAM_IMAGE_H_
@@ -50,11 +53,19 @@
 extern "C" {
 #endif
 
+#ifndef WIFI_NVRAM_LTXP
+#define WIFI_NVRAM_LTXP 0
+#endif
+
 /**
  * Character array of NVRAM image
  */
 
-static const char wifi_nvram_image[] =
+#if !WIFI_NVRAM_LTXP
+static const char wifi_main_nvram_image[] =
+#else
+static const char wifi_ltxp_nvram_image[] =
+#endif
         "manfid=0x2d0"                                              "\x00"
         "prodid=0x492"                                              "\x00"
         "vendid=0x14e4"                                             "\x00"
@@ -69,11 +80,20 @@ static const char wifi_nvram_image[] =
         NVRAM_GENERATED_MAC_ADDRESS                                 "\x00"
         "aa2g=3"                                                    "\x00"
         "ag0=2"                                                     "\x00"
-        "maxp2ga0=74"                                               "\x00"
+
+#if !WIFI_NVRAM_LTXP
+		"maxp2ga0=74"                                               "\x00"
         "ofdm2gpo=0x44111111"                                       "\x00"
         "mcs2gpo0=0x4444"                                           "\x00"
         "mcs2gpo1=0x6444"                                           "\x00"
-        "pa0maxpwr=80"                                              "\x00"
+#else
+		"maxp2ga0=62"                                               "\x00"
+        "ofdm2gpo=0xCCCCCCCC"                                       "\x00"
+        "mcs2gpo0=0xCCCC"                                           "\x00"
+        "mcs2gpo1=0xCCCC"                                           "\x00"
+#endif
+
+		"pa0maxpwr=80"                                              "\x00"
         "pa0b0=5609"                                                "\x00"  /*PA params*/
         "pa0b1=-672"                                                "\x00"
         "pa0b2=-170"                                                "\x00"
@@ -111,8 +131,8 @@ static const char wifi_nvram_image[] =
         "rfreg033_cck=0x1f"                                         "\x00"
         "cckPwrIdxCorr=-8"                                          "\x00"
         "spuravoid_enable2g=1"                                      "\x00"
-        "edonthd=-70"                                               "\x00"
-        "edoffthd=-76"                                              "\x00"
+		"edonthd=-70" 												"\x00"
+		"edoffthd=-76"												"\x00"
         "\x00\x00";
 
 #ifdef __cplusplus

--- a/hal/src/photon/platforms/BCM9WCDUSI14/wifi_nvram_image.h
+++ b/hal/src/photon/platforms/BCM9WCDUSI14/wifi_nvram_image.h
@@ -82,18 +82,18 @@ static const char wifi_ltxp_nvram_image[] =
         "ag0=2"                                                     "\x00"
 
 #if !WIFI_NVRAM_LTXP
-		"maxp2ga0=74"                                               "\x00"
+        "maxp2ga0=74"                                               "\x00"
         "ofdm2gpo=0x44111111"                                       "\x00"
         "mcs2gpo0=0x4444"                                           "\x00"
         "mcs2gpo1=0x6444"                                           "\x00"
 #else
-		"maxp2ga0=62"                                               "\x00"
+        "maxp2ga0=62"                                               "\x00"
         "ofdm2gpo=0xCCCCCCCC"                                       "\x00"
         "mcs2gpo0=0xCCCC"                                           "\x00"
         "mcs2gpo1=0xCCCC"                                           "\x00"
 #endif
 
-		"pa0maxpwr=80"                                              "\x00"
+        "pa0maxpwr=80"                                              "\x00"
         "pa0b0=5609"                                                "\x00"  /*PA params*/
         "pa0b1=-672"                                                "\x00"
         "pa0b2=-170"                                                "\x00"
@@ -131,8 +131,8 @@ static const char wifi_ltxp_nvram_image[] =
         "rfreg033_cck=0x1f"                                         "\x00"
         "cckPwrIdxCorr=-8"                                          "\x00"
         "spuravoid_enable2g=1"                                      "\x00"
-		"edonthd=-70" 												"\x00"
-		"edoffthd=-76"												"\x00"
+        "edonthd=-70"                                               "\x00"
+        "edoffthd=-76"                                              "\x00"
         "\x00\x00";
 
 #ifdef __cplusplus

--- a/hal/src/photon/resources.c
+++ b/hal/src/photon/resources.c
@@ -18,28 +18,25 @@ static const resource_hnd_t wifi_nvram_resources[] = {
 static uint8_t wifi_nvram_resource_index = 0;
 
 /**
- * This is a bit of a hack. The resources.c file is compiled in the HAL, but then it's borrowed for system-part1, which is linked as a
- * dynamic library. The resources.o is still linked in the hal in part2, but part2 is also importing the dynamic library, leading to a double
- * definition of these functions. Marking them weak sidesteps this.
+ * This is a bit of a hack. The resources.c file is compiled in the HAL, but then it's borrowed for
+ * system-part1, which is linked as a dynamic library. The resources.o is still linked in the hal in
+ * part2, but part2 is also importing the dynamic library, leading to a double definition of these
+ * functions. Marking them weak sidesteps this.
  * I imagine there's a more elegant way to solve this, but this was quick to implement.
  */
 const resource_hnd_t* wwd_nvram_image_resource(void) __attribute__((weak));
 int wwd_select_nvram_image_resource(uint8_t index, void* reserved) __attribute__((weak));
-
 
 const resource_hnd_t* wwd_nvram_image_resource(void)
 {
     return &wifi_nvram_resources[wifi_nvram_resource_index];
 }
 
-
-
 /**
  * @param index: 0 for regular, 1 for reduced transmit power (for TELEC certification.)
  */
 int wwd_select_nvram_image_resource(uint8_t index, void* reserved)
 {
-	wifi_nvram_resource_index = index;
-	return 0;
+    wifi_nvram_resource_index = index;
+    return 0;
 }
-

--- a/hal/src/photon/resources.c
+++ b/hal/src/photon/resources.c
@@ -1,16 +1,45 @@
 
 #include "wiced_resource.h"
+#include "wwd_resources.h"
+
+#define WIFI_NVRAM_LTXP 1
+#include "wifi_nvram_image.h"
+#undef WIFI_NVRAM_LTXP
+#undef INCLUDED_NVRAM_IMAGE_H_
 #include "wifi_nvram_image.h"
 
-#define NVRAM_SIZE             sizeof( wifi_nvram_image )
-#define NVRAM_IMAGE_VARIABLE   wifi_nvram_image
 
-const resource_hnd_t* wwd_nvram_image_resource(void) __attribute__((weak)) ;
+static const resource_hnd_t wifi_nvram_resources[] = {
+		{ RESOURCE_IN_MEMORY, sizeof( wifi_main_nvram_image ), {.mem = { (const char *) wifi_main_nvram_image }}},
+		{ RESOURCE_IN_MEMORY, sizeof( wifi_ltxp_nvram_image ), {.mem = { (const char *) wifi_ltxp_nvram_image }}}
+};
+
+
+static uint8_t wifi_nvram_resource_index = 0;
+
+/**
+ * This is a bit of a hack. The resources.c file is compiled in the HAL, but then it's borrowed for system-part1, which is linked as a
+ * dynamic library. The resources.o is still linked in the hal in part2, but part2 is also importing the dynamic library, leading to a double
+ * definition of these functions. Marking them weak sidesteps this.
+ * I imagine there's a more elegant way to solve this, but this was quick to implement.
+ */
+const resource_hnd_t* wwd_nvram_image_resource(void) __attribute__((weak));
+int wwd_select_nvram_image_resource(uint8_t index, void* reserved) __attribute__((weak));
+
 
 const resource_hnd_t* wwd_nvram_image_resource(void)
 {
-    static const resource_hnd_t wifi_nvram_resource = { RESOURCE_IN_MEMORY, NVRAM_SIZE, {.mem = { (const char *) NVRAM_IMAGE_VARIABLE}}};
-    return &wifi_nvram_resource;
+    return &wifi_nvram_resources[wifi_nvram_resource_index];
 }
 
+
+
+/**
+ * @param index: 0 for regular, 1 for reduced transmit power (for TELEC certification.)
+ */
+int wwd_select_nvram_image_resource(uint8_t index, void* reserved)
+{
+	wifi_nvram_resource_index = index;
+	return 0;
+}
 

--- a/hal/src/photon/softap.h
+++ b/hal/src/photon/softap.h
@@ -36,6 +36,7 @@ extern "C" {
         uint16_t passwordLen, wiced_security_t security, unsigned channel);
 
     size_t hex_decode(uint8_t* buf, size_t len, const char* hex);
+    uint8_t hex_nibble(unsigned char c);
 
 #ifdef	__cplusplus
 }

--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -52,22 +52,28 @@ wiced_country_code_t fetch_country_code()
 {
     const uint8_t* code = (const uint8_t*)dct_read_app_data(DCT_COUNTRY_CODE_OFFSET);
 
-    wiced_country_code_t result = wiced_country_code_t(MK_CNTRY(code[0], code[1], hex_nibble(code[2])));
-    if (code[0]==0xFF || code[0]==0) {
-        result = WICED_COUNTRY_UNITED_KINGDOM;          // default is UK, so channels 1-13 are available by default.
+    wiced_country_code_t result =
+        wiced_country_code_t(MK_CNTRY(code[0], code[1], hex_nibble(code[2])));
+    if (code[0] == 0xFF || code[0] == 0)
+    {
+        result = WICED_COUNTRY_UNITED_KINGDOM; // default is UK, so channels 1-13 are available by default.
     }
-    if (result==WICED_COUNTRY_JAPAN)
-        wwd_select_nvram_image_resource(1, nullptr);    // lower tx power for TELEC certification
+    if (result == WICED_COUNTRY_JAPAN)
+    {
+        wwd_select_nvram_image_resource(1, nullptr); // lower tx power for TELEC certification
+    }
     return result;
 }
 
-bool initialize_dct(platform_dct_wifi_config_t* wifi_config, bool force=false)
+bool initialize_dct(platform_dct_wifi_config_t* wifi_config, bool force = false)
 {
     bool changed = false;
     wiced_country_code_t country = fetch_country_code();
-    if (force || wifi_config->device_configured!=WICED_TRUE || wifi_config->country_code!=country) {
+    if (force || wifi_config->device_configured != WICED_TRUE ||
+        wifi_config->country_code != country)
+    {
         if (!wifi_config->device_configured)
-    			memset(wifi_config, 0, sizeof(*wifi_config));
+            memset(wifi_config, 0, sizeof(*wifi_config));
         wifi_config->country_code = country;
         wifi_config->device_configured = WICED_TRUE;
         changed = true;
@@ -83,11 +89,14 @@ wiced_result_t wlan_initialize_dct()
 {
     // find the next available slot, or use the first
     platform_dct_wifi_config_t* wifi_config = NULL;
-    wiced_result_t result = wiced_dct_read_lock( (void**) &wifi_config, WICED_TRUE, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
-    if (result==WICED_SUCCESS) {
+    wiced_result_t result = wiced_dct_read_lock((void**)&wifi_config, WICED_TRUE,
+                                                DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
+    if (result == WICED_SUCCESS)
+    {
         // the storage may not have been initialized, so device_configured will be 0xFF
         if (initialize_dct(wifi_config))
-            result = wiced_dct_write( (const void*) wifi_config, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config) );
+            result = wiced_dct_write((const void*)wifi_config, DCT_WIFI_CONFIG_SECTION, 0,
+                                     sizeof(*wifi_config));
         wiced_dct_read_unlock(wifi_config, WICED_TRUE);
     }
     return result;
@@ -114,43 +123,52 @@ int wlan_clear_credentials()
     // write to DCT credentials
     // clear current IP
     platform_dct_wifi_config_t* wifi_config = NULL;
-    wiced_result_t result = wiced_dct_read_lock( (void**) &wifi_config, WICED_TRUE, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
-    if (!result) {
+    wiced_result_t result = wiced_dct_read_lock((void**)&wifi_config, WICED_TRUE,
+                                                DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
+    if (!result)
+    {
         memset(wifi_config->stored_ap_list, 0, sizeof(wifi_config->stored_ap_list));
-        result = wiced_dct_write( (const void*) wifi_config, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config) );
+        result = wiced_dct_write((const void*)wifi_config, DCT_WIFI_CONFIG_SECTION, 0,
+                                 sizeof(*wifi_config));
         wiced_dct_read_unlock(wifi_config, WICED_TRUE);
     }
     return result;
 }
 
-int is_set(const unsigned char* pv, unsigned length) {
+int is_set(const unsigned char* pv, unsigned length)
+{
     int result = 0;
     int result2 = 0xFF;
-    while (length-->0) {
+    while (length-- > 0)
+    {
         result |= *pv;
         result2 &= *pv;
     }
-    return result && result2!=0xFF;
+    return result && result2 != 0xFF;
 }
 
 bool is_ap_config_set(const wiced_config_ap_entry_t& ap_entry)
 {
-    bool set = ((ap_entry.details.SSID.length>0 && ap_entry.details.SSID.length<33))
-      || is_set(ap_entry.details.BSSID.octet, sizeof(ap_entry.details.BSSID));
+    bool set = ((ap_entry.details.SSID.length > 0 && ap_entry.details.SSID.length < 33)) ||
+               is_set(ap_entry.details.BSSID.octet, sizeof(ap_entry.details.BSSID));
     return set;
 }
 
 /**
  * Determine if the DCT contains wifi credentials.
- * @return 0 if the device has credentials. 1 otherwise. (yes, it's backwards! The intent is that negative values indicate some kind of error.)
+ * @return 0 if the device has credentials. 1 otherwise. (yes, it's backwards! The intent is that
+ * negative values indicate some kind of error.)
  */
 int wlan_has_credentials()
 {
     int has_credentials = 0;
     platform_dct_wifi_config_t* wifi_config = NULL;
-    wiced_result_t result = wiced_dct_read_lock( (void**) &wifi_config, WICED_FALSE, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
-    if (result==WICED_SUCCESS) {
-        has_credentials = wifi_config->device_configured==WICED_TRUE && is_ap_config_set(wifi_config->stored_ap_list[0]);
+    wiced_result_t result = wiced_dct_read_lock((void**)&wifi_config, WICED_FALSE,
+                                                DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
+    if (result == WICED_SUCCESS)
+    {
+        has_credentials = wifi_config->device_configured == WICED_TRUE &&
+                          is_ap_config_set(wifi_config->stored_ap_list[0]);
     }
     wiced_dct_read_unlock(wifi_config, WICED_FALSE);
     return !has_credentials;
@@ -168,11 +186,12 @@ int wlan_connect_init()
 
 bool to_wiced_ip_address(wiced_ip_address_t& wiced, const dct_ip_address_v4_t& dct)
 {
-	if (dct!=0) {
-		wiced.ip.v4 = dct;
-		wiced.version = WICED_IPV4;
-	}
-    return (dct!=0);
+    if (dct != 0)
+    {
+        wiced.ip.v4 = dct;
+        wiced.version = WICED_IPV4;
+    }
+    return (dct != 0);
 }
 
 void wlan_connect_timeout(os_timer_t t)
@@ -187,31 +206,35 @@ void wlan_connect_timeout(os_timer_t t)
 wlan_result_t wlan_connect_finalize()
 {
     os_timer_t cancel_timer = 0;
-    os_timer_create(&cancel_timer, 60000, &wlan_connect_timeout, nullptr, false /* oneshot */, nullptr);
+    os_timer_create(&cancel_timer, 60000, &wlan_connect_timeout, nullptr, false /* oneshot */,
+                    nullptr);
 
     // enable connection from stored profiles
     wlan_result_t result = wiced_interface_up(WICED_STA_INTERFACE);
-    if (!result) {
+    if (!result)
+    {
         HAL_NET_notify_connected();
         wiced_ip_setting_t settings;
         wiced_ip_address_t dns;
         const static_ip_config_t& ip_config = *wlan_fetch_saved_ip_config();
 
-        switch (IPAddressSource(ip_config.config_mode)) {
-            case STATIC_IP:
-                to_wiced_ip_address(settings.ip_address, ip_config.host);
-                to_wiced_ip_address(settings.netmask, ip_config.netmask);
-                to_wiced_ip_address(settings.gateway, ip_config.gateway);
-                result = wiced_network_up(WICED_STA_INTERFACE, WICED_USE_STATIC_IP, &settings);
-                if (!result) {
-                    if (to_wiced_ip_address(dns, ip_config.dns1))
-                        dns_client_add_server_address(dns);
-                    if (to_wiced_ip_address(dns, ip_config.dns2))
-                        dns_client_add_server_address(dns);
-                }
-            default:
-                result = wiced_network_up(WICED_STA_INTERFACE, WICED_USE_EXTERNAL_DHCP_SERVER, NULL);
-                break;
+        switch (IPAddressSource(ip_config.config_mode))
+        {
+        case STATIC_IP:
+            to_wiced_ip_address(settings.ip_address, ip_config.host);
+            to_wiced_ip_address(settings.netmask, ip_config.netmask);
+            to_wiced_ip_address(settings.gateway, ip_config.gateway);
+            result = wiced_network_up(WICED_STA_INTERFACE, WICED_USE_STATIC_IP, &settings);
+            if (!result)
+            {
+                if (to_wiced_ip_address(dns, ip_config.dns1))
+                    dns_client_add_server_address(dns);
+                if (to_wiced_ip_address(dns, ip_config.dns2))
+                    dns_client_add_server_address(dns);
+            }
+        default:
+            result = wiced_network_up(WICED_STA_INTERFACE, WICED_USE_EXTERNAL_DHCP_SERVER, NULL);
+            break;
         }
     }
     else
@@ -222,7 +245,8 @@ wlan_result_t wlan_connect_finalize()
     HAL_NET_notify_dhcp(!result);
     wiced_network_up_cancel = 0;
 
-    if (cancel_timer) {
+    if (cancel_timer)
+    {
         os_timer_destroy(cancel_timer, nullptr);
     }
     return result;
@@ -230,23 +254,25 @@ wlan_result_t wlan_connect_finalize()
 
 int wlan_select_antenna_impl(WLanSelectAntenna_TypeDef antenna);
 
-
 WLanSelectAntenna_TypeDef fetch_antenna_selection()
 {
     uint8_t result = *(const uint8_t*)dct_read_app_data(DCT_ANTENNA_SELECTION_OFFSET);
-    if (result==0xFF)
-        result = ANT_INTERNAL;  // default
+    if (result == 0xFF)
+        result = ANT_INTERNAL; // default
     return WLanSelectAntenna_TypeDef(result);
 }
 
-STATIC_ASSERT(wlanselectantenna_typedef_is_size_1, sizeof(WLanSelectAntenna_TypeDef)==1);
+STATIC_ASSERT(wlanselectantenna_typedef_is_size_1, sizeof(WLanSelectAntenna_TypeDef) == 1);
 
 void save_antenna_selection(WLanSelectAntenna_TypeDef selection)
 {
     dct_write_app_data(&selection, DCT_ANTENNA_SELECTION_OFFSET, DCT_ANTENNA_SELECTION_SIZE);
 }
 
-inline int wlan_refresh_antenna() { return wlan_select_antenna_impl(fetch_antenna_selection()); }
+inline int wlan_refresh_antenna()
+{
+    return wlan_select_antenna_impl(fetch_antenna_selection());
+}
 
 int wlan_select_antenna(WLanSelectAntenna_TypeDef antenna)
 {
@@ -254,18 +280,19 @@ int wlan_select_antenna(WLanSelectAntenna_TypeDef antenna)
     return wiced_wlan_connectivity_initialized() ? wlan_refresh_antenna() : 0;
 }
 
-
 wlan_result_t wlan_activate()
 {
     wlan_initialize_dct();
     wlan_result_t result = wiced_wlan_connectivity_init();
     if (!result)
-        wiced_network_register_link_callback(HAL_NET_notify_connected, HAL_NET_notify_disconnected, WICED_STA_INTERFACE);
+        wiced_network_register_link_callback(HAL_NET_notify_connected, HAL_NET_notify_disconnected,
+                                             WICED_STA_INTERFACE);
     wlan_refresh_antenna();
     return result;
 }
 
-wlan_result_t wlan_deactivate() {
+wlan_result_t wlan_deactivate()
+{
     wlan_disconnect_now();
     return 0;
 }
@@ -278,7 +305,6 @@ wlan_result_t wlan_disconnect_now()
     HAL_NET_notify_disconnected();
     return result;
 }
-
 
 bool wlan_reset_credentials_store_required()
 {
@@ -300,7 +326,7 @@ void Set_NetApp_Timeout(void)
 int wlan_connected_rssi()
 {
     int32_t rssi = 0;
-    if (wwd_wifi_get_rssi( &rssi ))
+    if (wwd_wifi_get_rssi(&rssi))
         rssi = 0;
     return rssi;
 }
@@ -317,10 +343,9 @@ struct SnifferInfo
     int count;
 };
 
-
 WLanSecurityType toSecurityType(wiced_security_t sec)
 {
-    if (sec==WICED_SECURITY_OPEN)
+    if (sec == WICED_SECURITY_OPEN)
         return WLAN_SEC_UNSEC;
     if (sec & WEP_ENABLED)
         return WLAN_SEC_WEP;
@@ -343,22 +368,26 @@ WLanSecurityCipher toCipherType(wiced_security_t sec)
 /*
  * Callback function to handle scan results
  */
-wiced_result_t sniffer( wiced_scan_handler_result_t* malloced_scan_result )
+wiced_result_t sniffer(wiced_scan_handler_result_t* malloced_scan_result)
 {
-    malloc_transfer_to_curr_thread( malloced_scan_result );
+    malloc_transfer_to_curr_thread(malloced_scan_result);
 
     SnifferInfo* info = (SnifferInfo*)malloced_scan_result->user_data;
-    if ( malloced_scan_result->status == WICED_SCAN_INCOMPLETE )
+    if (malloced_scan_result->status == WICED_SCAN_INCOMPLETE)
     {
         wiced_scan_result_t* record = &malloced_scan_result->ap_details;
         info->count++;
-        if (!info->callback) {
-            if (record->SSID.length==info->ssid_len && !memcmp(record->SSID.value, info->ssid, info->ssid_len)) {
+        if (!info->callback)
+        {
+            if (record->SSID.length == info->ssid_len &&
+                !memcmp(record->SSID.value, info->ssid, info->ssid_len))
+            {
                 info->security = record->security;
                 info->rssi = record->signal_strength;
             }
         }
-        else {
+        else
+        {
             WiFiAccessPoint data;
             memcpy(data.ssid, record->SSID.value, record->SSID.length);
             memcpy(data.bssid, (uint8_t*)&record->BSSID, 6);
@@ -372,19 +401,23 @@ wiced_result_t sniffer( wiced_scan_handler_result_t* malloced_scan_result )
             info->callback(&data, info->callback_data);
         }
     }
-    else {
+    else
+    {
         wiced_rtos_set_semaphore(&info->complete);
     }
-    free( malloced_scan_result );
+    free(malloced_scan_result);
     return WICED_SUCCESS;
 }
 
-wiced_result_t sniff_security(SnifferInfo* info) {
+wiced_result_t sniff_security(SnifferInfo* info)
+{
 
     wiced_result_t result = wiced_rtos_init_semaphore(&info->complete);
-    if (result!=WICED_SUCCESS) return result;
+    if (result != WICED_SUCCESS)
+        return result;
     result = wiced_wifi_scan_networks(sniffer, info);
-    if (result==WICED_SUCCESS) {
+    if (result == WICED_SUCCESS)
+    {
         wiced_rtos_get_semaphore(&info->complete, 30000);
     }
     wiced_rtos_deinit_semaphore(&info->complete);
@@ -396,22 +429,24 @@ wiced_result_t sniff_security(SnifferInfo* info) {
 /**
  * Converts the given the current security credentials.
  */
-wiced_security_t toSecurity(const char* ssid, unsigned ssid_len, WLanSecurityType sec, WLanSecurityCipher cipher)
+wiced_security_t toSecurity(const char* ssid, unsigned ssid_len, WLanSecurityType sec,
+                            WLanSecurityCipher cipher)
 {
     int result = 0;
-    switch (sec) {
-        case WLAN_SEC_UNSEC:
-            result = WICED_SECURITY_OPEN;
-            break;
-        case WLAN_SEC_WEP:
-            result = WICED_SECURITY_WEP_PSK;
-            break;
-        case WLAN_SEC_WPA:
-            result = WPA_SECURITY;
-            break;
-        case WLAN_SEC_WPA2:
-            result = WPA2_SECURITY;
-            break;
+    switch (sec)
+    {
+    case WLAN_SEC_UNSEC:
+        result = WICED_SECURITY_OPEN;
+        break;
+    case WLAN_SEC_WEP:
+        result = WICED_SECURITY_WEP_PSK;
+        break;
+    case WLAN_SEC_WPA:
+        result = WPA_SECURITY;
+        break;
+    case WLAN_SEC_WPA2:
+        result = WPA2_SECURITY;
+        break;
     }
 
     if (cipher & WLAN_CIPHER_AES)
@@ -419,16 +454,19 @@ wiced_security_t toSecurity(const char* ssid, unsigned ssid_len, WLanSecurityTyp
     if (cipher & WLAN_CIPHER_TKIP)
         result |= TKIP_ENABLED;
 
-    if (sec==WLAN_SEC_NOT_SET ||    // security not set, or WPA/WPA2 and cipher not set
-            ((result & (WPA_SECURITY | WPA2_SECURITY) && (cipher==WLAN_CIPHER_NOT_SET)))) {
+    if (sec == WLAN_SEC_NOT_SET || // security not set, or WPA/WPA2 and cipher not set
+        ((result & (WPA_SECURITY | WPA2_SECURITY) && (cipher == WLAN_CIPHER_NOT_SET))))
+    {
         SnifferInfo info;
         memset(&info, 0, sizeof(info));
         info.ssid = ssid;
         info.ssid_len = ssid_len;
-        if (!sniff_security(&info)) {
+        if (!sniff_security(&info))
+        {
             result = info.security;
         }
-        else {
+        else
+        {
             result = WLAN_SET_CREDENTIALS_CIPHER_REQUIRED;
         }
     }
@@ -437,52 +475,62 @@ wiced_security_t toSecurity(const char* ssid, unsigned ssid_len, WLanSecurityTyp
 
 bool equals_ssid(const char* ssid, wiced_ssid_t& current)
 {
-	return (strlen(ssid)==current.length) && !memcmp(ssid, current.value, current.length);
+    return (strlen(ssid) == current.length) && !memcmp(ssid, current.value, current.length);
 }
 
 static bool wifi_creds_changed;
-wiced_result_t add_wiced_wifi_credentials(const char *ssid, uint16_t ssidLen, const char *password,
-    uint16_t passwordLen, wiced_security_t security, unsigned channel)
+wiced_result_t add_wiced_wifi_credentials(const char* ssid, uint16_t ssidLen, const char* password,
+                                          uint16_t passwordLen, wiced_security_t security,
+                                          unsigned channel)
 {
     platform_dct_wifi_config_t* wifi_config = NULL;
-    wiced_result_t result = wiced_dct_read_lock( (void**) &wifi_config, WICED_TRUE, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
-    if (!result) {
+    wiced_result_t result = wiced_dct_read_lock((void**)&wifi_config, WICED_TRUE,
+                                                DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
+    if (!result)
+    {
         // the storage may not have been initialized, so device_configured will be 0xFF
         initialize_dct(wifi_config);
 
         int replace = -1;
 
         // find a slot with the same ssid
-        for (unsigned i=0; i<CONFIG_AP_LIST_SIZE; i++) {
-        		if (equals_ssid(ssid, wifi_config->stored_ap_list[i].details.SSID)) {
-        			replace = i;
-        			break;
-        		}
+        for (unsigned i = 0; i < CONFIG_AP_LIST_SIZE; i++)
+        {
+            if (equals_ssid(ssid, wifi_config->stored_ap_list[i].details.SSID))
+            {
+                replace = i;
+                break;
+            }
         }
 
         if (replace < 0)
-        	{
-			// shuffle all slots along
-			memmove(wifi_config->stored_ap_list+1, wifi_config->stored_ap_list, sizeof(wiced_config_ap_entry_t)*(CONFIG_AP_LIST_SIZE-1));
-			replace = 0;
-        	}
+        {
+            // shuffle all slots along
+            memmove(wifi_config->stored_ap_list + 1, wifi_config->stored_ap_list,
+                    sizeof(wiced_config_ap_entry_t) * (CONFIG_AP_LIST_SIZE - 1));
+            replace = 0;
+        }
         wiced_config_ap_entry_t& entry = wifi_config->stored_ap_list[replace];
         memset(&entry, 0, sizeof(entry));
         passwordLen = std::min(passwordLen, uint16_t(64));
         ssidLen = std::min(ssidLen, uint16_t(32));
         memcpy(entry.details.SSID.value, ssid, ssidLen);
         entry.details.SSID.length = ssidLen;
-        if (security==WICED_SECURITY_WEP_PSK && passwordLen>1 && password[0]>4) {
+        if (security == WICED_SECURITY_WEP_PSK && passwordLen > 1 && password[0] > 4)
+        {
             // convert from hex to binary
-            entry.security_key_length = hex_decode((uint8_t*)entry.security_key, sizeof(entry.security_key), password);
+            entry.security_key_length =
+                hex_decode((uint8_t*)entry.security_key, sizeof(entry.security_key), password);
         }
-        else {
+        else
+        {
             memcpy(entry.security_key, password, passwordLen);
             entry.security_key_length = passwordLen;
         }
         entry.details.security = security;
         entry.details.channel = channel;
-        result = wiced_dct_write( (const void*) wifi_config, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config) );
+        result = wiced_dct_write((const void*)wifi_config, DCT_WIFI_CONFIG_SECTION, 0,
+                                 sizeof(*wifi_config));
         if (!result)
             wifi_creds_changed = true;
         wiced_dct_read_unlock(wifi_config, WICED_TRUE);
@@ -490,20 +538,26 @@ wiced_result_t add_wiced_wifi_credentials(const char *ssid, uint16_t ssidLen, co
     return result;
 }
 
-int wlan_set_credentials_internal(const char *ssid, uint16_t ssidLen, const char *password,
-    uint16_t passwordLen, WLanSecurityType security, WLanSecurityCipher cipher, unsigned channel, unsigned flags)
+int wlan_set_credentials_internal(const char* ssid, uint16_t ssidLen, const char* password,
+                                  uint16_t passwordLen, WLanSecurityType security,
+                                  WLanSecurityCipher cipher, unsigned channel, unsigned flags)
 {
     int result = WICED_ERROR;
-    if (ssidLen>0 && ssid) {
+    if (ssidLen > 0 && ssid)
+    {
         int security_result = toSecurity(ssid, ssidLen, security, cipher);
-        if (security_result==WLAN_SET_CREDENTIALS_CIPHER_REQUIRED) {
+        if (security_result == WLAN_SET_CREDENTIALS_CIPHER_REQUIRED)
+        {
             result = WLAN_SET_CREDENTIALS_CIPHER_REQUIRED;
         }
-        else if (flags & WLAN_SET_CREDENTIALS_FLAGS_DRY_RUN) {
+        else if (flags & WLAN_SET_CREDENTIALS_FLAGS_DRY_RUN)
+        {
             result = WICED_SUCCESS;
         }
-        else {
-            result = add_wiced_wifi_credentials(ssid, ssidLen, password, passwordLen, wiced_security_t(security_result), channel);
+        else
+        {
+            result = add_wiced_wifi_credentials(ssid, ssidLen, password, passwordLen,
+                                                wiced_security_t(security_result), channel);
         }
     }
     return result;
@@ -514,19 +568,23 @@ int wlan_set_credentials(WLanCredentials* c)
     // size v1: 28
     // added flags: size 32
     int flags = 0;
-    if (c->size>=32) {
+    if (c->size >= 32)
+    {
         flags = c->flags;
     }
-    STATIC_ASSERT(wlan_credentials_size, sizeof(WLanCredentials)==32);
-    return wlan_set_credentials_internal(c->ssid, c->ssid_len, c->password, c->password_len, c->security, c->cipher, c->channel, flags);
+    STATIC_ASSERT(wlan_credentials_size, sizeof(WLanCredentials) == 32);
+    return wlan_set_credentials_internal(c->ssid, c->ssid_len, c->password, c->password_len,
+                                         c->security, c->cipher, c->channel, flags);
 }
 
 softap_handle current_softap_handle;
 
-void wlan_smart_config_init() {
+void wlan_smart_config_init()
+{
 
     wifi_creds_changed = false;
-    if (!current_softap_handle) {
+    if (!current_softap_handle)
+    {
         softap_config config;
         config.softap_complete = HAL_WLAN_notify_simple_config_done;
         wlan_disconnect_now();
@@ -536,9 +594,10 @@ void wlan_smart_config_init() {
 
 bool wlan_smart_config_finalize()
 {
-    if (current_softap_handle) {
+    if (current_softap_handle)
+    {
         softap_stop(current_softap_handle);
-        wlan_disconnect_now();  // force a full refresh
+        wlan_disconnect_now(); // force a full refresh
         HAL_Delay_Milliseconds(5);
         wlan_activate();
         current_softap_handle = NULL;
@@ -560,7 +619,8 @@ void wlan_set_error_count(uint32_t errorCount)
 {
 }
 
-inline void setAddress(wiced_ip_address_t* addr, HAL_IPAddress& target) {
+inline void setAddress(wiced_ip_address_t* addr, HAL_IPAddress& target)
+{
     HAL_IPV4_SET(&target, GET_IPV4_ADDRESS(*addr));
 }
 
@@ -569,33 +629,35 @@ void wlan_fetch_ipconfig(WLanConfig* config)
     wiced_ip_address_t addr;
     wiced_interface_t ifup = WICED_STA_INTERFACE;
 
-    if (wiced_network_is_up(ifup)) {
+    if (wiced_network_is_up(ifup))
+    {
 
-        if (wiced_ip_get_ipv4_address(ifup, &addr)==WICED_SUCCESS)
+        if (wiced_ip_get_ipv4_address(ifup, &addr) == WICED_SUCCESS)
             setAddress(&addr, config->nw.aucIP);
 
-        if (wiced_ip_get_netmask(ifup, &addr)==WICED_SUCCESS)
+        if (wiced_ip_get_netmask(ifup, &addr) == WICED_SUCCESS)
             setAddress(&addr, config->nw.aucSubnetMask);
 
-        if (wiced_ip_get_gateway_address(ifup, &addr)==WICED_SUCCESS)
+        if (wiced_ip_get_gateway_address(ifup, &addr) == WICED_SUCCESS)
             setAddress(&addr, config->nw.aucDefaultGateway);
     }
 
     wiced_mac_t my_mac_address;
-    if (wiced_wifi_get_mac_address( &my_mac_address)==WICED_SUCCESS)
+    if (wiced_wifi_get_mac_address(&my_mac_address) == WICED_SUCCESS)
         memcpy(config->nw.uaMacAddr, &my_mac_address, 6);
 
     wl_bss_info_t ap_info;
     wiced_security_t sec;
 
-    if ( wwd_wifi_get_ap_info( &ap_info, &sec ) == WWD_SUCCESS )
+    if (wwd_wifi_get_ap_info(&ap_info, &sec) == WWD_SUCCESS)
     {
         uint8_t len = std::min(ap_info.SSID_len, uint8_t(32));
         memcpy(config->uaSSID, ap_info.SSID, len);
         config->uaSSID[len] = 0;
 
-        if (config->size>=WLanConfig_Size_V2) {
-        		memcpy(config->BSSID, ap_info.BSSID.octet, sizeof(config->BSSID));
+        if (config->size >= WLanConfig_Size_V2)
+        {
+            memcpy(config->BSSID, ap_info.BSSID.octet, sizeof(config->BSSID));
         }
     }
     // todo DNS and DHCP servers
@@ -616,19 +678,33 @@ void SPARK_WLAN_SmartConfigProcess()
  *          -1 : if the antenna selection was not set
  *
  */
-int wlan_select_antenna_impl(WLanSelectAntenna_TypeDef antenna) {
+int wlan_select_antenna_impl(WLanSelectAntenna_TypeDef antenna)
+{
 
     wwd_result_t result;
-    switch(antenna) {
+    switch (antenna)
+    {
 #if PLATFORM_ID == 6 // Photon
-        case ANT_EXTERNAL: result = wwd_wifi_select_antenna(WICED_ANTENNA_1); break;
-        case ANT_INTERNAL: result = wwd_wifi_select_antenna(WICED_ANTENNA_2); break;
+    case ANT_EXTERNAL:
+        result = wwd_wifi_select_antenna(WICED_ANTENNA_1);
+        break;
+    case ANT_INTERNAL:
+        result = wwd_wifi_select_antenna(WICED_ANTENNA_2);
+        break;
 #else
-        case ANT_INTERNAL: result = wwd_wifi_select_antenna(WICED_ANTENNA_1); break;
-        case ANT_EXTERNAL: result = wwd_wifi_select_antenna(WICED_ANTENNA_2); break;
+    case ANT_INTERNAL:
+        result = wwd_wifi_select_antenna(WICED_ANTENNA_1);
+        break;
+    case ANT_EXTERNAL:
+        result = wwd_wifi_select_antenna(WICED_ANTENNA_2);
+        break;
 #endif
-        case ANT_AUTO: result = wwd_wifi_select_antenna(WICED_ANTENNA_AUTO); break;
-        default: result = WWD_DOES_NOT_EXIST; break;
+    case ANT_AUTO:
+        result = wwd_wifi_select_antenna(WICED_ANTENNA_AUTO);
+        break;
+    default:
+        result = WWD_DOES_NOT_EXIST;
+        break;
     }
     if (result == WWD_SUCCESS)
         return 0;
@@ -642,21 +718,20 @@ void wlan_connect_cancel(bool called_from_isr)
     wwd_wifi_join_cancel(called_from_isr ? WICED_TRUE : WICED_FALSE);
 }
 
-
 /**
  * Sets the IP source - static or dynamic.
  */
 void wlan_set_ipaddress_source(IPAddressSource source, bool persist, void* reserved)
 {
     char c = source;
-    dct_write_app_data(&c, DCT_IP_CONFIG_OFFSET+offsetof(static_ip_config_t, config_mode), 1);
+    dct_write_app_data(&c, DCT_IP_CONFIG_OFFSET + offsetof(static_ip_config_t, config_mode), 1);
 }
-
 
 void assign_if_set(dct_ip_address_v4_t& dct_address, const HAL_IPAddress* address)
 {
-    if (address && is_ipv4(address)) {
-            dct_address = address->ipv4;
+    if (address && is_ipv4(address))
+    {
+        dct_address = address->ipv4;
     }
 }
 
@@ -669,7 +744,9 @@ void assign_if_set(dct_ip_address_v4_t& dct_address, const HAL_IPAddress* addres
  * @param dns2
  * @param reserved
  */
-void wlan_set_ipaddress(const HAL_IPAddress* host, const HAL_IPAddress* netmask, const HAL_IPAddress* gateway, const HAL_IPAddress* dns1, const HAL_IPAddress* dns2, void* reserved)
+void wlan_set_ipaddress(const HAL_IPAddress* host, const HAL_IPAddress* netmask,
+                        const HAL_IPAddress* gateway, const HAL_IPAddress* dns1,
+                        const HAL_IPAddress* dns2, void* reserved)
 {
     const static_ip_config_t* pconfig = wlan_fetch_saved_ip_config();
     static_ip_config_t config;
@@ -682,14 +759,13 @@ void wlan_set_ipaddress(const HAL_IPAddress* host, const HAL_IPAddress* netmask,
     dct_write_app_data(&config, DCT_IP_CONFIG_OFFSET, sizeof(config));
 }
 
-
 int wlan_scan(wlan_scan_result_t callback, void* cookie)
 {
     SnifferInfo info;
     memset(&info, 0, sizeof(info));
     info.callback = callback;
     info.callback_data = cookie;
-    int result =  sniff_security(&info);
+    int result = sniff_security(&info);
     return result < 0 ? result : info.count;
 }
 
@@ -700,25 +776,30 @@ int wlan_get_credentials(wlan_scan_result_t callback, void* callback_data)
 {
     int count = 0;
     platform_dct_wifi_config_t* wifi_config = NULL;
-    wiced_result_t result = wiced_dct_read_lock( (void**) &wifi_config, WICED_FALSE, DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
-    if (!result) {
+    wiced_result_t result = wiced_dct_read_lock((void**)&wifi_config, WICED_FALSE,
+                                                DCT_WIFI_CONFIG_SECTION, 0, sizeof(*wifi_config));
+    if (!result)
+    {
         // the storage may not have been initialized, so device_configured will be 0xFF
         initialize_dct(wifi_config);
 
         // iterate through each stored ap
-        for(int i = 0; i < CONFIG_AP_LIST_SIZE; i++) {
-            const wiced_config_ap_entry_t &ap = wifi_config->stored_ap_list[i];
+        for (int i = 0; i < CONFIG_AP_LIST_SIZE; i++)
+        {
+            const wiced_config_ap_entry_t& ap = wifi_config->stored_ap_list[i];
 
-            if(!is_ap_config_set(ap)) {
+            if (!is_ap_config_set(ap))
+            {
                 continue;
             }
             count++;
 
-            if(!callback) {
+            if (!callback)
+            {
                 continue;
             }
 
-            const wiced_ap_info_t *record = &ap.details;
+            const wiced_ap_info_t* record = &ap.details;
 
             WiFiAccessPoint data;
             memcpy(data.ssid, record->SSID.value, record->SSID.length);

--- a/hal/src/photon/wwd_resources.h
+++ b/hal/src/photon/wwd_resources.h
@@ -24,14 +24,26 @@
 #ifndef WICED_STUBS_H
 #define	WICED_STUBS_H
 
-typedef struct resource_hnd_t {
+#include <stdint.h>
 
-} resource_hnd_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef INCLUDED_RESOURCE_H_
+// resource_hnd_t not defined so let's typedef it (it's only used as a pointer here.)
+typedef struct{} resource_hnd_t;
+#endif
 
 const resource_hnd_t* wwd_firmware_image_resource(void);
 
 const resource_hnd_t* wwd_nvram_image_resource(void);
 
+int wwd_select_nvram_image_resource(uint8_t res, void* reserved);
+
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif	/* WICED_STUBS_H */

--- a/hal/src/photon/wwd_resources.h
+++ b/hal/src/photon/wwd_resources.h
@@ -22,7 +22,7 @@
  */
 
 #ifndef WICED_STUBS_H
-#define	WICED_STUBS_H
+#define WICED_STUBS_H
 
 #include <stdint.h>
 
@@ -32,7 +32,9 @@ extern "C" {
 
 #ifndef INCLUDED_RESOURCE_H_
 // resource_hnd_t not defined so let's typedef it (it's only used as a pointer here.)
-typedef struct{} resource_hnd_t;
+typedef struct
+{
+} resource_hnd_t;
 #endif
 
 const resource_hnd_t* wwd_firmware_image_resource(void);
@@ -45,6 +47,4 @@ int wwd_select_nvram_image_resource(uint8_t res, void* reserved);
 }
 #endif
 
-
-#endif	/* WICED_STUBS_H */
-
+#endif /* WICED_STUBS_H */

--- a/modules/photon/system-part1/inc/wifi_dynalib.h
+++ b/modules/photon/system-part1/inc/wifi_dynalib.h
@@ -30,6 +30,7 @@ DYNALIB_BEGIN(wifi_resource)
 
 DYNALIB_FN(0, wifi_resource, wwd_firmware_image_resource, const resource_hnd_t*(void))
 DYNALIB_FN(1, wifi_resource, wwd_nvram_image_resource, const resource_hnd_t*(void))
+DYNALIB_FN(2, wifi_resource, wwd_select_nvram_image_resource, int(uint8_t, void*))
 
 DYNALIB_END(wifi_resource)
 

--- a/modules/photon/system-part1/src/wiced_stubs.c
+++ b/modules/photon/system-part1/src/wiced_stubs.c
@@ -1,4 +1,4 @@
-#include "wiced_stubs.h"
+#include "wwd_resources.h"
 
 extern resource_hnd_t wifi_firmware_image;
 

--- a/modules/photon/system-part1/src/wifi_dynalib.c
+++ b/modules/photon/system-part1/src/wifi_dynalib.c
@@ -1,4 +1,4 @@
 
 #define DYNALIB_EXPORT
-#include "wiced_stubs.h"
+#include "wwd_resources.h"
 #include "wifi_dynalib.h"

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
@@ -57,7 +57,8 @@ typedef struct __attribute__((packed)) application_dct {
     uint8_t device_private_key[1216];   // sufficient for 2048 bits
     uint8_t device_public_key[384];     // sufficient for 2048 bits
     static_ip_config_t  ip_config;
-    uint8_t unused[104];
+    uint8_t unused[100];
+    uint8_t country_code[4];            // WICED country code. Stored as bit-endian format: CH1/CH2/0/rev (max 255)
     uint8_t claim_code[63];             // claim code. no terminating null.
     uint8_t claimed[1];                 // 0,0xFF, not claimed. 1 claimed.
     uint8_t ssid_prefix[26];            // SSID prefix (25 chars max). First byte is length.
@@ -88,6 +89,7 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_SERVER_PUBLIC_KEY_OFFSET (offsetof(application_dct_t, server_public_key))
 #define DCT_SERVER_ADDRESS_OFFSET ((DCT_SERVER_PUBLIC_KEY_OFFSET)+384)
 #define DCT_IP_CONFIG_OFFSET (offsetof(application_dct_t, ip_config))
+#define DCT_COUNTRY_CODE_OFFSET (offsetof(application_dct_t, country_code))
 #define DCT_CLAIM_CODE_OFFSET (offsetof(application_dct_t, claim_code))
 #define DCT_SSID_PREFIX_OFFSET (offsetof(application_dct_t, ssid_prefix))
 #define DCT_DNS_RESOLVE_OFFSET (offsetof(application_dct_t, dns_resolve))
@@ -107,6 +109,7 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_DEVICE_PUBLIC_KEY_SIZE  (sizeof(application_dct_t::device_public_key))
 #define DCT_SERVER_PUBLIC_KEY_SIZE  (sizeof(application_dct_t::server_public_key))
 #define DCT_IP_CONFIG_SIZE (sizeof(application_dct_t::ip_config))
+#define DCT_COUNTRY_CODE_SIZE  (sizeof(application_dct_t::country_code))
 #define DCT_CLAIM_CODE_SIZE  (sizeof(application_dct_t::claim_code))
 #define DCT_SSID_PREFIX_SIZE  (sizeof(application_dct_t::ssid_prefix))
 #define DCT_DNS_RESOLVE_SIZE  (sizeof(application_dct_t::dns_resolve))
@@ -132,7 +135,8 @@ STATIC_ASSERT_DCT_OFFSET(version, 32);
 STATIC_ASSERT_DCT_OFFSET(device_private_key, 34);
 STATIC_ASSERT_DCT_OFFSET(device_public_key, 1250 /*34+1216*/);
 STATIC_ASSERT_DCT_OFFSET(ip_config, 1634 /* 1250 + 384 */);
-STATIC_ASSERT_DCT_OFFSET(claim_code, 1762 /* 1634 + 128 */);
+STATIC_ASSERT_DCT_OFFSET(country_code, 1758 /* 1634 + 124 */);
+STATIC_ASSERT_DCT_OFFSET(claim_code, 1762 /* 1758 + 4 */);
 STATIC_ASSERT_DCT_OFFSET(claimed, 1825 /* 1762 + 63 */ );
 STATIC_ASSERT_DCT_OFFSET(ssid_prefix, 1826 /* 1825 + 1 */);
 STATIC_ASSERT_DCT_OFFSET(device_id, 1852 /* 1826 + 26 */);


### PR DESCRIPTION
adds support for setting the wifi country code. This is used to set the available channels, and in the case of japan, the transmit power.

This changes the default country setting to UK, which gives channels 1-13 (previously the default was japan.) This change is so that the default is still full power. 

The country code `JP2` can be used to set the region to Japan, with lower transmit power for TELEC conformance. 

```
# set to japan
echo -n "JP2" > jp2
dfu-util -d 2b04:d006 -a 1 -s 1758:leave -D jp2

# set to us
echo -n "US4" > us
dfu-util -d 2b04:d006 -a 1 -s 1758:leave -D us


# reset to default
echo "0: 00000000" | xxd -r > null
dfu-util -d 2b04:d006 -a 1 -s 1758:leave -D null

```

In theory, the JP2 setting should have 25% less transmit power than the default setting. Looking at the Signal/Noise and SNR on my router, I could see some correlation, although I would welcome further testes to be certain the power level is being altered.

---

- [x] Review code
- [x] Test on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md