### PR TITLE
Electron G350 TCP Client fix for #896

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1761,6 +1761,7 @@ int MDMParser::socketRecv(int socket, char* buf, int len)
 */
     system_tick_t start = HAL_Timer_Get_Milli_Seconds();
     while (len) {
+        // DEBUG_D("socketRecv: LEN: %d\r\n", len);
         int blk = MAX_SIZE; // still need space for headers and unsolicited  commands
         if (len < blk) blk = len;
         bool ok = false;
@@ -1770,7 +1771,12 @@ int MDMParser::socketRecv(int socket, char* buf, int len)
 				if (_sockets[socket].connected) {
 					int available = socketReadable(socket);
 					if (available<0)  {
-						ok = false;
+                        // DEBUG_D("socketRecv: SOCKET CLOSED or NO AVAIL DATA\r\n");
+                        // Socket may have been closed remotely during read, or no more data to read.
+                        // Zero the `len` to break out of the while(len), and set `ok` to true so
+                        // we return the `cnt` recv'd up until the socket was closed.
+                        len = 0;
+                        ok = true;
 					}
 					else
 					{
@@ -1811,7 +1817,7 @@ int MDMParser::socketRecv(int socket, char* buf, int len)
             return MDM_SOCKET_ERROR;
         }
     }
-    //DEBUG_D("socketRecv: %d \"%*s\"\r\n", cnt, cnt, buf-cnt);
+    // DEBUG_D("socketRecv: %d \"%*s\"\r\n", cnt, cnt, buf-cnt);
     return cnt;
 }
 

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -57,7 +57,7 @@ std::recursive_mutex mdm_mutex;
 //! registration done check helper (no need to poll further)
 #define REG_DONE(r)     ((r == REG_HOME) || (r == REG_ROAMING) || (r == REG_DENIED))
 //! helper to make sure that lock unlock pair is always balanced
-#define LOCK()		std::lock_guard<std::recursive_mutex> __mdm_guard(mdm_mutex);
+#define LOCK()      std::lock_guard<std::recursive_mutex> __mdm_guard(mdm_mutex);
 //! helper to make sure that lock unlock pair is always balanced
 #define UNLOCK()
 
@@ -1668,19 +1668,19 @@ int MDMParser::socketSend(int socket, const char * buf, int len)
             blk = cnt;
         bool ok = false;
         {
-			LOCK();
-			if (ISSOCKET(socket)) {
-				sendFormated("AT+USOWR=%d,%d\r\n",_sockets[socket].handle,blk);
-				if (RESP_PROMPT == waitFinalResp()) {
-					HAL_Delay_Milliseconds(50);
-					send(buf, blk);
-					if (RESP_OK == waitFinalResp())
-						ok = true;
-				}
-			}
-			UNLOCK();
+            LOCK();
+            if (ISSOCKET(socket)) {
+                sendFormated("AT+USOWR=%d,%d\r\n",_sockets[socket].handle,blk);
+                if (RESP_PROMPT == waitFinalResp()) {
+                    HAL_Delay_Milliseconds(50);
+                    send(buf, blk);
+                    if (RESP_OK == waitFinalResp())
+                        ok = true;
+                }
+            }
+            UNLOCK();
         }
-		if (!ok)
+        if (!ok)
             return MDM_SOCKET_ERROR;
         buf += blk;
         cnt -= blk;
@@ -1698,17 +1698,17 @@ int MDMParser::socketSendTo(int socket, MDM_IP ip, int port, const char * buf, i
             blk = cnt;
         bool ok = false;
         {
-			LOCK();
-			if (ISSOCKET(socket)) {
-				sendFormated("AT+USOST=%d,\"" IPSTR "\",%d,%d\r\n",_sockets[socket].handle,IPNUM(ip),port,blk);
-				if (RESP_PROMPT == waitFinalResp()) {
-					HAL_Delay_Milliseconds(50);
-					send(buf, blk);
-					if (RESP_OK == waitFinalResp())
-						ok = true;
-				}
-			}
-			UNLOCK();
+            LOCK();
+            if (ISSOCKET(socket)) {
+                sendFormated("AT+USOST=%d,\"" IPSTR "\",%d,%d\r\n",_sockets[socket].handle,IPNUM(ip),port,blk);
+                if (RESP_PROMPT == waitFinalResp()) {
+                    HAL_Delay_Milliseconds(50);
+                    send(buf, blk);
+                    if (RESP_OK == waitFinalResp())
+                        ok = true;
+                }
+            }
+            UNLOCK();
         }
         if (!ok)
             return MDM_SOCKET_ERROR;
@@ -1722,10 +1722,10 @@ int MDMParser::socketReadable(int socket)
 {
     int pending = MDM_SOCKET_ERROR;
     if (_cancel_all_operations)
-    		return MDM_SOCKET_ERROR;
+            return MDM_SOCKET_ERROR;
     LOCK();
     if (ISSOCKET(socket) && _sockets[socket].connected) {
-    		//DEBUG_D("socketReadable(%d)\r\n", socket);
+            //DEBUG_D("socketReadable(%d)\r\n", socket);
         // allow to receive unsolicited commands
         waitFinalResp(NULL, NULL, 0);
         if (_sockets[socket].connected)
@@ -1766,53 +1766,53 @@ int MDMParser::socketRecv(int socket, char* buf, int len)
         if (len < blk) blk = len;
         bool ok = false;
         {
-        	LOCK();
-			if (ISSOCKET(socket)) {
-				if (_sockets[socket].connected) {
-					int available = socketReadable(socket);
-					if (available<0)  {
+            LOCK();
+            if (ISSOCKET(socket)) {
+                if (_sockets[socket].connected) {
+                    int available = socketReadable(socket);
+                    if (available<0)  {
                         // DEBUG_D("socketRecv: SOCKET CLOSED or NO AVAIL DATA\r\n");
                         // Socket may have been closed remotely during read, or no more data to read.
                         // Zero the `len` to break out of the while(len), and set `ok` to true so
                         // we return the `cnt` recv'd up until the socket was closed.
                         len = 0;
                         ok = true;
-					}
-					else
-					{
-						if (blk > available)	// only read up to the amount available. When 0,
-							blk = available;// skip reading and check timeout.
-						if (blk > 0) {
-							DEBUG_D("socketRecv: _cbUSORD\r\n");
-							sendFormated("AT+USORD=%d,%d\r\n",_sockets[socket].handle, blk);
-							USORDparam param;
-							param.buf = buf;
-							if (RESP_OK == waitFinalResp(_cbUSORD, &param)) {
-								blk = param.len;
-								_sockets[socket].pending -= blk;
-								len -= blk;
-								cnt += blk;
-								buf += blk;
-								ok = true;
-							}
-						} else if (!TIMEOUT(start, _sockets[socket].timeout_ms)) {
-							// DEBUG_D("socketRecv: WAIT FOR URCs\r\n");
-							ok = (WAIT == waitFinalResp(NULL,NULL,0)); // wait for URCs
-						} else {
-							// DEBUG_D("socketRecv: TIMEOUT\r\n");
-							len = 0;
-							ok = true;
-						}
-					}
-				} else {
-					// DEBUG_D("socketRecv: SOCKET NOT CONNECTED\r\n");
-					len = 0;
-					ok = true;
-				}
-			}
-			UNLOCK();
+                    }
+                    else
+                    {
+                        if (blk > available)    // only read up to the amount available. When 0,
+                            blk = available;// skip reading and check timeout.
+                        if (blk > 0) {
+                            DEBUG_D("socketRecv: _cbUSORD\r\n");
+                            sendFormated("AT+USORD=%d,%d\r\n",_sockets[socket].handle, blk);
+                            USORDparam param;
+                            param.buf = buf;
+                            if (RESP_OK == waitFinalResp(_cbUSORD, &param)) {
+                                blk = param.len;
+                                _sockets[socket].pending -= blk;
+                                len -= blk;
+                                cnt += blk;
+                                buf += blk;
+                                ok = true;
+                            }
+                        } else if (!TIMEOUT(start, _sockets[socket].timeout_ms)) {
+                            // DEBUG_D("socketRecv: WAIT FOR URCs\r\n");
+                            ok = (WAIT == waitFinalResp(NULL,NULL,0)); // wait for URCs
+                        } else {
+                            // DEBUG_D("socketRecv: TIMEOUT\r\n");
+                            len = 0;
+                            ok = true;
+                        }
+                    }
+                } else {
+                    // DEBUG_D("socketRecv: SOCKET NOT CONNECTED\r\n");
+                    len = 0;
+                    ok = true;
+                }
+            }
+            UNLOCK();
         }
-		if (!ok) {
+        if (!ok) {
             // DEBUG_D("socketRecv: ERROR\r\n");
             return MDM_SOCKET_ERROR;
         }
@@ -1852,31 +1852,31 @@ int MDMParser::socketRecvFrom(int socket, MDM_IP* ip, int* port, char* buf, int 
         if (len < blk) blk = len;
         bool ok = false;
         {
-				LOCK();
-			if (ISSOCKET(socket)) {
-				if (blk > 0) {
-					sendFormated("AT+USORF=%d,%d\r\n",_sockets[socket].handle, blk);
-					USORFparam param;
-					param.buf = buf;
-					if (RESP_OK == waitFinalResp(_cbUSORF, &param)) {
-						*ip = param.ip;
-						*port = param.port;
-						blk = param.len;
-						_sockets[socket].pending -= blk;
-						len -= blk;
-						cnt += blk;
-						buf += blk;
-						len = 0; // done
-						ok = true;
-					}
-				} else if (!TIMEOUT(start, _sockets[socket].timeout_ms)) {
-					ok = (WAIT == waitFinalResp(NULL,NULL,0)); // wait for URCs
-				} else {
-					len = 0; // no more data and socket closed or timed-out
-					ok = true;
-				}
-			}
-			UNLOCK();
+                LOCK();
+            if (ISSOCKET(socket)) {
+                if (blk > 0) {
+                    sendFormated("AT+USORF=%d,%d\r\n",_sockets[socket].handle, blk);
+                    USORFparam param;
+                    param.buf = buf;
+                    if (RESP_OK == waitFinalResp(_cbUSORF, &param)) {
+                        *ip = param.ip;
+                        *port = param.port;
+                        blk = param.len;
+                        _sockets[socket].pending -= blk;
+                        len -= blk;
+                        cnt += blk;
+                        buf += blk;
+                        len = 0; // done
+                        ok = true;
+                    }
+                } else if (!TIMEOUT(start, _sockets[socket].timeout_ms)) {
+                    ok = (WAIT == waitFinalResp(NULL,NULL,0)); // wait for URCs
+                } else {
+                    len = 0; // no more data and socket closed or timed-out
+                    ok = true;
+                }
+            }
+            UNLOCK();
         }
         if (!ok) {
             DEBUG_D("socketRecv: ERROR\r\n");


### PR DESCRIPTION
Part of #896 was previously solved for U260's with #900, but G350's were still not working.  The complete message was not being received by the TCPClient for short messages.

The issue was that U260 and G350 both were receiving a +UUSOCL URC for a remotely closed socket. The U260 would receive this later in time and therefor did not see any issue.  The G350 would receive the URC earlier which caused the socketReadable() routine to throw an unexpected error by setting OK to false.  This was keeping the `cnt` from being returned for the last bytes received.  When not `readable` now, we ensure `len` is set to 0 and OK is set to `true`.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)