### PR TITLE
Fire Hazard, Wrong bitmask is provided for 4208

### DIFF
--- a/wiring/src/spark_wiring_power.cpp
+++ b/wiring/src/spark_wiring_power.cpp
@@ -629,7 +629,7 @@ bool PMIC::setChargeVoltage(uint16_t voltage) {
         break;
 
         case 4208:
-        writeRegister(CHARGE_VOLTAGE_CONTROL_REGISTER, (mask | 0b11100000));
+        writeRegister(CHARGE_VOLTAGE_CONTROL_REGISTER, (mask | 0b10110000));
         break;
 
         default:


### PR DESCRIPTION
In the Power Management, there is a function for setting the cut off voltage which takes an integer and converts it to the appropriate bit mask.

When sending in 4.208 volts (the upper bound on the LiPo battery provided with spark kits) it sets the voltage to 4.4 volts. This has caused units on our test bench to fail, and could cause fires if using any other standard LiPo battery that doesn't have a limit circuit installed in the battery.

I am not sure how to complete all of the required steps to get this through your processes, but see this bug as a danger, and would appreciate any help in getting it implemented. Or if someone else can do the unit testing required to get it passed I would not mind them taking over the issue.

---

Doneness:

- [X] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
When passing in 4208, 4400 is actually set to the register.
4.2 is the uppper bound on the operating parameters for the battery that
is provided with the electron.
It would be nice if this function exposed a wider range of voltages,
however this change to perform the function as advertised needs to be
implmented more quickly as it is a fire hazard.