### PR TITLE
reduce datausage on reset/wakeup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 
 ### FEATURES
 
+- [Electron] Reduced data consumption connecting to the cloud with deep sleep. (NB: see the docs for how to gain the full data reduction.) [#953](https://github.com/spark/firmware/pull/953)
 - Can set Claim Code via the Serial interface (for use by the CLI.) [#602](https://github.com/spark/firmware/issues/602) 
+
 
 ### ENHANCEMENTS
 

--- a/build/arm/linker/stm32f2xx/backup_ram_system.ld
+++ b/build/arm/linker/stm32f2xx/backup_ram_system.ld
@@ -1,9 +1,10 @@
     
-    .backup_system :
-    {
-        link_global_retained_system_start = .;
-        *(.retained_system*)
-        link_global_retained_system_end = .;
-    }>BACKUPSRAM_SYSTEM AT> APP_FLASH
-    /* even though we don't initialize the system backup RAM presently, it has to be
-     placed at APP_FLASH or the resulting file ends up being hundreds of megabytes in size */
+.backup_system :
+{
+    link_global_retained_system_initial_values = LOADADDR( .backup_system ); /* This is the location in flash of the initial values of retained global variables */
+    link_global_retained_system_start = .;
+    *(.retained_system*)
+    link_global_retained_system_end = .;
+}>BACKUPSRAM_SYSTEM AT> APP_FLASH
+/* even though we don't initialize the system backup RAM presently, it has to be
+ placed at APP_FLASH or the resulting file ends up being hundreds of megabytes in size */

--- a/communication/src/coap_channel.h
+++ b/communication/src/coap_channel.h
@@ -578,11 +578,11 @@ public:
 		return server;
 	}
 
-	ProtocolError establish() override
+	ProtocolError establish(uint32_t& flags, uint32_t app_crc) override
 	{
 		server.clear();
 		client.clear();
-		return channel::establish();
+		return channel::establish(flags, app_crc);
 	}
 
 	/**

--- a/communication/src/dtls_message_channel.h
+++ b/communication/src/dtls_message_channel.h
@@ -73,6 +73,8 @@ public:
 		 * Restore to the given buffer. Returns the number of bytes restored.
 		 */
 		int (*restore)(void* data, size_t max_length, uint8_t type, void* reserved);
+
+		uint32_t (*calculate_crc)(const uint8_t* data, uint32_t length);
 	};
 
 private:
@@ -125,7 +127,7 @@ private:
 
 	virtual bool is_unreliable() override;
 
-	virtual ProtocolError establish() override;
+	virtual ProtocolError establish(uint32_t& flags, uint32_t app_crc) override;
 
 	/**
 	 * Retrieve first the 2 byte length from the stream, which determines

--- a/communication/src/dtls_protocol.cpp
+++ b/communication/src/dtls_protocol.cpp
@@ -17,6 +17,7 @@ void DTLSProtocol::init(const char *id,
 	channelCallbacks.handle_seed = handle_seed;
 	channelCallbacks.receive = callbacks.receive;
 	channelCallbacks.send = callbacks.send;
+	channelCallbacks.calculate_crc = callbacks.calculate_crc;
 	if (callbacks.size>=52) {
 		channelCallbacks.save = callbacks.save;
 		channelCallbacks.restore = callbacks.restore;

--- a/communication/src/dtls_session_persist.h
+++ b/communication/src/dtls_session_persist.h
@@ -21,7 +21,8 @@
 #include "stddef.h"
 
 // The size of the persisted data
-#define SessionPersistBaseSize 196
+#define SessionPersistBaseSize 208
+
 // variable size due to int/size_t members
 #define SessionPersistVariableSize (sizeof(int)+sizeof(int)+sizeof(size_t))
 
@@ -80,8 +81,21 @@ struct __attribute__((packed)) SessionPersistData
 	message_id_t next_coap_id;
 #else
 	// when the mbedtls headers aren't available, just pad with the requisite size
-	uint8_t opaque_ssl[64+sizeof(int)+sizeof(int)+sizeof(size_t)+32+48+2+8+2];
+	uint8_t opaque_ssl[64+SessionPersistVariableSize+32+48+2+8+2];
 #endif
+
+   /**
+	 * Checksum of the state of the subscriptions that have been sent to the cloud.
+	 */
+	uint32_t subscriptions_crc;
+	/**
+	 * Checksum of state of the functions and variables last sent to the cloud.
+	 */
+	uint32_t describe_app_crc;
+	/**
+	  * Checksum of the system describe message.
+	  */
+	uint32_t describe_system_crc;
 
 };
 
@@ -186,6 +200,7 @@ public:
 	 * Persist information in this context .
 	 */
 	void save(save_fn_t saver);
+	void restore(restore_fn_t restore) { restore_this_from(restore); }
 
 	/**
 	 * Update information in this context and saves if the context
@@ -222,6 +237,9 @@ public:
 	 */
 	RestoreStatus restore(mbedtls_ssl_context* context, bool renegotiate, uint32_t keys_checksum, message_id_t* message, restore_fn_t restorer);
 
+	uint32_t application_state_checksum(uint32_t (*calc_crc)(const uint8_t* data, uint32_t len));
+
+	SessionPersistData& as_data() { return *this; }
 };
 
 static_assert(sizeof(SessionPersist)==SessionPersistBaseSize+sizeof(mbedtls_ssl_session::ciphersuite)+sizeof(mbedtls_ssl_session::id_len)+sizeof(mbedtls_ssl_session::compression), "SessionPersist size");

--- a/communication/src/dtls_session_persist.h
+++ b/communication/src/dtls_session_persist.h
@@ -119,7 +119,7 @@ public:
 
 #ifdef MBEDTLS_SSL_H
 
-class __attribute__((packed)) SessionPersist : SessionPersistOpaque
+class __attribute__((packed)) SessionPersist : public SessionPersistOpaque
 {
 public:
 
@@ -155,10 +155,15 @@ private:
 	{
 		if (restorer)
 		{
-			if (restorer(this, sizeof(*this), SparkCallbacks::PERSIST_SESSION, nullptr)!=sizeof(*this))
+			int size = restorer(this, sizeof(*this), SparkCallbacks::PERSIST_SESSION, nullptr);
+			if (size!=sizeof(*this)) {
+				DEBUG("restore size mismatch 1: %d/%d", size, sizeof(*this));
 				return false;
-			if (size!=sizeof(*this))
+			}
+			if (size!=sizeof(*this)) {
+				DEBUG("restore size mismatch %d/%d", size, sizeof(*this));
 				return false;
+			}
 		}
 		return true;
 	}

--- a/communication/src/lightssl_message_channel.h
+++ b/communication/src/lightssl_message_channel.h
@@ -79,7 +79,7 @@ public:
 	void init(const uint8_t* core_private, const uint8_t* server_public,
 			const uint8_t* device_id, Callbacks& callbacks, message_id_t* counter);
 
-	virtual ProtocolError establish() override
+	virtual ProtocolError establish(uint32_t& flags, uint32_t app_crc) override
 	{
 		return handshake();
 	}

--- a/communication/src/message_channel.h
+++ b/communication/src/message_channel.h
@@ -158,6 +158,16 @@ struct Channel
 		 * the session has moved.
 		 */
 		MOVE_SESSION = 2,
+
+		/**
+		 * Load session - load the session from persistent store.
+		 */
+		LOAD_SESSION = 3,
+
+		/**
+		 * Save session - saves the session to persistent store.
+		 */
+		SAVE_SESSION = 4,
 	};
 
 
@@ -201,8 +211,10 @@ struct MessageChannel : public Channel
 
 	/**
 	 * Establish this channel for communication.
+	 * @param flags on return, SKIP_SESSION_RESUME_HELLO is set if the hello/vars/funcs/sucriptions regitration is not needed.
+	 * @param app_state_crc	The crc of the current application state.
 	 */
-	virtual ProtocolError establish()=0;
+	virtual ProtocolError establish(uint32_t& flags, uint32_t app_state_crc)=0;
 
 	/**
 	 * Retrieves a new message object containing the message buffer.

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -64,8 +64,8 @@ namespace ChunkReceivedCode {
 }
 
 enum DescriptionType {
-    DESCRIBE_SYSTEM = 1<<1,            // modules
-    DESCRIBE_APPLICATION = 1<<2,       // functions and variables
+    DESCRIBE_SYSTEM = 1<<0,            // modules
+    DESCRIBE_APPLICATION = 1<<1,       // functions and variables
 	DESCRIBE_ALL = DESCRIBE_SYSTEM | DESCRIBE_APPLICATION
 };
 

--- a/communication/src/spark_descriptor.h
+++ b/communication/src/spark_descriptor.h
@@ -40,6 +40,25 @@ namespace SparkReturnType {
   };
 }
 
+/**
+ * The application state is divided into distinct types.
+ */
+namespace SparkAppStateSelector {
+	enum Enum {
+		DESCRIBE_APP,
+		DESCRIBE_SYSTEM,
+		SUBSCRIPTIONS,
+	};
+}
+
+namespace SparkAppStateUpdate {
+	enum Enum {
+		COMPUTE = 1,
+		PERSIST = 2,
+		COMPUTE_AND_PERSIST = 3
+	};
+}
+
 struct SparkDescriptor
 {
     typedef std::function<bool(const void*, SparkReturnType::Enum)> FunctionResultCallback;
@@ -61,7 +80,19 @@ struct SparkDescriptor
 
     void (*call_event_handler)(uint16_t size, FilteringEventHandler* handler, const char* event, const char* data, void* reserved);
 
-    void* reserved[3];      // add a few additional pointers
+    /**
+     * Optional callback - may be null.
+     * @param selector	The app state information to retrieve or update
+     * @param operation	COMPUTE to retrieve, the value. PESIST to set the persistent storage to the given value, COMPUTE_AND_PERSIST to compute and persist a given value. funcs/vars crc can be retrieved,
+     * 	subscriptions crc can be set.
+     * 	The descriptor state (DESCRIBE_APP/DESCRIBE_SYSTEM) can be computed by the callback and can be used with COMPUTE and COMPUTE_AND_PERSIST operations.
+     * 	The subscription state (SUBSCRIPTIONS) is computed by the caller and passed to the callback (secifying PERSIST as the operation.)
+     * @param data		when operation==1 this is the value ot set. otherwise unused.
+     * @return when operation==COMPUTE, the crc of the application state is retrieved when operation is COMPUTE. Otherwise the return value is 0.
+     */
+    uint32_t (*app_state_selector_info)(SparkAppStateSelector::Enum selector, SparkAppStateUpdate::Enum operation, uint32_t data, void* reserved);
+
+    void* reserved[2];      // add a few additional pointers
 };
 
 STATIC_ASSERT(SparkDescriptor_size, sizeof(SparkDescriptor)==60 || sizeof(void*)!=4);

--- a/communication/src/spark_protocol.cpp
+++ b/communication/src/spark_protocol.cpp
@@ -747,7 +747,7 @@ int SparkProtocol::description(unsigned char *buf, unsigned char token,
     appender.append("{");
     bool has_content = false;
 
-    if (desc_flags && DESCRIBE_APPLICATION) {
+    if (desc_flags & DESCRIBE_APPLICATION) {
         has_content = true;
       appender.append("\"f\":[");
 

--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -11,6 +11,38 @@ Particle Device Firmware
 
 ## Cloud Functions
 
+{{#if electron}}
+### Optimizing Cellular Data Use with Cloud connectivity on the Electron
+_Since 0.6.0_
+
+When the device first connects to the cloud, it provides the cloud
+with detials of the registered functions, variables and subscriptions, as well as establishing a secure channel. This requires 4300 bytes of ata, plus additional data for each function, variable and subscription. 
+
+Subsequent reconnections to the cloud while the device is still powered does not resend this data. Instead,
+just a ping is sent to the cloud, which uses 135 bytes.   
+
+Prior to 0.6.0, when the device was reset or when woke from deep sleep, the cloud connection would be fullly reinitialized, resending the 4300 bytes of data. From 0.6.0, the device determines that a full reinitialization isn't needed and reuses the existing session, after validating that the local state matches what was last communicated to the cloud. Connecting to the cloud after reset or wake-up sends just a ping message, useing 135 bytes of data. A key requirement for the device to be able to determine that the existing session can be reuses is that the functions, variables and subscriptions are registered BEFORE connecting to the cloud. 
+
+Ensuring the application has registered its cloud state before connecting to the cloud can be easily done using `SEMI_AUTOMATIC` mode: 
+
+```cpp
+// Using SEMI_AUTOMATIC mode to get the lowest possible data usage
+// when reconnecting to the cloud. 
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+void setup() {
+	// register cloudy things
+    Particle.function(....);
+    Particle.variable(....);
+    Particle.subscribe(....);
+    // etc...
+    // then connect
+    Particle.connect();
+}
+```
+{{/if}}
+
+
 ### Particle.variable()
 
 Expose a *variable* through the Cloud so that it can be called with `GET /v1/devices/{DEVICE_ID}/{VARIABLE}`.

--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -13,17 +13,18 @@ Particle Device Firmware
 
 {{#if electron}}
 ### Optimizing Cellular Data Use with Cloud connectivity on the Electron
+
 _Since 0.6.0_
 
-When the device first connects to the cloud, it provides the cloud
-with detials of the registered functions, variables and subscriptions, as well as establishing a secure channel. This requires 4300 bytes of ata, plus additional data for each function, variable and subscription. 
+When the device first connects to the cloud, it establishes a secure channel
+and informs the cloud of the registered functions, variables and subscriptions. This uses 4400 bytes of data, plus additional data for each function, variable and subscription. 
 
 Subsequent reconnections to the cloud while the device is still powered does not resend this data. Instead,
-just a ping is sent to the cloud, which uses 135 bytes.   
+a small reconnection message is sent to the cloud, which uses 135 bytes.   
 
-Prior to 0.6.0, when the device was reset or when woke from deep sleep, the cloud connection would be fullly reinitialized, resending the 4300 bytes of data. From 0.6.0, the device determines that a full reinitialization isn't needed and reuses the existing session, after validating that the local state matches what was last communicated to the cloud. Connecting to the cloud after reset or wake-up sends just a ping message, useing 135 bytes of data. A key requirement for the device to be able to determine that the existing session can be reuses is that the functions, variables and subscriptions are registered BEFORE connecting to the cloud. 
+Prior to 0.6.0, when the device was reset or woken from deep sleep, the cloud connection would be fullly reinitialized, which meant resending the 4400 bytes of data. From 0.6.0, the device determines that a full reinitialization isn't needed and reuses the existing session, after validating that the local state matches what was last communicated to the cloud. Connecting to the cloud after reset or wake-up sends just a reconnect message, using 135 bytes of data. A key requirement for the device to be able to determine that the existing session can be reused is that the functions, variables and subscriptions are registered BEFORE connecting to the cloud. 
 
-Ensuring the application has registered its cloud state before connecting to the cloud can be easily done using `SEMI_AUTOMATIC` mode: 
+Registering functions and variables before connecting to the cloud is easily done using `SEMI_AUTOMATIC` mode: 
 
 ```cpp
 // Using SEMI_AUTOMATIC mode to get the lowest possible data usage

--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -17,22 +17,22 @@ Particle Device Firmware
 _Since 0.6.0_
 
 When the device first connects to the cloud, it establishes a secure channel
-and informs the cloud of the registered functions, variables and subscriptions. This uses 4400 bytes of data, plus additional data for each function, variable and subscription. 
+and informs the cloud of the registered functions, variables and subscriptions. This uses 4400 bytes of data, plus additional data for each function, variable and subscription.
 
-Subsequent reconnections to the cloud while the device is still powered does not resend this data. Instead,
-a small reconnection message is sent to the cloud, which uses 135 bytes.   
+Subsequent reconnections to the cloud while the device is still powered does not resend this data. Instead, a small reconnection message is sent to the cloud, which uses 135 bytes.
 
-Prior to 0.6.0, when the device was reset or woken from deep sleep, the cloud connection would be fullly reinitialized, which meant resending the 4400 bytes of data. From 0.6.0, the device determines that a full reinitialization isn't needed and reuses the existing session, after validating that the local state matches what was last communicated to the cloud. Connecting to the cloud after reset or wake-up sends just a reconnect message, using 135 bytes of data. A key requirement for the device to be able to determine that the existing session can be reused is that the functions, variables and subscriptions are registered BEFORE connecting to the cloud. 
+Prior to 0.6.0, when the device was reset or woken from deep sleep, the cloud connection would be fully reinitialized, which meant resending the 4400 bytes of data. From 0.6.0, the device determines that a full reinitialization isn't needed and reuses the existing session, after validating that the local state matches what was last communicated to the cloud. Connecting to the cloud after reset or wake-up sends just a reconnect message, using 135 bytes of data. A key requirement for the device to be able to determine that the existing session can be reused is that the functions, variables and subscriptions are registered BEFORE connecting to the cloud.
 
-Registering functions and variables before connecting to the cloud is easily done using `SEMI_AUTOMATIC` mode: 
+Registering functions and variables before connecting to the cloud is easily done using `SEMI_AUTOMATIC` mode:
 
 ```cpp
-// Using SEMI_AUTOMATIC mode to get the lowest possible data usage
-// when reconnecting to the cloud. 
+// EXAMPLE USAGE
+// Using SEMI_AUTOMATIC mode to get the lowest possible data usage by
+// registering functions and variables BEFORE connecting to the cloud.
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
 void setup() {
-	// register cloudy things
+    // register cloudy things
     Particle.function(....);
     Particle.variable(....);
     Particle.subscribe(....);

--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -385,6 +385,8 @@ void HAL_Core_Setup_finalize(void)
 {
     uint32_t* isrs = (uint32_t*)&link_ram_interrupt_vectors_location;
     isrs[SysTick_Handler_Idx] = (uint32_t)SysTickChain;
+    // retained memory is critical for efficient data use on the electron
+    HAL_Feature_Set(FEATURE_RETAINED_MEMORY, ENABLE);
 }
 
 /******************************************************************************/

--- a/modules/electron/system-part2/linker.ld
+++ b/modules/electron/system-part2/linker.ld
@@ -14,6 +14,8 @@ MEMORY
        The value given here is the sum of system_static_ram_size and stack_size
     */
     SRAM      (rwx) : ORIGIN = 0x20020000 - 40K, LENGTH = 40K
+    
+    INCLUDE backup_ram_memory.ld    
 }
 
 

--- a/modules/shared/stm32f2xx/part2.ld
+++ b/modules/shared/stm32f2xx/part2.ld
@@ -91,6 +91,8 @@ SECTIONS
         link_ram_interrupt_vectors_location_end = .;
     }> SRAM
 
+    INCLUDE backup_ram_system.ld
+
     .data : /* Contains the non-zero initialised global variables */
     {
         _sidata = LOADADDR( .data ); /* This is the location in flash of the initial values of global variables */
@@ -102,7 +104,6 @@ SECTIONS
         _edata = . ;
         . = ALIGN(., 4);
     }> SRAM AT> APP_FLASH
-
 
     .bss : /* Zero initialised memory used for zero initialised variables */
     {

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -128,6 +128,78 @@ int call_raw_user_function(void* data, const char* param, void* reserved)
     return (*fn)(p);
 }
 
+inline uint32_t crc(const void* data, size_t len)
+{
+	return HAL_Core_Compute_CRC32((const uint8_t*)data, len);
+}
+
+template <typename T>
+uint32_t crc(const T& t)
+{
+	return crc(&t, sizeof(t));
+}
+
+uint32_t string_crc(const char* s)
+{
+	return crc(s, strlen(s));
+}
+
+/**
+ * Computes the checksum of the registered functions.
+ * The function name is used to compute the checksum.
+ */
+uint32_t compute_functions_checksum()
+{
+	uint32_t checksum = 0;
+	for (int i = funcs.size(); i-->0; )
+    {
+		checksum += string_crc(funcs[i].userFuncKey);
+    }
+	return checksum;
+}
+
+/**
+ * Computes the checksum of the registered variables.
+ * The checksum is derived from the variable name and type.
+ */
+uint32_t compute_variables_checksum()
+{
+	uint32_t checksum = 0;
+	for (int i = vars.size(); i-->0; )
+	{
+		checksum += string_crc(vars[i].userVarKey);
+		checksum += crc(vars[i].userVarType);
+	}
+	return checksum;
+}
+
+/**
+ * Computes the checksum of all functions and variables.
+ */
+uint32_t compute_describe_app_checksum()
+{
+	uint32_t chk[2];
+	chk[0] = compute_variables_checksum();
+	chk[1] = compute_functions_checksum();
+	return crc(chk, sizeof(chk));
+}
+
+uint32_t compute_describe_system_checksum()
+{
+    hal_system_info_t info;
+    memset(&info, 0, sizeof(info));
+    info.size = sizeof(info);
+    HAL_System_Info(&info, true, NULL);
+	uint32_t checksum = info.platform_id;
+	for (int i=0; i<info.module_count; i++)
+	{
+		checksum += crc(info.modules[i].suffix->sha);
+	}
+	HAL_System_Info(&info, false, NULL);
+    return checksum;
+}
+
+
 /**
  * Register a function.
  * @param desc
@@ -404,9 +476,10 @@ void SystemEvents(const char* name, const char* data)
     }
 }
 
-using particle::protocol::SessionPersistOpaque;
-
 #if HAL_PLATFORM_CLOUD_UDP
+using particle::protocol::SessionPersistOpaque;
+using particle::protocol::SessionPersistData;
+
 int Spark_Save(const void* buffer, size_t length, uint8_t type, void* reserved)
 {
 	if (type==SparkCallbacks::PERSIST_SESSION)
@@ -432,7 +505,53 @@ int Spark_Restore(void* buffer, size_t max_length, uint8_t type, void* reserved)
 		length = 0;
 	return length;
 }
+
+void update_persisted_state(std::function<void(SessionPersistOpaque&)> fn)
+{
+	SessionPersistOpaque persist;
+	if (Spark_Restore(&persist, sizeof(persist), SparkCallbacks::PERSIST_SESSION, nullptr)==sizeof(persist) && persist.is_valid())
+	{
+		fn(persist);
+		Spark_Save(&persist, sizeof(persist), SparkCallbacks::PERSIST_SESSION, nullptr);
+	}
+}
+
+uint32_t compute_cloud_state_checksum(SparkAppStateSelector::Enum stateSelector, SparkAppStateUpdate::Enum operation, uint32_t value, void* reserved)
+{
+	if (operation==SparkAppStateUpdate::COMPUTE_AND_PERSIST ) {
+		switch (stateSelector)
+		{
+		case SparkAppStateSelector::DESCRIBE_APP:
+			update_persisted_state([](SessionPersistData& data){
+				data.describe_app_crc = compute_describe_app_checksum();
+			});
+		case SparkAppStateSelector::DESCRIBE_SYSTEM:
+			update_persisted_state([](SessionPersistData& data){
+				data.describe_system_crc = compute_describe_system_checksum();
+			});
+		}
+	}
+	else if (operation==SparkAppStateUpdate::PERSIST && stateSelector==SparkAppStateSelector::SUBSCRIPTIONS)
+	{
+		update_persisted_state([value](SessionPersistData& data){
+			data.subscriptions_crc = value;
+		});
+	}
+	else if (operation==SparkAppStateUpdate::COMPUTE)
+	{
+		switch (stateSelector)
+		{
+		case SparkAppStateSelector::DESCRIBE_APP:
+			return compute_describe_app_checksum();
+
+		case SparkAppStateSelector::DESCRIBE_SYSTEM:
+			return compute_describe_system_checksum();
+		}
+	}
+	return 0;
+}
 #endif
+
 
 void Spark_Protocol_Init(void)
 {
@@ -503,7 +622,9 @@ void Spark_Protocol_Init(void)
         descriptor.ota_upgrade_status_sent = HAL_OTA_Flashed_ResetStatus;
         descriptor.append_system_info = system_module_info;
         descriptor.call_event_handler = invokeEventHandler;
-
+#if HAL_PLATFORM_CLOUD_UDP
+        descriptor.app_state_selector_info = compute_cloud_state_checksum;
+#endif
         // todo - this pushes a lot of data on the stack! refactor to remove heavy stack usage
         unsigned char pubkey[EXTERNAL_FLASH_SERVER_PUBLIC_KEY_LENGTH];
         unsigned char private_key[EXTERNAL_FLASH_CORE_PRIVATE_KEY_LENGTH];

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -70,7 +70,7 @@ struct User_Func_Lookup_Table_t
 {
     void* pUserFuncData;
     cloud_function_t pUserFunc;
-    char userFuncKey[USER_FUNC_KEY_LENGTH];
+    char userFuncKey[USER_FUNC_KEY_LENGTH+1];
 };
 
 


### PR DESCRIPTION
Reduces data consumption when the device is reset or wakes up from deep sleep. 

Computes a checksum of the last set of subscriptions, functions, variables and system modules that were sent to the cloud, which is maintained in retained storage, as part of the session. 

Before sending a hello after resuming the session, the device checks the current checksum for the subscriptions, functions variables and system modules. If it is the same as the persisted checksum, the hello message is stkipped, since the local application state is the same as what was last sent to the cloud. When the checksums are not the same, the hello message is sent, which clears the app state on the server, so all subsequent describe messages and subscriptions are resent.

For this to work optimally, code should use SEMI_AUTOMATIC mode and connect to the cloud after registering all subscriptions, variables and functions. 

e.g.

```
SYSTEM_MODE(SEMI_AUTOMATIC);

void setup()
{
     Particle.function(...); 
     Particle.subscribe(...);
     Particle.variable(...);

    Particle.connect();
}

```

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)