### PR TITLE
arm gcc 5.3.1 compatibility

### DIFF
--- a/build/module.mk
+++ b/build/module.mk
@@ -33,6 +33,10 @@ CFLAGS += $(addprefix -D,$(GLOBAL_DEFINES))
 export GLOBAL_DEFINES
 endif
 
+# fixes build errors on ubuntu with arm gcc 5.3.1
+# GNU_SOURCE is needed for isascii/toascii
+# WINSOCK_H stops select.h from being used which conflicts with CC3000 headers
+CFLAGS += -D_GNU_SOURCE -D_WINSOCK_H
 
 # Collect all object and dep files
 ALLOBJ += $(addprefix $(BUILD_PATH)/, $(CSRC:.c=.o))

--- a/platform/NET/CC3000/CC3000_Host_Driver/socket.h
+++ b/platform/NET/CC3000/CC3000_Host_Driver/socket.h
@@ -35,6 +35,13 @@
 #ifndef __SOCKET_H__
 #define __SOCKET_H__
 
+// exclude timeval definition on linux
+#define _SYS__TIMEVAL_H_
+// exclude system select
+#define _SYS_SELECT_H
+
+
+
 #include "data_types.h"
 #include "time.h"
 


### PR DESCRIPTION
adds GNU suport (for isascii and toascii) and avoids duplicate symbol definitions on linux. Provides compatibility with arm gcc 5.3.1 and fixes #963

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
… 