### PR TITLE
Revert EEPROM capacity to 2048 instead of 2047 Photon / 128 Core

### DIFF
--- a/services/inc/eeprom_emulation.h
+++ b/services/inc/eeprom_emulation.h
@@ -228,7 +228,7 @@ public:
     // The actual capacity is set to 50% of the records that fit in the smallest page
     constexpr size_t capacity()
     {
-        return (SmallestPageSize - sizeof(PageHeader)) / sizeof(Record) / 2;
+        return SmallestPageSize / sizeof(Record) / 2;
     }
 
     // Check if the old page needs to be erased

--- a/user/tests/unit/eeprom_emulation.cpp
+++ b/user/tests/unit/eeprom_emulation.cpp
@@ -528,7 +528,7 @@ TEST_CASE("Capacity", "[eeprom]")
     TestEEPROM eeprom;
     // Each record is 4 bytes, and some space is used by the page header
     // Capacity if 50% of the theoretical max
-    size_t expectedByteCapacity = PageSize2 / 4 / 2 - 1;
+    size_t expectedByteCapacity = PageSize2 / 4 / 2;
 
     REQUIRE(eeprom.capacity() == expectedByteCapacity);
 }

--- a/user/tests/wiring/no_fixture/eeprom.cpp
+++ b/user/tests/wiring/no_fixture/eeprom.cpp
@@ -32,6 +32,15 @@ struct EEPROMCustomObject{
   char sValue[10];
 };
 
+test(EEPROM_Capacity) {
+#if (PLATFORM_ID == 0) // Core
+  uint16_t expectedCapacity = 128;
+#else // Photon/P1/Electron
+  uint16_t expectedCapacity = 2048;
+#endif
+  assertEqual(EEPROM.length(), expectedCapacity);
+}
+
 test(EEPROM_ReadWriteSucceedsForAllAddressWithInRange) {
     int EEPROM_SIZE = EEPROM.length();
     uint16_t address = 0;


### PR DESCRIPTION
The EEPROM rewrite in 0.5.0 inadvertently reduced the EEPROM capacity from 2048 to 2047.

This restores the capacity and adds an explicit on-device test for it.

---

Doneness:

- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
