### PR TITLE
feature/dfu_device_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - [Electron] Reduced data consumption connecting to the cloud with deep sleep. (NB: see the docs for how to gain the full data reduction.) [#953](https://github.com/spark/firmware/pull/953)
 - Can set Claim Code via the Serial interface (for use by the CLI.) [#602](https://github.com/spark/firmware/issues/602) 
+- Device ID available via dfu-util. [#949](https://github.com/spark/firmware/pull/949)
 
 ### ENHANCEMENTS
 

--- a/hal/inc/deviceid_hal.h
+++ b/hal/inc/deviceid_hal.h
@@ -57,13 +57,11 @@ unsigned HAL_Platform_ID();
  */
 int HAL_Get_Device_Identifier(const char** name, char* buf, size_t buflen, unsigned index, void* reserved);
 
-
 /**
  * Save the device ID to persistent storage so it can be retrieved via DCT. This is
  * done automatically by the system on startup.
  */
 void HAL_save_device_id(uint32_t offset);
-
 
 #ifdef	__cplusplus
 }

--- a/hal/inc/deviceid_hal.h
+++ b/hal/inc/deviceid_hal.h
@@ -58,6 +58,13 @@ unsigned HAL_Platform_ID();
 int HAL_Get_Device_Identifier(const char** name, char* buf, size_t buflen, unsigned index, void* reserved);
 
 
+/**
+ * Save the device ID to persistent storage so it can be retrieved via DCT. This is
+ * done automatically by the system on startup.
+ */
+void HAL_save_device_id(uint32_t offset);
+
+
 #ifdef	__cplusplus
 }
 #endif

--- a/hal/src/core/deviceid_hal.cpp
+++ b/hal/src/core/deviceid_hal.cpp
@@ -31,6 +31,7 @@
 
 const unsigned device_id_len = 12;
 
+/* Read the STM32 Device electronic signature */
 unsigned HAL_device_ID(uint8_t* dest, unsigned destLen)
 {
     if (dest!=NULL && destLen!=0)

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -50,6 +50,7 @@
 #include "malloc.h"
 #include "usb_hal.h"
 #include "usart_hal.h"
+#include "deviceid_hal.h"
 
 #define STOP_MODE_EXIT_CONDITION_PIN 0x01
 #define STOP_MODE_EXIT_CONDITION_RTC 0x02
@@ -280,6 +281,8 @@ void HAL_Core_Setup(void) {
 
     bootloader_update_if_needed();
     HAL_Bootloader_Lock(true);
+
+    HAL_save_device_id(DCT_DEVICE_ID_OFFSET);
 
 #if !defined(MODULAR_FIRMWARE)
     module_user_init_hook();

--- a/hal/src/stm32f2xx/deviceid_hal.cpp
+++ b/hal/src/stm32f2xx/deviceid_hal.cpp
@@ -46,12 +46,11 @@ unsigned HAL_Platform_ID()
 
 void HAL_save_device_id(uint32_t dct_offset)
 {
-	const char* saved_device_id = (const char*)dct_read_app_data(dct_offset);
-	if (*saved_device_id==0xFF)
-	{
-		uint8_t device_id[device_id_len];
-		HAL_device_ID(device_id, sizeof(device_id));
-		dct_write_app_data(device_id, dct_offset, device_id_len);
-	}
+    const char* saved_device_id = (const char*)dct_read_app_data(dct_offset);
+    if (*saved_device_id == 0xFF)
+    {
+        uint8_t device_id[device_id_len];
+        HAL_device_ID(device_id, sizeof(device_id));
+        dct_write_app_data(device_id, dct_offset, device_id_len);
+    }
 }
-

--- a/hal/src/stm32f2xx/deviceid_hal.cpp
+++ b/hal/src/stm32f2xx/deviceid_hal.cpp
@@ -26,6 +26,7 @@
 
 #include "deviceid_hal.h"
 #include "platform_config.h"
+#include "dct_hal.h"
 #include <algorithm>
 #include <cstring>
 
@@ -42,3 +43,15 @@ unsigned HAL_Platform_ID()
 {
     return PLATFORM_ID;
 }
+
+void HAL_save_device_id(uint32_t dct_offset)
+{
+	const char* saved_device_id = (const char*)dct_read_app_data(dct_offset);
+	if (*saved_device_id==0xFF)
+	{
+		uint8_t device_id[device_id_len];
+		HAL_device_ID(device_id, sizeof(device_id));
+		dct_write_app_data(device_id, dct_offset, device_id_len);
+	}
+}
+

--- a/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
+++ b/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
@@ -409,8 +409,8 @@ int HAL_Set_System_Config(hal_system_config_t config_item, const void* data, uns
         dct_write_app_data(&data_length, offset++, 1);
         break;
     case SYSTEM_CONFIG_SOFTAP_SUFFIX:
-        offset = DCT_DEVICE_ID_OFFSET;
-        length = DCT_DEVICE_ID_SIZE;
+        offset = DCT_DEVICE_CODE_OFFSET;
+        length = DCT_DEVICE_CODE_SIZE;
         break;
     case SYSTEM_CONFIG_SOFTAP_HOSTNAMES:
         break;

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
@@ -62,7 +62,7 @@ typedef struct __attribute__((packed)) application_dct {
     uint8_t claim_code[63];             // claim code. no terminating null.
     uint8_t claimed[1];                 // 0,0xFF, not claimed. 1 claimed.
     uint8_t ssid_prefix[26];            // SSID prefix (25 chars max). First byte is length.
-    uint8_t device_id[6];               // 6 suffix characters (not null terminated))
+    uint8_t device_code[6];               // 6 suffix characters (not null terminated))
     uint8_t version_string[32];         // version string including date
     uint8_t dns_resolve[128];           // DNS names to resolve.
     uint8_t reserved1[64];
@@ -76,8 +76,8 @@ typedef struct __attribute__((packed)) application_dct {
     uint8_t alt_device_private_key[192];	// alternative device private key
     uint8_t alt_server_public_key[192];
     uint8_t alt_server_address[DCT_SERVER_ADDRESS_SIZE];		// server address info
-
-    uint8_t reserved2[640];
+    uint8_t device_id[12];									// the STM32 device ID
+    uint8_t reserved2[628];
     // safe to add more data here or use up some of the reserved space to keep the end where it is
     uint8_t end[0];
 } application_dct_t;
@@ -93,7 +93,7 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_CLAIM_CODE_OFFSET (offsetof(application_dct_t, claim_code))
 #define DCT_SSID_PREFIX_OFFSET (offsetof(application_dct_t, ssid_prefix))
 #define DCT_DNS_RESOLVE_OFFSET (offsetof(application_dct_t, dns_resolve))
-#define DCT_DEVICE_ID_OFFSET (offsetof(application_dct_t, device_id))
+#define DCT_DEVICE_CODE_OFFSET (offsetof(application_dct_t, device_code))
 #define DCT_DEVICE_CLAIMED_OFFSET (offsetof(application_dct_t, claimed))
 #define DCT_FLASH_MODULES_OFFSET (offsetof(application_dct_t, flash_modules))
 #define DCT_PRODUCT_STORE_OFFSET (offsetof(application_dct_t, product_store))
@@ -103,6 +103,7 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_ALT_DEVICE_PRIVATE_KEY_OFFSET (offsetof(application_dct_t, alt_device_private_key))
 #define DCT_ALT_SERVER_PUBLIC_KEY_OFFSET (offsetof(application_dct_t, alt_server_public_key))
 #define DCT_ALT_SERVER_ADDRESS_OFFSET (offsetof(application_dct_t, alt_server_address))
+#define DCT_DEVICE_ID_OFFSET (offsetof(application_dct_t, device_id))
 
 #define DCT_SYSTEM_FLAGS_SIZE  (sizeof(application_dct_t::system_flags))
 #define DCT_DEVICE_PRIVATE_KEY_SIZE  (sizeof(application_dct_t::device_private_key))
@@ -113,7 +114,7 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_CLAIM_CODE_SIZE  (sizeof(application_dct_t::claim_code))
 #define DCT_SSID_PREFIX_SIZE  (sizeof(application_dct_t::ssid_prefix))
 #define DCT_DNS_RESOLVE_SIZE  (sizeof(application_dct_t::dns_resolve))
-#define DCT_DEVICE_ID_SIZE  (sizeof(application_dct_t::device_id))
+#define DCT_DEVICE_CODE_SIZE  (sizeof(application_dct_t::device_code))
 #define DCT_DEVICE_CLAIMED_SIZE  (sizeof(application_dct_t::claimed))
 #define DCT_FLASH_MODULES_SIZE  (sizeof(application_dct_t::flash_modules))
 #define DCT_PRODUCT_STORE_SIZE  (sizeof(application_dct_t::product_store))
@@ -123,6 +124,8 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_ALT_DEVICE_PRIVATE_KEY_SIZE  (sizeof(application_dct_t::alt_device_private_key))
 #define DCT_ALT_SERVER_PUBLIC_KEY_SIZE  (sizeof(application_dct_t::alt_server_public_key))
 #define DCT_ALT_SERVER_ADDRESS_SIZE  (sizeof(application_dct_t::alt_server_address))
+#define DCT_DEVICE_ID_SIZE  (sizeof(application_dct_t::device_id))
+
 
 #define STATIC_ASSERT_DCT_OFFSET(field, expected) STATIC_ASSERT( dct_##field, offsetof(application_dct_t, field)==expected)
 #define STATIC_ASSERT_FLAGS_OFFSET(field, expected) STATIC_ASSERT( dct_sysflag_##field, offsetof(platform_system_flags_t, field)==expected)
@@ -139,7 +142,7 @@ STATIC_ASSERT_DCT_OFFSET(country_code, 1758 /* 1634 + 124 */);
 STATIC_ASSERT_DCT_OFFSET(claim_code, 1762 /* 1758 + 4 */);
 STATIC_ASSERT_DCT_OFFSET(claimed, 1825 /* 1762 + 63 */ );
 STATIC_ASSERT_DCT_OFFSET(ssid_prefix, 1826 /* 1825 + 1 */);
-STATIC_ASSERT_DCT_OFFSET(device_id, 1852 /* 1826 + 26 */);
+STATIC_ASSERT_DCT_OFFSET(device_code, 1852 /* 1826 + 26 */);
 STATIC_ASSERT_DCT_OFFSET(version_string, 1858 /* 1852 + 6 */);
 STATIC_ASSERT_DCT_OFFSET(dns_resolve, 1890 /* 1868 + 32 */);
 STATIC_ASSERT_DCT_OFFSET(reserved1, 2018 /* 1890 + 128 */);
@@ -153,8 +156,9 @@ STATIC_ASSERT_DCT_OFFSET(alt_device_public_key, 2978 /* 2977 + 1 */);
 STATIC_ASSERT_DCT_OFFSET(alt_device_private_key, 3106 /* 2978 + 128 */);
 STATIC_ASSERT_DCT_OFFSET(alt_server_public_key, 3298 /* 3106 + 192 */);
 STATIC_ASSERT_DCT_OFFSET(alt_server_address, 3490 /* 3298 + 192 */);
+STATIC_ASSERT_DCT_OFFSET(device_id, 3618 /* 3490 + 128 */);
 
-STATIC_ASSERT_DCT_OFFSET(reserved2, 3618 /* 3490 + 128 */);
+STATIC_ASSERT_DCT_OFFSET(reserved2, 3630 /* 3618 + 12 */);
 STATIC_ASSERT_DCT_OFFSET(end, 4258 /* 2952 + 1280 */);
 
 STATIC_ASSERT_FLAGS_OFFSET(Bootloader_Version_SysFlag, 4);

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
@@ -62,21 +62,21 @@ typedef struct __attribute__((packed)) application_dct {
     uint8_t claim_code[63];             // claim code. no terminating null.
     uint8_t claimed[1];                 // 0,0xFF, not claimed. 1 claimed.
     uint8_t ssid_prefix[26];            // SSID prefix (25 chars max). First byte is length.
-    uint8_t device_code[6];               // 6 suffix characters (not null terminated))
+    uint8_t device_code[6];             // 6 suffix characters (not null terminated))
     uint8_t version_string[32];         // version string including date
     uint8_t dns_resolve[128];           // DNS names to resolve.
     uint8_t reserved1[64];
     uint8_t server_public_key[768];     // 4096 bits
     uint8_t padding[2];                 // align to 4 byte boundary
-    platform_flash_modules_t flash_modules[MAX_MODULES_SLOT];//100 bytes
+    platform_flash_modules_t flash_modules[MAX_MODULES_SLOT]; //100 bytes
     uint16_t product_store[12];
     uint8_t antenna_selection;           // 0xFF is uninitialized
-    uint8_t cloud_transport;				// 0xFF is uninitialized meaning platform default (TCP for Photon, UDP for Electron). 0 is TCP on Electron.
-    uint8_t alt_device_public_key[128];	// alternative device public key
-    uint8_t alt_device_private_key[192];	// alternative device private key
+    uint8_t cloud_transport;             // 0xFF is uninitialized meaning platform default (TCP for Photon, UDP for Electron). 0 is TCP on Electron.
+    uint8_t alt_device_public_key[128];  // alternative device public key
+    uint8_t alt_device_private_key[192]; // alternative device private key
     uint8_t alt_server_public_key[192];
-    uint8_t alt_server_address[DCT_SERVER_ADDRESS_SIZE];		// server address info
-    uint8_t device_id[12];									// the STM32 device ID
+    uint8_t alt_server_address[DCT_SERVER_ADDRESS_SIZE]; // server address info
+    uint8_t device_id[12];                               // the STM32 device ID
     uint8_t reserved2[628];
     // safe to add more data here or use up some of the reserved space to keep the end where it is
     uint8_t end[0];
@@ -125,7 +125,6 @@ typedef struct __attribute__((packed)) application_dct {
 #define DCT_ALT_SERVER_PUBLIC_KEY_SIZE  (sizeof(application_dct_t::alt_server_public_key))
 #define DCT_ALT_SERVER_ADDRESS_SIZE  (sizeof(application_dct_t::alt_server_address))
 #define DCT_DEVICE_ID_SIZE  (sizeof(application_dct_t::device_id))
-
 
 #define STATIC_ASSERT_DCT_OFFSET(field, expected) STATIC_ASSERT( dct_##field, offsetof(application_dct_t, field)==expected)
 #define STATIC_ASSERT_FLAGS_OFFSET(field, expected) STATIC_ASSERT( dct_sysflag_##field, offsetof(platform_system_flags_t, field)==expected)

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
@@ -29,6 +29,8 @@
 
 #include "platforms.h"
 
+// STM32 Device electronic signature
+// Factory-programmed 12 byte unique device ID
 #define         ID1          (0x1FFF7A10)
 #define         ID2          (0x1FFF7A14)
 #define         ID3          (0x1FFF7A18)


### PR DESCRIPTION
Makes the device ID available via dfu, via the DCT, offset 3618, length 12. 

The device ID is copied to persistent storage if the first byte is not 0xFF. 

Works on the P1/Photon/Electron. 
Core TBD. 

The DCT contained a field "device_id" which stored a 6 digit random code. This was renamed "device_code", so we can use "device_id" for the 12 byte stm32 id.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- N/A API tests compiled
- N/A Run unit/integration/application tests on device
- [ ] Add documentation: (Need a new DFU section for the DFU memory map for the DCT region.)
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)