### PR TITLE
Fail the build early if crc32 tool is not available

### DIFF
--- a/build/common-tools.mk
+++ b/build/common-tools.mk
@@ -21,5 +21,10 @@ CRC = crc32
 XXD = xxd
 SERIAL_SWITCHER = $(COMMON_BUILD)/serial_switcher.py
 
+crc32_path := $(shell which $(CRC))
+ifeq ("$(crc32_path)", "")
+    $(error "$(CRC) tool is not found")
+endif
+
 CPPFLAGS +=
 


### PR DESCRIPTION
Fixes #941

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
