### PR TITLE
makes the MAC address available after `WiFi.on()` in all modes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 - [Electron] Reduced data consumption connecting to the cloud with deep sleep. (NB: see the docs for how to gain the full data reduction.) [#953](https://github.com/spark/firmware/pull/953)
 - Can set Claim Code via the Serial interface (for use by the CLI.) [#602](https://github.com/spark/firmware/issues/602) 
 
-
 ### ENHANCEMENTS
 
 - Local build warns if crc32 is not present. [#941](https://github.com/spark/firmware/issues/941)
+- [Photon/Core] MAC address is available immediately after `WiFi.on()` [#879](https://github.com/spark/firmware/issues/879)
 
 ### BUGFIXES
 

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -345,6 +345,7 @@ public:
         {
             config_clear();
             on_now();
+            update_config(true);
             SPARK_WLAN_STARTED = 1;
             SPARK_WLAN_SLEEP = 0;
             SPARK_LED_FADE = 1;


### PR DESCRIPTION
fixes #879 

Tested on the Core/P1
---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- N/A  API tests compiled
- [ ] Run unit/integration/application tests on device. Really need the test framework to support reset before each test and setting device modes. 
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
