### PR TITLE
Free memory allocated for previous system interrupt handler

### DIFF
--- a/hal/src/stm32/system_interrupts.cpp
+++ b/hal/src/stm32/system_interrupts.cpp
@@ -21,8 +21,10 @@ uint8_t HAL_Set_System_Interrupt_Handler(hal_irq_t irq, const HAL_InterruptCallb
         *previous = cb;
     if (callback)
         cb = *callback;
-    else
+    else {
         cb.handler = 0;
+        cb.data = 0;
+    }
 
     return true;
 }

--- a/user/tests/wiring/no_fixture/interrupts.cpp
+++ b/user/tests/wiring/no_fixture/interrupts.cpp
@@ -36,3 +36,46 @@ test(interrupts_atomic_section)
 
 	assertMore(end_millis, start_millis);
 }
+
+namespace
+{
+
+class TestHandler
+{
+public:
+	TestHandler()
+	{
+		++count;
+	}
+
+	TestHandler(const TestHandler&)
+	{
+		++count;
+	}
+
+	~TestHandler()
+	{
+		--count;
+	}
+
+	void operator()()
+	{
+	}
+
+	static int count;
+};
+
+} // namespace
+
+int TestHandler::count = 0;
+
+test(interrupts_detached_handler_is_destroyed)
+{
+	assertEqual(TestHandler::count, 0);
+	attachSystemInterrupt(SysInterrupt_SysTick, TestHandler());
+	assertEqual(TestHandler::count, 1);
+	attachSystemInterrupt(SysInterrupt_SysTick, TestHandler()); // Override current handler
+	assertEqual(TestHandler::count, 1); // Previous handler has been destroyed
+	detachSystemInterrupt(SysInterrupt_SysTick);
+	assertEqual(TestHandler::count, 0);
+}

--- a/wiring/src/spark_wiring_interrupts.cpp
+++ b/wiring/src/spark_wiring_interrupts.cpp
@@ -150,7 +150,10 @@ bool attachSystemInterrupt(hal_irq_t irq, wiring_interrupt_handler_t handler)
     callback.handler = call_wiring_interrupt_handler;
     wiring_interrupt_handler_t& h = handler;
     callback.data = new wiring_interrupt_handler_t(h);
-    return HAL_Set_System_Interrupt_Handler(irq, &callback, NULL, NULL);
+    HAL_InterruptCallback prev = { 0 };
+    const bool ok = HAL_Set_System_Interrupt_Handler(irq, &callback, &prev, NULL);
+    delete (wiring_interrupt_handler_t*)prev.data;
+    return ok;
 }
 
 /**
@@ -160,5 +163,8 @@ bool attachSystemInterrupt(hal_irq_t irq, wiring_interrupt_handler_t handler)
  */
 bool detachSystemInterrupt(hal_irq_t irq)
 {
-    return HAL_Set_System_Interrupt_Handler(irq, NULL, NULL, NULL);
+    HAL_InterruptCallback prev = { 0 };
+    const bool ok = HAL_Set_System_Interrupt_Handler(irq, NULL, &prev, NULL);
+    delete (wiring_interrupt_handler_t*)prev.data;
+    return ok;
 }


### PR DESCRIPTION
Fixes #927 

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)