### PR TITLE
millis()/micros() hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - SoftAP mode persisting when setup complete if Wi-Fi was off. [#971](https://github.com/spark/firmware/issues/971) 
 - Free memory allocated for previous system interrupt handler [#927](https://github.com/spark/firmware/issues/927)
 - Fixes to I2C Slave mode implementation with clock stretching enabled [#931](https://github.com/spark/firmware/pull/931)
+- `millis()`/`micros()` are now atomic to ensure monotonic values. Fixes [#916](https://github.com/spark/firmware/issues/916) and [#925](https://github.com/spark/firmware/issues/925) 
 
 
 

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -56,8 +56,8 @@ void System1MsTick(void)
  */
 system_tick_t GetSystem1MsTick()
 {
-	int is = __get_PRIMASK();
-	__disable_irq();
+    int is = __get_PRIMASK();
+    __disable_irq();
 
     system_tick_t millis = system_millis + (DWT->CYCCNT-system_millis_clock) / SYSTEM_US_TICKS / 1000;
 
@@ -76,15 +76,17 @@ system_tick_t GetSystem1UsTick()
     system_tick_t base_millis;
     system_tick_t base_clock;
 
-    // these values need to be fetched consistently - if system_millis changes after fetching
-    // (due to the millisecond counter being updated), try again.
-    do {
-        base_millis = system_millis;
-        base_clock = system_millis_clock;
-    }
-    while (base_millis!=system_millis);
+    int is = __get_PRIMASK();
+    __disable_irq();
 
+    base_millis = system_millis;
+    base_clock = system_millis_clock;
+    
     system_tick_t elapsed_since_millis = ((DWT->CYCCNT-base_clock) / SYSTEM_US_TICKS);
+
+    if ((is & 1) == 0) {
+        __enable_irq();
+    }
     return (base_millis * 1000) + elapsed_since_millis;
 }
 

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -39,8 +39,15 @@ static volatile system_tick_t system_millis_clock = 0;
  */
 void System1MsTick(void)
 {
+	int is = __get_PRIMASK();
+	__disable_irq();
+
     system_millis++;
     system_millis_clock = DWT->CYCCNT;
+
+    if ((is & 1) == 0) {
+        __enable_irq();
+    }
 }
 
 /**
@@ -49,7 +56,15 @@ void System1MsTick(void)
  */
 system_tick_t GetSystem1MsTick()
 {
-    return system_millis;
+	int is = __get_PRIMASK();
+	__disable_irq();
+
+    system_tick_t millis = system_millis + (DWT->CYCCNT-system_millis_clock) / SYSTEM_US_TICKS / 1000;
+
+    if ((is & 1) == 0) {
+        __enable_irq();
+    }
+	return millis;
 }
 
 /**

--- a/user/tests/wiring/no_fixture_long_running/ticks.cpp
+++ b/user/tests/wiring/no_fixture_long_running/ticks.cpp
@@ -2,8 +2,16 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
+#ifndef ABS
+#define ABS(x) (x >= 0 ? x : -x)
+#endif
+
 void assert_micros_millis(system_tick_t duration)
 {
+#if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
+    // Just in case
+    NVIC_DisableIRQ(TIM4_IRQn);
+#endif
     system_tick_t last = millis();
     system_tick_t end = last + duration;
 
@@ -26,6 +34,59 @@ void assert_micros_millis(system_tick_t duration)
     while (last<end);
 }
 
+void assert_micros_millis_interrupts(system_tick_t duration)
+{
+#if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
+    // Enable some high priority interrupt to run interference
+    pinMode(D0, OUTPUT);
+    // D0 uses TIM2 and channel 2 equally on Core and Photon/Electron
+    // Run at 4khz (T=250us)
+    analogWrite(D0, 1, 4000);
+    randomSeed(micros());
+    // Set higher than SysTick_IRQn priority for TIM4_IRQn
+    NVIC_SetPriority(TIM4_IRQn, 3);
+    TIM_ITConfig(TIM4, TIM_IT_CC2, ENABLE);
+    NVIC_EnableIRQ(TIM4_IRQn);
+    attachSystemInterrupt(SysInterrupt_TIM4_IRQ, [&] {
+        // Do some work up to 200 microseconds
+        delayMicroseconds(random(200));
+        TIM_ClearITPendingBit(TIM4, TIM_IT_CC2);
+    });
+#endif
+
+    system_tick_t last = millis();
+    system_tick_t last_micros = micros();
+    system_tick_t end = last + duration;
+    do
+    {
+        system_tick_t now = millis();
+        system_tick_t now_micros = micros();
+
+        assertMoreOrEqual(now, last);
+        assertMoreOrEqual(now_micros, last_micros);
+        // micros always at least (millis()*1000)
+        // even with overflow
+        assertMoreOrEqual(now_micros, now*1000);
+        // 1ms millis() advancement
+        assertTrue(((int32_t)now - (int32_t)last) <= 1);
+        // 1ms micros() advancement
+        assertTrue(((int32_t)now_micros - (int32_t)last_micros) <= 1000);
+        // at most 1.5ms difference between micros() and millis()
+        assertTrue(ABS((int32_t)now_micros - (int32_t)now*1000) <= 1500);
+
+        last = now;
+        last_micros = now_micros;
+    }
+    while (last<end);
+
+#if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
+    NVIC_DisableIRQ(TIM4_IRQn);
+    detachSystemInterrupt(SysInterrupt_TIM4_IRQ);
+    TIM_ITConfig(TIM4, TIM_IT_CC2, DISABLE);
+    digitalWrite(D0, HIGH);
+#endif
+}
+
 
 #if !MODULAR_FIRMWARE
 // the __advance_system1MsTick isn't dynamically linked so we build this as a monolithic app
@@ -38,6 +99,10 @@ test(ticks_millis_and_micros_rollover)
 }
 #endif
 
+test(ticks_millis_and_micros_along_with_high_priority_interrupts)
+{
+    assert_micros_millis_interrupts(2*60*1000); // 2 minutes
+}
 
 test(ticks_millis_and_micros_monotonically_increases)
 {


### PR DESCRIPTION
makes millis()/micros() operations atomic - an interrupt could cause the computed value to be off. Fixes #916 and #925 

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)