### PR TITLE
WKP pin should not be enabled as a wakeup source unconditionally for STOP mode

### DIFF
--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -480,9 +480,6 @@ void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long
 
 void HAL_Core_Execute_Stop_Mode(void)
 {
-    /* Enable WKUP pin */
-    PWR_WakeUpPinCmd(ENABLE);
-
     /* Request to enter STOP mode with regulator in low power mode */
     PWR_EnterSTOPMode(PWR_Regulator_LowPower, PWR_STOPEntry_WFI);
 


### PR DESCRIPTION
Fixes #938 

Confirmed that after exiting STOP mode with some other pin specified as a wakeup source, WKP pin retains its configuration (e.g. tone() continues working).

If WKP is specified as wakeup source for System.sleep(), its pinMode will be changed to either INPUT, INPUT_PULLDOWN or INPUT_PULLUP depending on trigger condition. The pin will have to be reconfigured.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- N/A - API tests compiled
- [x] Run unit/integration/application tests on device
- N/A Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)