### PR TITLE
SYSTEM_FLAG_WIFITEST_OVER_SERIAL1

### DIFF
--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -109,15 +109,15 @@ typedef enum
      */
     SYSTEM_FLAG_STARTUP_SAFE_LISTEN_MODE,
 
-    /**
-     * When 0, the application code is not paused.
-     * When 1, the application code is paused.
-     */
-    // SYSTEM_FLAG_APPLICATION_PAUSED=4,
+	/**
+	 * Enable/Disable use of serial1 during setup.
+	 */
+	SYSTEM_FLAG_WIFITESTER_OVER_SERIAL1,
 
     SYSTEM_FLAG_MAX
 
 } system_flag_t;
+
 
 void system_shutdown_if_needed();
 void system_pending_shutdown();

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -180,8 +180,13 @@ template<typename Config> void SystemSetupConsole<Config>::read_line(char *dst, 
         serial.read();
 }
 
-
 #if Wiring_WiFi
+
+inline bool setup_serial1() {
+	uint8_t value = 0;
+	system_get_flag(SYSTEM_FLAG_WIFITESTER_OVER_SERIAL1, &value, nullptr);
+	return value;
+}
 
 WiFiSetupConsole::WiFiSetupConsole(WiFiSetupConsoleConfig& config)
  : SystemSetupConsole(config)
@@ -189,7 +194,9 @@ WiFiSetupConsole::WiFiSetupConsole(WiFiSetupConsoleConfig& config)
 #if SETUP_OVER_SERIAL1
     serial1Enabled = false;
     magicPos = 0;
-    Serial1.begin(9600);
+    if (setup_serial1()) {
+    		SETUP_SERIAL.begin(9600);
+    }
     this->tester = NULL;
 #endif
 }
@@ -204,33 +211,35 @@ WiFiSetupConsole::~WiFiSetupConsole()
 void WiFiSetupConsole::loop()
 {
 #if SETUP_OVER_SERIAL1
-    int c = -1;
-    if (SETUP_SERIAL.available()) {
-        c = SETUP_SERIAL.read();
-    }
-    if (SETUP_LISTEN_MAGIC) {
-        static uint8_t magic_code[] = { 0xe1, 0x63, 0x57, 0x3f, 0xe7, 0x87, 0xc2, 0xa6, 0x85, 0x20, 0xa5, 0x6c, 0xe3, 0x04, 0x9e, 0xa0 };
-        if (!serial1Enabled) {
-            if (c>=0) {
-                if (c==magic_code[magicPos++]) {
-                    serial1Enabled = magicPos==sizeof(magic_code);
-                    if (serial1Enabled) {
-                        if (tester==NULL)
-                            tester = new WiFiTester();
-                        tester->setup(SETUP_OVER_SERIAL1);
-                    }
-                }
-                else {
-                    magicPos = 0;
-                }
-                c = -1;
-            }
-        }
-        else {
-            if (tester)
-                tester->loop(c);
-        }
-    }
+	if (setup_serial1()) {
+		int c = -1;
+		if (SETUP_SERIAL.available()) {
+			c = SETUP_SERIAL.read();
+		}
+		if (SETUP_LISTEN_MAGIC) {
+			static uint8_t magic_code[] = { 0xe1, 0x63, 0x57, 0x3f, 0xe7, 0x87, 0xc2, 0xa6, 0x85, 0x20, 0xa5, 0x6c, 0xe3, 0x04, 0x9e, 0xa0 };
+			if (!serial1Enabled) {
+				if (c>=0) {
+					if (c==magic_code[magicPos++]) {
+						serial1Enabled = magicPos==sizeof(magic_code);
+						if (serial1Enabled) {
+							if (tester==NULL)
+								tester = new WiFiTester();
+							tester->setup(SETUP_OVER_SERIAL1);
+						}
+					}
+					else {
+						magicPos = 0;
+					}
+					c = -1;
+				}
+			}
+			else {
+				if (tester)
+					tester->loop(c);
+			}
+		}
+	}
 #endif
     super::loop();
 }

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -60,12 +60,14 @@ static_assert(SYSTEM_FLAG_OTA_UPDATE_ENABLED==1, "system flag value");
 static_assert(SYSTEM_FLAG_RESET_PENDING==2, "system flag value");
 static_assert(SYSTEM_FLAG_RESET_ENABLED==3, "system flag value");
 static_assert(SYSTEM_FLAG_STARTUP_SAFE_LISTEN_MODE == 4, "system flag value");
-static_assert(SYSTEM_FLAG_MAX == 5, "system flag max value");
+static_assert(SYSTEM_FLAG_WIFITESTER_OVER_SERIAL1 == 5, "system flag value");
+static_assert(SYSTEM_FLAG_MAX == 6, "system flag max value");
 
 volatile uint8_t systemFlags[SYSTEM_FLAG_MAX] = {
     0, 1, // OTA updates pending/enabled
     0, 1, // Reset pending/enabled
-    0,    // SYSTEM_FLAG_STARTUP_SAFE_LISTEN_MODE
+    0,    // SYSTEM_FLAG_STARTUP_SAFE_LISTEN_MODE,
+	0,	  // SYSTEM_FLAG_SETUP_OVER_SERIAL1
 };
 
 const uint16_t SAFE_MODE_LISTEN = 0x5A1B;

--- a/user/applications/tinker/application.cpp
+++ b/user/applications/tinker/application.cpp
@@ -22,13 +22,17 @@
 #include "stdarg.h"
 
 PRODUCT_ID(PLATFORM_ID);
-PRODUCT_VERSION(2);
+PRODUCT_VERSION(3);
 
 /* Function prototypes -------------------------------------------------------*/
 int tinkerDigitalRead(String pin);
 int tinkerDigitalWrite(String command);
 int tinkerAnalogRead(String pin);
 int tinkerAnalogWrite(String command);
+
+#if Wiring_WiFi
+STARTUP(System.enable(SYSTEM_FLAG_WIFITESTER_OVER_SERIAL1));
+#endif
 
 SYSTEM_MODE(AUTOMATIC);
 

--- a/user/src/application.cpp
+++ b/user/src/application.cpp
@@ -22,13 +22,17 @@
 #include "stdarg.h"
 
 PRODUCT_ID(PLATFORM_ID);
-PRODUCT_VERSION(2);
+PRODUCT_VERSION(3);
 
 /* Function prototypes -------------------------------------------------------*/
 int tinkerDigitalRead(String pin);
 int tinkerDigitalWrite(String command);
 int tinkerAnalogRead(String pin);
 int tinkerAnalogWrite(String command);
+
+#if Wiring_WiFi
+STARTUP(System.enable(SYSTEM_FLAG_WIFITESTER_OVER_SERIAL1));
+#endif
 
 SYSTEM_MODE(AUTOMATIC);
 

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -253,6 +253,14 @@ public:
         return get_flag(SYSTEM_FLAG_RESET_PENDING)!=0;
     }
 
+    inline void enable(system_flag_t flag) {
+    		set_flag(flag, true);
+    }
+
+    inline void disable(system_flag_t flag) {
+		set_flag(flag, false);
+    }
+
 
 private:
 


### PR DESCRIPTION
adds `SYSTEM_FLAG_WIFITEST_OVER_SERIAL1` which is disabled by default. Tinker enables this so that the WiFi tester is available during  manufacturing.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)