### PR TITLE
softap persists on exiting listening mode if wifi module was off.

### DIFF
--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -201,7 +201,7 @@ protected:
         LED_On(LED_RGB);
         led_state.restore();
 
-        WLAN_LISTEN_ON_FAILED_CONNECT = started && on_stop_listening();
+        WLAN_LISTEN_ON_FAILED_CONNECT = on_stop_listening() && started;
 
         on_finalize_listening(WLAN_SMART_CONFIG_FINISHED);
 


### PR DESCRIPTION
when the wifi module was not active (and so made active in the listen method) the `on_stop_listning()` method was not called due to short-circuit evaluation when `started` was false.  Swapping the order fixes this.  Fixes #971.

---

Doneness:

- [x] Contributor has signed CLA
- [ ] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)