### PR TITLE
DAC and PWM resolution

### DIFF
--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -2204,8 +2204,8 @@ analogWrite(pin, value, frequency);
 `analogWrite()` takes two or three arguments:
 
 - `pin`: the number of the pin whose value you wish to set
-- `value`: the duty cycle: between 0 (always off) and 255 (always on).
-- `frequency`: the PWM frequency: between 1 Hz and 65535 Hz (default 500 Hz).
+- `value`: the duty cycle: between 0 (always off) and 255 (always on). *Since 0.6.0:* between 0 and 255 (default 8-bit resolution) or `2^(analogWriteResolution(pin)) - 1` in general.
+- `frequency`: the PWM frequency: between 1 Hz and 65535 Hz (default 500 Hz). *Since 0.6.0:* between 1 Hz and `analogWriteMaxFrequency(pin)`.
 
 **NOTE:** `pinMode(pin, OUTPUT);` is required before calling `analogWrite(pin, value);` or else the `pin` will not be initialized as a PWM output and set to the desired duty cycle.
 
@@ -2244,6 +2244,55 @@ The PWM frequency must be the same for pins in the same timer group.
 - On the Electron, the timer groups are D0/D1/C4/C5, D2/D3/A4/A5/B2/B3, WKP, RX/TX, B0/B1.
 
 **NOTE:** When used with PWM capable pins, the `analogWrite()` function sets up these pins as PWM only.  {{#unless core}}This function operates differently when used with the [`Analog Output (DAC)`](#analog-output-dac-) pins.{{/unless}}
+
+{{#unless core}}
+### analogWriteResolution() (PWM and DAC)
+{{/unless}}
+{{#if core}}
+### analogWriteResolution() (PWM)
+{{/if}}
+
+*Since 0.6.0.*
+
+Sets or retrieves the resolution of `analogWrite()` function of a particular pin.
+
+`analogWriteResolution()` takes one or two arguments:
+
+- `pin`: the number of the pin whose resolution you wish to set or retrieve
+- `resolution`: (optional) resolution in bits. The value can range from 2 to 31 bits. If the resolution is not supported, it will not be applied. 
+
+`analogWriteResolution()` returns currently set resolution.
+
+```C++
+// EXAMPLE USAGE
+pinMode(D1, OUTPUT);     // sets the pin as output
+analogWriteResolution(D1, 12); // sets analogWrite resolution to 12 bits
+analogWrite(D1, 3000, 1000); // 3000/4095 = ~73% duty cycle at 1kHz
+```
+
+{{#unless core}}
+**NOTE:** DAC pins `DAC1` (`A6`) and `DAC2` (`A3`) support only either 8-bit or 12-bit (default) resolutions.
+{{/unless}}
+
+**NOTE:** The resolution also affects maximum frequency that can be used with `analogWrite()`. The maximum frequency allowed with current resolution can be checked by calling `analogWriteMaxFrequency()`.
+
+### analogWriteMaxFrequency() (PWM)
+
+*Since 0.6.0.*
+
+Returns maximum frequency that can be used with `analogWrite()` on this pin.
+
+`analogWriteMaxFrequency()` takes one argument:
+
+- `pin`: the number of the pin
+
+```C++
+// EXAMPLE USAGE
+pinMode(D1, OUTPUT);     // sets the pin as output
+analogWriteResolution(D1, 12); // sets analogWrite resolution to 12 bits
+int maxFreq = analogWriteMaxFrequency(D1);
+analogWrite(D1, 3000, maxFreq / 2); // 3000/4095 = ~73% duty cycle
+```
 
 {{#unless core}}
 ### Analog Output (DAC)

--- a/hal/inc/dac_hal.h
+++ b/hal/inc/dac_hal.h
@@ -45,6 +45,9 @@ extern "C" {
 void HAL_DAC_Write(pin_t pin, uint16_t value);
 uint8_t HAL_DAC_Is_Enabled(pin_t pin);
 uint8_t HAL_DAC_Enable(pin_t pin, uint8_t state);
+uint8_t HAL_DAC_Get_Resolution(pin_t pin);
+void HAL_DAC_Set_Resolution(pin_t pin, uint8_t resolution);
+void HAL_DAC_Enable_Buffer(pin_t pin, uint8_t state);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -74,6 +74,15 @@ DYNALIB_FN(22, hal_gpio, HAL_PWM_Write_With_Frequency, void(uint16_t, uint8_t, u
 DYNALIB_FN(23, hal_gpio, HAL_DAC_Is_Enabled, uint8_t(pin_t))
 DYNALIB_FN(24, hal_gpio, HAL_DAC_Enable, uint8_t(pin_t, uint8_t))
 
+DYNALIB_FN(25, hal_gpio, HAL_DAC_Get_Resolution, uint8_t(pin_t))
+DYNALIB_FN(26, hal_gpio, HAL_DAC_Set_Resolution, void(pin_t, uint8_t))
+DYNALIB_FN(27, hal_gpio, HAL_DAC_Enable_Buffer, void(pin_t pin, uint8_t state))
+DYNALIB_FN(28, hal_gpio, HAL_PWM_Get_Resolution, uint8_t(uint16_t))
+DYNALIB_FN(29, hal_gpio, HAL_PWM_Set_Resolution, void(uint16_t, uint8_t))
+DYNALIB_FN(30, hal_gpio, HAL_PWM_Write_Ext, void(uint16_t, uint16_t))
+DYNALIB_FN(31, hal_gpio, HAL_PWM_Write_With_Frequency_Ext, void(uint16_t, uint16_t, uint16_t))
+
+
 DYNALIB_END(hal_gpio)
 
 #endif	/* HAL_DYNALIB_GPIO_H */

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -79,8 +79,11 @@ DYNALIB_FN(26, hal_gpio, HAL_DAC_Set_Resolution, void(pin_t, uint8_t))
 DYNALIB_FN(27, hal_gpio, HAL_DAC_Enable_Buffer, void(pin_t pin, uint8_t state))
 DYNALIB_FN(28, hal_gpio, HAL_PWM_Get_Resolution, uint8_t(uint16_t))
 DYNALIB_FN(29, hal_gpio, HAL_PWM_Set_Resolution, void(uint16_t, uint8_t))
-DYNALIB_FN(30, hal_gpio, HAL_PWM_Write_Ext, void(uint16_t, uint16_t))
-DYNALIB_FN(31, hal_gpio, HAL_PWM_Write_With_Frequency_Ext, void(uint16_t, uint16_t, uint16_t))
+DYNALIB_FN(30, hal_gpio, HAL_PWM_Write_Ext, void(uint16_t, uint32_t))
+DYNALIB_FN(31, hal_gpio, HAL_PWM_Write_With_Frequency_Ext, void(uint16_t, uint32_t, uint32_t))
+DYNALIB_FN(32, hal_gpio, HAL_PWM_Get_Frequency_Ext, uint32_t(uint16_t))
+DYNALIB_FN(33, hal_gpio, HAL_PWM_Get_AnalogValue_Ext, uint32_t(uint16_t))
+DYNALIB_FN(34, hal_gpio, HAL_PWM_Get_Max_Frequency, uint32_t(uint16_t))
 
 
 DYNALIB_END(hal_gpio)

--- a/hal/inc/pwm_hal.h
+++ b/hal/inc/pwm_hal.h
@@ -52,11 +52,15 @@ extern "C" {
 
 void HAL_PWM_Write(uint16_t pin, uint8_t value);
 void HAL_PWM_Write_With_Frequency(uint16_t pin, uint8_t value, uint16_t pwm_frequency);
-void HAL_PWM_Write_Ext(uint16_t pin, uint16_t value);
-void HAL_PWM_Write_With_Frequency_Ext(uint16_t pin, uint16_t value, uint16_t pwm_frequency);
+void HAL_PWM_Write_Ext(uint16_t pin, uint32_t value);
+void HAL_PWM_Write_With_Frequency_Ext(uint16_t pin, uint32_t value, uint32_t pwm_frequency);
 uint16_t HAL_PWM_Get_Frequency(uint16_t pin);
 uint16_t HAL_PWM_Get_AnalogValue(uint16_t pin);
+uint32_t HAL_PWM_Get_Frequency_Ext(uint16_t pin);
+uint32_t HAL_PWM_Get_AnalogValue_Ext(uint16_t pin);
+uint32_t HAL_PWM_Get_Max_Frequency(uint16_t pin);
 void HAL_PWM_UpdateDutyCycle(uint16_t pin, uint16_t value);
+void HAL_PWM_UpdateDutyCycle_Ext(uint16_t pin, uint32_t value);
 uint8_t HAL_PWM_Get_Resolution(uint16_t pin);
 void HAL_PWM_Set_Resolution(uint16_t pin, uint8_t resolution);
 

--- a/hal/inc/pwm_hal.h
+++ b/hal/inc/pwm_hal.h
@@ -52,9 +52,13 @@ extern "C" {
 
 void HAL_PWM_Write(uint16_t pin, uint8_t value);
 void HAL_PWM_Write_With_Frequency(uint16_t pin, uint8_t value, uint16_t pwm_frequency);
+void HAL_PWM_Write_Ext(uint16_t pin, uint16_t value);
+void HAL_PWM_Write_With_Frequency_Ext(uint16_t pin, uint16_t value, uint16_t pwm_frequency);
 uint16_t HAL_PWM_Get_Frequency(uint16_t pin);
 uint16_t HAL_PWM_Get_AnalogValue(uint16_t pin);
 void HAL_PWM_UpdateDutyCycle(uint16_t pin, uint16_t value);
+uint8_t HAL_PWM_Get_Resolution(uint16_t pin);
+void HAL_PWM_Set_Resolution(uint16_t pin, uint8_t resolution);
 
 #ifdef __cplusplus
 }

--- a/hal/src/stm32/pwm_hal.c
+++ b/hal/src/stm32/pwm_hal.c
@@ -24,6 +24,7 @@
  */
 
 /* Includes ------------------------------------------------------------------*/
+#include <stddef.h>
 #include "pwm_hal.h"
 #include "gpio_hal.h"
 #include "pinmap_impl.h"

--- a/hal/src/stm32f2xx/dac_hal.c
+++ b/hal/src/stm32f2xx/dac_hal.c
@@ -31,6 +31,10 @@
 #include <string.h>
 
 /* Private typedef -----------------------------------------------------------*/
+typedef struct dac_state_t {
+    uint8_t resolution;
+    uint8_t buffer;
+} dac_state_t;
 
 /* Private define ------------------------------------------------------------*/
 
@@ -38,8 +42,18 @@
 
 /* Private variables ---------------------------------------------------------*/
 
-uint8_t dacInitFirstTime = true;
+static uint8_t dacInitFirstTime = true;
 
+static dac_state_t DAC_State[2] = {
+    {
+        .resolution = DAC_Align_12b_R,
+        .buffer = 1
+    },
+    {
+        .resolution = DAC_Align_12b_R,
+        .buffer = 1
+    }
+};
 /* Extern variables ----------------------------------------------------------*/
 
 /* Private function prototypes -----------------------------------------------*/
@@ -60,9 +74,11 @@ static void HAL_DAC_Init()
     memset(&DAC_InitStructure, 0, sizeof DAC_InitStructure);
     DAC_InitStructure.DAC_Trigger = DAC_Trigger_None;
     DAC_InitStructure.DAC_WaveGeneration = DAC_WaveGeneration_None;
-    DAC_InitStructure.DAC_OutputBuffer = DAC_OutputBuffer_Enable;
 
+    DAC_InitStructure.DAC_OutputBuffer = DAC_State[0].buffer ? DAC_OutputBuffer_Enable : DAC_OutputBuffer_Disable;
     DAC_Init(DAC_Channel_1, &DAC_InitStructure);
+    
+    DAC_InitStructure.DAC_OutputBuffer = DAC_State[1].buffer ? DAC_OutputBuffer_Enable : DAC_OutputBuffer_Disable;
     DAC_Init(DAC_Channel_2, &DAC_InitStructure);
 }
 
@@ -89,13 +105,13 @@ void HAL_DAC_Write(pin_t pin, uint16_t value)
     if (PIN_MAP[pin].dac_channel == DAC_Channel_1)
     {
         /* Set the DAC Channel1 data */
-        DAC_SetChannel1Data(DAC_Align_12b_R, value);
+        DAC_SetChannel1Data(DAC_State[0].resolution, value);
 
     }
     else if (PIN_MAP[pin].dac_channel == DAC_Channel_2)
     {
         /* Set the DAC Channel2 data */
-        DAC_SetChannel2Data(DAC_Align_12b_R, value);
+        DAC_SetChannel2Data(DAC_State[1].resolution, value);
     }
 }
 
@@ -121,4 +137,62 @@ uint8_t HAL_DAC_Enable(pin_t pin, uint8_t state)
     }
 
     return 1;
+}
+
+uint8_t HAL_DAC_Get_Resolution(pin_t pin)
+{
+    STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
+
+    if (PIN_MAP[pin].dac_channel == DAC_Channel_1)
+    {
+        return DAC_State[0].resolution == DAC_Align_12b_R ? 12 : 8;
+    }
+    else if (PIN_MAP[pin].dac_channel == DAC_Channel_2)
+    {
+        return DAC_State[1].resolution == DAC_Align_12b_R ? 12 : 8;
+    }
+
+    return 0;
+}
+
+void HAL_DAC_Set_Resolution(pin_t pin, uint8_t resolution)
+{
+    STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
+
+    if (PIN_MAP[pin].dac_channel == DAC_Channel_1)
+    {
+        DAC_State[0].resolution = resolution <= 8 ? DAC_Align_8b_R : DAC_Align_12b_R;
+    }
+    else if (PIN_MAP[pin].dac_channel == DAC_Channel_2)
+    {
+        DAC_State[1].resolution = resolution <= 8 ? DAC_Align_8b_R : DAC_Align_12b_R;
+    }
+}
+
+void HAL_DAC_Enable_Buffer(pin_t pin, uint8_t state)
+{
+    STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
+
+    if (PIN_MAP[pin].dac_channel == DAC_Channel_1)
+    {
+        DAC_State[0].buffer = state;
+        if (!dacInitFirstTime)
+        {
+            if (state)
+                DAC->CR |= DAC_CR_BOFF1;
+            else
+                DAC->CR &= ~(DAC_CR_BOFF1);
+        }
+    }
+    else if (PIN_MAP[pin].dac_channel == DAC_Channel_2)
+    {
+        DAC_State[1].buffer = state;
+        if (!dacInitFirstTime)
+        {
+            if (state)
+                DAC->CR |= DAC_CR_BOFF2;
+            else
+                DAC->CR &= ~(DAC_CR_BOFF2);
+        }
+    }
 }

--- a/hal/src/template/dac_hal.cpp
+++ b/hal/src/template/dac_hal.cpp
@@ -41,3 +41,26 @@
 void HAL_DAC_Write(pin_t pin, uint16_t value)
 {
 }
+
+uint8_t HAL_DAC_Is_Enabled(pin_t pin)
+{
+    return 0;
+}
+
+uint8_t HAL_DAC_Enable(pin_t pin, uint8_t state)
+{
+    return 0;
+}
+
+uint8_t HAL_DAC_Get_Resolution(pin_t pin)
+{
+    return 0;
+}
+
+void HAL_DAC_Set_Resolution(pin_t pin, uint8_t resolution)
+{
+}
+
+void HAL_DAC_Enable_Buffer(pin_t pin, uint8_t state)
+{
+}

--- a/hal/src/template/pwm_hal.cpp
+++ b/hal/src/template/pwm_hal.cpp
@@ -43,7 +43,7 @@ uint16_t HAL_PWM_Get_AnalogValue(uint16_t pin)
     return 0;
 }
 
-void HAL_PWM_Write_Ext(uint16_t pin, uint32_t value);
+void HAL_PWM_Write_Ext(uint16_t pin, uint32_t value)
 {
 }
 

--- a/hal/src/template/pwm_hal.cpp
+++ b/hal/src/template/pwm_hal.cpp
@@ -43,6 +43,14 @@ uint16_t HAL_PWM_Get_AnalogValue(uint16_t pin)
     return 0;
 }
 
+void HAL_PWM_Write_Ext(uint16_t pin, uint32_t value);
+{
+}
+
+void HAL_PWM_Write_With_Frequency_Ext(uint16_t pin, uint32_t value, uint32_t pwm_frequency)
+{
+}
+
 uint32_t HAL_PWM_Get_Frequency_Ext(uint16_t pin)
 {
     return 0;

--- a/hal/src/template/pwm_hal.cpp
+++ b/hal/src/template/pwm_hal.cpp
@@ -42,3 +42,35 @@ uint16_t HAL_PWM_Get_AnalogValue(uint16_t pin)
 {
     return 0;
 }
+
+uint32_t HAL_PWM_Get_Frequency_Ext(uint16_t pin)
+{
+    return 0;
+}
+
+uint32_t HAL_PWM_Get_AnalogValue_Ext(uint16_t pin)
+{
+    return 0;
+}
+
+uint32_t HAL_PWM_Get_Max_Frequency(uint16_t pin)
+{
+    return 0;
+}
+
+void HAL_PWM_UpdateDutyCycle(uint16_t pin, uint16_t value)
+{
+}
+
+void HAL_PWM_UpdateDutyCycle_Ext(uint16_t pin, uint32_t value)
+{
+}
+
+uint8_t HAL_PWM_Get_Resolution(uint16_t pin)
+{
+    return 0;
+}
+
+void HAL_PWM_Set_Resolution(uint16_t pin, uint8_t resolution)
+{
+}

--- a/user/tests/wiring/adc_dac/application.cpp
+++ b/user/tests/wiring/adc_dac/application.cpp
@@ -1,4 +1,6 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
+SYSTEM_MODE(MANUAL);
+
 UNIT_TEST_APP();

--- a/user/tests/wiring/no_fixture/pwm.cpp
+++ b/user/tests/wiring/no_fixture/pwm.cpp
@@ -27,6 +27,7 @@
 #include "pwm_hal.h"
 #include "unit-test/unit-test.h"
 
+SYSTEM_MODE(MANUAL);
 
 uint8_t pwm_pins[] = {
 
@@ -44,7 +45,7 @@ test(PWM_NoAnalogWriteWhenPinModeIsNotSetToOutput) {
     pinMode(pin, INPUT);//pin set to INPUT mode
     analogWrite(pin, 50);
     // then
-    assertNotEqual(HAL_PWM_Get_AnalogValue(pin), 50);
+    assertNotEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 50);
     //To Do : Add test for remaining pins if required
 }
 
@@ -55,7 +56,7 @@ test(PWM_NoAnalogWriteWhenPinSelectedIsNotTimerChannel) {
     analogWrite(pin, 100);
     // then
     //analogWrite has a default PWM frequency of 500Hz
-    assertNotEqual(HAL_PWM_Get_Frequency(pin), TIM_PWM_FREQ);
+    assertNotEqual(HAL_PWM_Get_Frequency_Ext(pin), TIM_PWM_FREQ);
     //To Do : Add test for remaining pins if required
 }
 
@@ -65,7 +66,7 @@ test(PWM_NoAnalogWriteWhenPinSelectedIsOutOfRange) {
     pinMode(pin, OUTPUT);//21 is not a user pin
     analogWrite(pin, 100);
     // then
-    assertNotEqual(HAL_PWM_Get_AnalogValue(pin), 100);
+    assertNotEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 100);
     //To Do : Add test for remaining pins if required
 }
 
@@ -81,10 +82,36 @@ test(PWM_AnalogWriteOnPinResultsInCorrectFrequency) {
     for_all_pwm_pins([](uint16_t pin) {
 	// when
     pinMode(pin, OUTPUT);
+
+    // 8-bit resolution
+    analogWriteResolution(pin, 8);
+    assertEqual(analogWriteResolution(pin), 8);
     analogWrite(pin, 150);
     // then
     //analogWrite has a default PWM frequency of 500Hz
-    assertEqual(HAL_PWM_Get_Frequency(pin), TIM_PWM_FREQ);
+    assertEqual(HAL_PWM_Get_Frequency_Ext(pin), TIM_PWM_FREQ);
+
+    // 4-bit resolution
+    analogWriteResolution(pin, 4);
+    assertEqual(analogWriteResolution(pin), 4);
+    analogWrite(pin, 9);
+    // then
+    assertEqual(HAL_PWM_Get_Frequency_Ext(pin), TIM_PWM_FREQ);
+
+    // 12-bit resolution
+    analogWriteResolution(pin, 12);
+    assertEqual(analogWriteResolution(pin), 12);
+    analogWrite(pin, 1900);
+    // then
+    assertEqual(HAL_PWM_Get_Frequency_Ext(pin), TIM_PWM_FREQ);
+
+    // 15-bit resolution
+    analogWriteResolution(pin, 15);
+    assertEqual(analogWriteResolution(pin), 15);
+    analogWrite(pin, 15900);
+    // then
+    assertEqual(HAL_PWM_Get_Frequency_Ext(pin), TIM_PWM_FREQ);
+
     pinMode(pin, INPUT);
     });
 }
@@ -93,9 +120,35 @@ test(PWM_AnalogWriteOnPinResultsInCorrectAnalogValue) {
 	for_all_pwm_pins([](uint16_t pin) {
 	// when
 	pinMode(pin, OUTPUT);
+
+    // 8-bit resolution
+    analogWriteResolution(pin, 8);
+    assertEqual(analogWriteResolution(pin), 8);
 	analogWrite(pin, 200);
 	// then
-	assertEqual(HAL_PWM_Get_AnalogValue(pin), 200);
+	assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 200);
+
+    // 4-bit resolution
+    analogWriteResolution(pin, 4);
+    assertEqual(analogWriteResolution(pin), 4);
+    analogWrite(pin, 9);
+    // then
+    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 9);
+
+    // 12-bit resolution
+    analogWriteResolution(pin, 12);
+    assertEqual(analogWriteResolution(pin), 12);
+    analogWrite(pin, 1900);
+    // then
+    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 1900);
+
+    // 15-bit resolution
+    analogWriteResolution(pin, 15);
+    assertEqual(analogWriteResolution(pin), 15);
+    analogWrite(pin, 15900);
+    // then
+    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 15900);
+
 	pinMode(pin, INPUT);
 	});
 }
@@ -105,9 +158,39 @@ test(PWM_AnalogWriteWithFrequencyOnPinResultsInCorrectFrequency) {
 
 	// when
     pinMode(pin, OUTPUT);
-    analogWrite(pin, 150, 10000);
+
+    // 8-bit resolution
+    analogWriteResolution(pin, 8);
+    assertEqual(analogWriteResolution(pin), 8);
+    analogWrite(pin, 150, analogWriteMaxFrequency(pin) / 2);
     // then
-    assertEqual(HAL_PWM_Get_Frequency(pin), 10000);
+    // 1 digit error is acceptible due to rounding at higher frequencies
+    assertLessOrEqual((int32_t)HAL_PWM_Get_Frequency_Ext(pin) - analogWriteMaxFrequency(pin) / 2, 1);
+
+    // 4-bit resolution
+    analogWriteResolution(pin, 4);
+    assertEqual(analogWriteResolution(pin), 4);
+    analogWrite(pin, 9, analogWriteMaxFrequency(pin) / 2);
+    // then
+    // 1 digit error is acceptible due to rounding at higher frequencies
+    assertLessOrEqual((int32_t)HAL_PWM_Get_Frequency_Ext(pin) - analogWriteMaxFrequency(pin) / 2, 1);
+
+    // 12-bit resolution
+    analogWriteResolution(pin, 12);
+    assertEqual(analogWriteResolution(pin), 12);
+    analogWrite(pin, 1900, analogWriteMaxFrequency(pin) / 2);
+    // then
+    // 1 digit error is acceptible due to rounding at higher frequencies
+    assertLessOrEqual((int32_t)HAL_PWM_Get_Frequency_Ext(pin) - analogWriteMaxFrequency(pin) / 2, 1);
+
+    // 15-bit resolution
+    analogWriteResolution(pin, 15);
+    assertEqual(analogWriteResolution(pin), 15);
+    analogWrite(pin, 15900, analogWriteMaxFrequency(pin) / 2);
+    // then
+    // 1 digit error is acceptible due to rounding at higher frequencies
+    assertLessOrEqual((int32_t)HAL_PWM_Get_Frequency_Ext(pin) - analogWriteMaxFrequency(pin) / 2, 1);
+
 	pinMode(pin, INPUT);
 	});
 }
@@ -116,9 +199,35 @@ test(PWM_AnalogWriteWithFrequencyOnPinResultsInCorrectAnalogValue) {
 	for_all_pwm_pins([](uint16_t pin) {
 	// when
     pinMode(pin, OUTPUT);
-    analogWrite(pin, 200, 10000);
+
+    // 8-bit resolution
+    analogWriteResolution(pin, 8);
+    assertEqual(analogWriteResolution(pin), 8);
+    analogWrite(pin, 200, analogWriteMaxFrequency(pin) / 2);
     // then
-    assertEqual(HAL_PWM_Get_AnalogValue(pin), 200);
+    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 200);
+
+    // 4-bit resolution
+    analogWriteResolution(pin, 4);
+    assertEqual(analogWriteResolution(pin), 4);
+    analogWrite(pin, 9, analogWriteMaxFrequency(pin) / 2);
+    // then
+    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 9);
+
+    // 12-bit resolution
+    analogWriteResolution(pin, 12);
+    assertEqual(analogWriteResolution(pin), 12);
+    analogWrite(pin, 1900, analogWriteMaxFrequency(pin) / 2);
+    // then
+    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 1900);
+
+    // 15-bit resolution
+    analogWriteResolution(pin, 15);
+    assertEqual(analogWriteResolution(pin), 15);
+    analogWrite(pin, 15900, analogWriteMaxFrequency(pin) / 2);
+    // then
+    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 15900);
+
     pinMode(pin, INPUT);
 	});
 }
@@ -130,6 +239,9 @@ test(PWM_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // when
     pinMode(pin, OUTPUT);
 
+    // 8-bit resolution
+    analogWriteResolution(pin, 8);
+    assertEqual(analogWriteResolution(pin), 8);
     uint32_t avgPulseHigh = 0;
     for(int i=0;i<100;i++) {
         analogWrite(pin, 25); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
@@ -142,6 +254,55 @@ test(PWM_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // avgPulseHigh should equal 200 +/- 50
     assertMoreOrEqual(avgPulseHigh, 150);
     assertLessOrEqual(avgPulseHigh, 250);
+
+    // 4-bit resolution
+    analogWriteResolution(pin, 4);
+    assertEqual(analogWriteResolution(pin), 4);
+    avgPulseHigh = 0;
+    for(int i=0;i<100;i++) {
+        analogWrite(pin, 2); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 100;
+    analogWrite(pin, 0);
+
+    // then
+    // avgPulseHigh should equal 200 +/- 80
+    assertMoreOrEqual(avgPulseHigh, 120);
+    assertLessOrEqual(avgPulseHigh, 280);
+
+    // 12-bit resolution
+    analogWriteResolution(pin, 12);
+    assertEqual(analogWriteResolution(pin), 12);
+    avgPulseHigh = 0;
+    for(int i=0;i<100;i++) {
+        analogWrite(pin, 409); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 100;
+    analogWrite(pin, 0);
+
+    // then
+    // avgPulseHigh should equal 200 +/- 50
+    assertMoreOrEqual(avgPulseHigh, 150);
+    assertLessOrEqual(avgPulseHigh, 250);
+
+    // 15-bit resolution
+    analogWriteResolution(pin, 15);
+    assertEqual(analogWriteResolution(pin), 15);
+    avgPulseHigh = 0;
+    for(int i=0;i<100;i++) {
+        analogWrite(pin, 3277); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 100;
+    analogWrite(pin, 0);
+
+    // then
+    // avgPulseHigh should equal 200 +/- 50
+    assertMoreOrEqual(avgPulseHigh, 150);
+    assertLessOrEqual(avgPulseHigh, 250);
+
     pinMode(pin, INPUT);
 	});
 }
@@ -151,18 +312,64 @@ test(PWM_LowFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	// when
     pinMode(pin, OUTPUT);
 
+    // 8-bit resolution
+    analogWriteResolution(pin, 8);
+    assertEqual(analogWriteResolution(pin), 8);
     uint32_t avgPulseHigh = 0;
     for(int i=0;i<5;i++) {
         analogWrite(pin, 25, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
     avgPulseHigh /= 5;
-    analogWrite(pin, 0, 10);
-    pinMode(pin, INPUT);
     // then
     // avgPulseHigh should equal 10000 +/- 50
     assertMoreOrEqual(avgPulseHigh, 9050);
     assertLessOrEqual(avgPulseHigh, 10050);
+
+    // 4-bit resolution
+    analogWriteResolution(pin, 4);
+    assertEqual(analogWriteResolution(pin), 4);
+    avgPulseHigh = 0;
+    for(int i=0;i<5;i++) {
+        analogWrite(pin, 2, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 5;
+    // then
+    // avgPulseHigh should equal 10000 +/- 4000
+    assertMoreOrEqual(avgPulseHigh, 6000);
+    assertLessOrEqual(avgPulseHigh, 14000);
+
+    // 12-bit resolution
+    analogWriteResolution(pin, 12);
+    assertEqual(analogWriteResolution(pin), 12);
+    avgPulseHigh = 0;
+    for(int i=0;i<5;i++) {
+        analogWrite(pin, 409, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 5;
+    // then
+    // avgPulseHigh should equal 10000 +/- 50
+    assertMoreOrEqual(avgPulseHigh, 9050);
+    assertLessOrEqual(avgPulseHigh, 10050);
+
+    // 15-bit resolution
+    analogWriteResolution(pin, 15);
+    assertEqual(analogWriteResolution(pin), 15);
+    avgPulseHigh = 0;
+    for(int i=0;i<5;i++) {
+        analogWrite(pin, 3277, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 5;
+    // then
+    // avgPulseHigh should equal 10000 +/- 50
+    assertMoreOrEqual(avgPulseHigh, 9050);
+    assertLessOrEqual(avgPulseHigh, 10050);
+
+    analogWrite(pin, 0, 10);
+    pinMode(pin, INPUT);
 	});
 }
 
@@ -172,18 +379,63 @@ test(PWM_HighFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	// when
     pinMode(pin, OUTPUT);
 
+    // 8-bit resolution
+    analogWriteResolution(pin, 8);
+    assertEqual(analogWriteResolution(pin), 8);
     uint32_t avgPulseHigh = 0;
     for(int i=0;i<1000;i++) {
-        analogWrite(pin, 25, 10000); // 10% Duty Cycle at 10Hz = 10us HIGH, 90us LOW.
+        analogWrite(pin, 25, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
     avgPulseHigh /= 1000;
-    analogWrite(pin, 0, 10);
-    pinMode(pin, INPUT);
     // then
     // avgPulseHigh should equal 10 +/- 5
     assertMoreOrEqual(avgPulseHigh, 5);
     assertLessOrEqual(avgPulseHigh, 15);
+
+    // 4-bit resolution
+    analogWriteResolution(pin, 4);
+    assertEqual(analogWriteResolution(pin), 4);
+    avgPulseHigh = 0;
+    for(int i=0;i<1000;i++) {
+        analogWrite(pin, 2, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 1000;
+    // then
+    // avgPulseHigh should equal 10 +/- 5
+    assertMoreOrEqual(avgPulseHigh, 5);
+    assertLessOrEqual(avgPulseHigh, 15);
+
+    // 12-bit resolution
+    analogWriteResolution(pin, 12);
+    assertEqual(analogWriteResolution(pin), 12);
+    avgPulseHigh = 0;
+    for(int i=0;i<1000;i++) {
+        analogWrite(pin, 409, 1000); // 10% Duty Cycle at 1kHz = 100us HIGH, 900us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 1000;
+    // then
+    // avgPulseHigh should equal 100 +/- 20
+    assertMoreOrEqual(avgPulseHigh, 80);
+    assertLessOrEqual(avgPulseHigh, 120);
+
+    // 15-bit resolution
+    analogWriteResolution(pin, 15);
+    assertEqual(analogWriteResolution(pin), 15);
+    avgPulseHigh = 0;
+    for(int i=0;i<1000;i++) {
+        analogWrite(pin, 3277, 1000); // 10% Duty Cycle at 1kHz = 100us HIGH, 900us LOW.
+        avgPulseHigh += pulseIn(pin, HIGH);
+    }
+    avgPulseHigh /= 1000;
+    // then
+    // avgPulseHigh should equal 100 +/- 20
+    assertMoreOrEqual(avgPulseHigh, 80);
+    assertLessOrEqual(avgPulseHigh, 120);
+
+    analogWrite(pin, 0, 1000);
+    pinMode(pin, INPUT);
 	});
 }
-

--- a/user/tests/wiring/no_fixture/pwm.cpp
+++ b/user/tests/wiring/no_fixture/pwm.cpp
@@ -40,7 +40,7 @@ uint8_t pwm_pins[] = {
 
 static pin_t pin = pwm_pins[0];
 
-test(PWM_NoAnalogWriteWhenPinModeIsNotSetToOutput) {
+test(PWM_01_NoAnalogWriteWhenPinModeIsNotSetToOutput) {
     // when
     pinMode(pin, INPUT);//pin set to INPUT mode
     analogWrite(pin, 50);
@@ -49,7 +49,7 @@ test(PWM_NoAnalogWriteWhenPinModeIsNotSetToOutput) {
     //To Do : Add test for remaining pins if required
 }
 
-test(PWM_NoAnalogWriteWhenPinSelectedIsNotTimerChannel) {
+test(PWM_02_NoAnalogWriteWhenPinSelectedIsNotTimerChannel) {
     pin_t pin = D5;//pin under test
     // when
     pinMode(pin, OUTPUT);//D5 is not a Timer channel
@@ -60,14 +60,14 @@ test(PWM_NoAnalogWriteWhenPinSelectedIsNotTimerChannel) {
     //To Do : Add test for remaining pins if required
 }
 
-test(PWM_NoAnalogWriteWhenPinSelectedIsOutOfRange) {
-    pin_t pin = 51;//pin under test (not a valid user pin)
+test(PWM_03_NoAnalogWriteWhenPinSelectedIsOutOfRange) {
+    pin_t pin = 51; // pin under test (not a valid user pin)
     // when
-    pinMode(pin, OUTPUT);//21 is not a user pin
-    analogWrite(pin, 100);
-    // then
-    assertNotEqual(HAL_PWM_Get_AnalogValue_Ext(pin), 100);
-    //To Do : Add test for remaining pins if required
+    pinMode(pin, OUTPUT); // will simply return
+    analogWrite(pin, 100); // will simply return
+    // when pinAvailable is checked with a bad pin,
+    // then it returns 0
+    assertEqual(pinAvailable(pin), 0);
 }
 
 template <typename F> void for_all_pwm_pins(F callback)
@@ -78,7 +78,7 @@ template <typename F> void for_all_pwm_pins(F callback)
 	}
 }
 
-test(PWM_AnalogWriteOnPinResultsInCorrectFrequency) {
+test(PWM_04_AnalogWriteOnPinResultsInCorrectFrequency) {
     for_all_pwm_pins([](uint16_t pin) {
 	// when
     pinMode(pin, OUTPUT);
@@ -116,7 +116,7 @@ test(PWM_AnalogWriteOnPinResultsInCorrectFrequency) {
     });
 }
 
-test(PWM_AnalogWriteOnPinResultsInCorrectAnalogValue) {
+test(PWM_05_AnalogWriteOnPinResultsInCorrectAnalogValue) {
 	for_all_pwm_pins([](uint16_t pin) {
 	// when
 	pinMode(pin, OUTPUT);
@@ -153,7 +153,7 @@ test(PWM_AnalogWriteOnPinResultsInCorrectAnalogValue) {
 	});
 }
 
-test(PWM_AnalogWriteWithFrequencyOnPinResultsInCorrectFrequency) {
+test(PWM_06_AnalogWriteWithFrequencyOnPinResultsInCorrectFrequency) {
 	for_all_pwm_pins([](uint16_t pin) {
 
 	// when
@@ -195,7 +195,7 @@ test(PWM_AnalogWriteWithFrequencyOnPinResultsInCorrectFrequency) {
 	});
 }
 
-test(PWM_AnalogWriteWithFrequencyOnPinResultsInCorrectAnalogValue) {
+test(PWM_07_AnalogWriteWithFrequencyOnPinResultsInCorrectAnalogValue) {
 	for_all_pwm_pins([](uint16_t pin) {
 	// when
     pinMode(pin, OUTPUT);
@@ -232,8 +232,7 @@ test(PWM_AnalogWriteWithFrequencyOnPinResultsInCorrectAnalogValue) {
 	});
 }
 
-
-test(PWM_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
+test(PWM_08_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	for_all_pwm_pins([](uint16_t pin) {
 
     // when
@@ -307,7 +306,7 @@ test(PWM_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	});
 }
 
-test(PWM_LowFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
+test(PWM_09_LowFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	for_all_pwm_pins([](uint16_t pin) {
 	// when
     pinMode(pin, OUTPUT);
@@ -373,7 +372,7 @@ test(PWM_LowFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	});
 }
 
-test(PWM_HighFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
+test(PWM_10_HighFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	for_all_pwm_pins([](uint16_t pin) {
 
 	// when

--- a/user/tests/wiring/no_fixture_long_running/pwm.cpp
+++ b/user/tests/wiring/no_fixture_long_running/pwm.cpp
@@ -1,0 +1,134 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "pwm_hal.h"
+#include <cmath>
+
+#ifndef ABS
+#define ABS(x) (x < 0 ? -x : x)
+#endif // ABS
+
+static const uint32_t maxPulseSamples = 100;
+static const uint32_t minimumFrequency = 100;
+ 
+uint8_t pwm_pins[] = {
+
+#if defined(STM32F2XX)
+        D0, D1, D2, D3, A4, A5, WKP, RX, TX
+#else
+        A0, A1, A4, A5, A6, A7, D0, D1
+#endif
+};
+
+static pin_t pin = pwm_pins[0];
+
+template <typename F> void for_all_pwm_pins(F callback)
+{
+    for (uint8_t i = 0; i<arraySize(pwm_pins); i++)
+    {
+        callback(pwm_pins[i]);
+    }
+}
+
+test(PWM_CompherensiveResolutionFrequency) {
+    for_all_pwm_pins([&](uint16_t pin) {
+        // when
+        pinMode(pin, OUTPUT);
+
+        uint8_t resolution = 2;
+
+        for (resolution = 2; ; resolution++) {
+            // Set resolution
+            analogWriteResolution(pin, resolution);
+            if (resolution <= 15) {
+                // All PWM pins should support resolution of up to 15 bits
+                assertEqual(resolution, analogWriteResolution(pin));
+            } else {
+                // Some PWM pins (which utilize 32-bit timers) may support higher resolution
+                if (resolution != analogWriteResolution(pin)) {
+                    break;
+                } else {
+                    assertEqual(resolution, analogWriteResolution(pin));
+                }
+            }
+
+            uint32_t maxVal = (1 << resolution) - 1;
+
+            uint32_t freq = 1;
+            uint32_t freqStep = 9;
+
+            // Test all frequencies up to analogWriteMaxFrequency() with logarithmic step
+            for (freq = minimumFrequency; freq <= analogWriteMaxFrequency(pin);) {
+                float fp = floor(log10((float)freq));
+                if (fp < 1)
+                    fp = 1;
+                freqStep = ((uint32_t)pow(10.0, fp + 1.0)) / 3;
+                if (freqStep < 33)
+                    freqStep = 33;
+
+                // Test all analog values with logarithmic step
+                uint32_t valueStep = 1;
+                float vp = floor(log2((float)maxVal));
+                if (vp < 2.0)
+                    vp = 2.0;
+                valueStep = ((uint32_t)pow(2.0, vp - 2.0)) / 3;
+                if (valueStep < 1)
+                    valueStep = 1;
+                for (uint32_t value = 1; value < maxVal;) {
+                    //Serial.printf("val=%d\r\n", value);
+                    analogWrite(pin, value, freq);
+                    uint32_t period = 1000 / freq;
+                    delay(period ? period : 1);
+
+                    // Check if the write resulted in correct analog value
+                    assertEqual(HAL_PWM_Get_AnalogValue_Ext(pin), value);
+
+                    float duty = (float)value/(float)maxVal;
+                    float refPulseWidthUs = duty * (1000000.0 / (double)freq);
+                    // pulseIn cannot measure pulses shorter than 10us reliably, limit to 20us
+                    if (refPulseWidthUs < 20.0) {
+                        // Skip
+                    } else if ((1.0 - duty) * refPulseWidthUs < 20.0) {
+                        // pulseIn will not be able to accurately measure high pulse that is followed by <20us low pulse
+                    } else {
+                        uint32_t pulseAcc = 0;
+                        uint32_t pulseSamples = freq < 1000 ? maxPulseSamples / 10 : maxPulseSamples;
+                        for (uint32_t i = 0; i < pulseSamples; i++) {
+                            ATOMIC_BLOCK() {
+                                pulseAcc += pulseIn(pin, HIGH);
+                            }
+                            // 0 and maxVal should result in a timeout
+                            if (value == 0 || value == maxVal) {
+                                assertEqual(pulseAcc, 0);
+                                assertEqual(digitalRead(pin), 0);
+                                break;
+                            }
+                        }
+                        double avgPulse = (double)pulseAcc / pulseSamples;
+                        double err = ABS(avgPulse - refPulseWidthUs);
+
+                        float errPulseWidth = 0.05 * refPulseWidthUs;
+                        // Pulse width should be witin 5% error margin
+                        assertLessOrEqual(err, errPulseWidth);
+                    }
+
+                    // Clamp to maxVal
+                    if (value < maxVal && (value + valueStep) > maxVal)
+                        value = maxVal;
+                    else
+                        value += valueStep;
+                }
+
+                // Clamp to analogWriteMaxFrequency(pin)
+                if (freq < analogWriteMaxFrequency(pin) && (freq + freqStep) > analogWriteMaxFrequency(pin))
+                    freq = analogWriteMaxFrequency(pin);
+                else if (freq < analogWriteMaxFrequency(pin))
+                    freq += freqStep;
+                else
+                    break;
+            }
+        }
+
+        // At least 15-bit maximum resolution
+        assertMoreOrEqual(resolution, 15);
+    });
+}

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -91,5 +91,6 @@ void analogWrite(pin_t pin, uint32_t value, uint32_t pwm_frequency);
 uint8_t analogWriteResolution(pin_t pin, uint8_t value);
 uint8_t analogWriteResolution(pin_t pin);
 uint32_t analogWriteMaxFrequency(pin_t pin);
+void setDACBufferred(pin_t pin, uint8_t state);
 
 #endif /* SPARK_WIRING_H_ */

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -86,9 +86,10 @@ uint32_t pulseIn(pin_t pin, uint16_t value);
 }
 #endif
 
-void analogWrite(uint16_t pin, uint16_t value);
-void analogWrite(uint16_t pin, uint16_t value, uint16_t pwm_frequency);
-uint8_t analogWriteResolution(uint16_t pin, uint8_t value);
+void analogWrite(pin_t pin, uint32_t value);
+void analogWrite(pin_t pin, uint32_t value, uint32_t pwm_frequency);
+uint8_t analogWriteResolution(pin_t pin, uint8_t value);
 uint8_t analogWriteResolution(pin_t pin);
+uint32_t analogWriteMaxFrequency(pin_t pin);
 
 #endif /* SPARK_WIRING_H_ */

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -88,5 +88,7 @@ uint32_t pulseIn(pin_t pin, uint16_t value);
 
 void analogWrite(uint16_t pin, uint16_t value);
 void analogWrite(uint16_t pin, uint16_t value, uint16_t pwm_frequency);
+uint8_t analogWriteResolution(uint16_t pin, uint8_t value);
+uint8_t analogWriteResolution(pin_t pin);
 
 #endif /* SPARK_WIRING_H_ */

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -178,32 +178,11 @@ int32_t analogRead(pin_t pin)
   return HAL_ADC_Read(pin);
 }
 
-int32_t analogReadSamples(uint16_t pin, void* sampleBuffer, uint32_t size)
-{
-  // Allow people to use 0-7 to define analog pins by checking to see if the values are too low.
-  if(pin < FIRST_ANALOG_PIN)
-  {
-    pin = pin + FIRST_ANALOG_PIN;
-  }
-
-  // Safety check
-  if( !pinAvailable(pin) ) {
-    return 0;
-  }
-
-  if(HAL_Validate_Pin_Function(pin, PF_ADC)!=PF_ADC)
-  {
-    return 0;
-  }
-
-  return HAL_ADC_Read_Samples(pin, sampleBuffer, size);
-}
-
 /*
  * @brief Should take an integer 0-255 and create a 500Hz PWM signal with a duty cycle from 0-100%.
  * On Photon, DAC1 and DAC2 act as true analog outputs(values: 0 to 4095) using onchip DAC peripheral
  */
-void analogWrite(pin_t pin, uint16_t value)
+void analogWrite(pin_t pin, uint32_t value)
 {
     // Safety check
     if (!pinAvailable(pin))
@@ -233,7 +212,7 @@ void analogWrite(pin_t pin, uint16_t value)
  * @brief Should take an integer 0-255 and create a PWM signal with a duty cycle from 0-100%
  * and frequency from 1 to 65535 Hz.
  */
-void analogWrite(pin_t pin, uint16_t value, uint16_t pwm_frequency)
+void analogWrite(pin_t pin, uint32_t value, uint32_t pwm_frequency)
 {
     // Safety check
     if (!pinAvailable(pin))
@@ -294,6 +273,11 @@ uint8_t analogWriteResolution(pin_t pin)
   }
 
   return 0;
+}
+
+uint32_t analogWriteMaxFrequency(pin_t pin)
+{
+  return HAL_PWM_Get_Max_Frequency(pin);
 }
 
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) {

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -278,6 +278,12 @@ uint8_t analogWriteResolution(pin_t pin)
 
 uint32_t analogWriteMaxFrequency(pin_t pin)
 {
+  // Safety check
+  if (!pinAvailable(pin))
+  {
+      return 0;
+  }
+
   return HAL_PWM_Get_Max_Frequency(pin);
 }
 

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -241,16 +241,17 @@ uint8_t analogWriteResolution(pin_t pin, uint8_t value)
       return 0;
   }
 
-  if (HAL_Validate_Pin_Function(pin, PF_TIMER) == PF_TIMER)
-  {
-    HAL_PWM_Set_Resolution(pin, value);
-    return HAL_PWM_Get_Resolution(pin);
-  }
-  else if (HAL_Validate_Pin_Function(pin, PF_TIMER) == PF_DAC)
+  if (HAL_Validate_Pin_Function(pin, PF_DAC) == PF_DAC)
   {
     HAL_DAC_Set_Resolution(pin, value);
     return HAL_DAC_Get_Resolution(pin);
   }
+  else if (HAL_Validate_Pin_Function(pin, PF_TIMER) == PF_TIMER)
+  {
+    HAL_PWM_Set_Resolution(pin, value);
+    return HAL_PWM_Get_Resolution(pin);
+  }
+  
 
   return 0;
 }
@@ -263,13 +264,13 @@ uint8_t analogWriteResolution(pin_t pin)
       return 0;
   }
 
-  if (HAL_Validate_Pin_Function(pin, PF_TIMER) == PF_TIMER)
-  {
-    return HAL_PWM_Get_Resolution(pin);
-  }
-  else if (HAL_Validate_Pin_Function(pin, PF_TIMER) == PF_DAC)
+  if (HAL_Validate_Pin_Function(pin, PF_DAC) == PF_DAC)
   {
     return HAL_DAC_Get_Resolution(pin);
+  }
+  else if (HAL_Validate_Pin_Function(pin, PF_TIMER) == PF_TIMER)
+  {
+    return HAL_PWM_Get_Resolution(pin);
   }
 
   return 0;
@@ -320,4 +321,8 @@ uint32_t pulseIn(pin_t pin, uint16_t value) {
     // NO SAFETY CHECKS!!! WILD WILD WEST!!!
 
     return HAL_Pulse_In(pin, value);
+}
+
+void setDACBufferred(pin_t pin, uint8_t state) {
+  HAL_DAC_Enable_Buffer(pin, state);
 }


### PR DESCRIPTION
Closes #841 

This PR implements configurable resolution for analogWrite (PWM and DAC).

New Wiring functions:
- `uint8_t analogWriteResolution(pin_t pin, uint8_t value);`
- `uint8_t analogWriteResolution(pin_t pin);`
- `uint32_t analogWriteMaxFrequency(pin_t pin);`

(see https://github.com/spark/firmware/blob/feature/dac-pwm-resolution/docs/reference/firmware.md for documentation)

DAC on Photon and Electron supports only 12-bit (default) or 8-bit resolution

Resolution also affects maximum frequency that can be used with `analogWrite()` on PWM pins:
## Supported resolutions/maximum frequency per PWM pin group on Photon/P1/Electron:
Resolution (bits) / Pins (max F)|TIM1: RX, TX|TIM2: RGBR, RGBG, RGBB|TIM3: D2, D3, A4, A5, P1S0, P1S1|TIM4: D0, D1, C4, C5|TIM5: A7
---|---|---|---|---|---|
2|30000000|30000000|15000000|15000000|15000000
3|15000000|15000000|7500000|7500000|7500000
4|7500000|7500000|3750000|3750000|3750000
5|3750000|3750000|1875000|1875000|1875000
6|1875000|1875000|937500|937500|937500
7|937500|937500|468750|468750|468750
8|468750|468750|234375|234375|234375
9|234375|234375|117187|117187|117187
10|117187|117187|58593|58593|58593
11|58593|58593|29296|29296|29296
12|29296|29296|14648|14648|14648
13|14648|14648|7324|7324|7324
14|7324|7324|3662|3662|3662
15|3662|3662|1831|1831|1831
16||1831|||915
17||915|||457
18||457|||228
19||228|||114
20||114|||57
21||57|||28
22||28|||14
23||14|||7
24||7|||3
25||3|||1
26||1|||

## Supported resolutions/maximum frequency per PWM pin group on Core:
Resolution (bits) / Pins (max F)|TIM2: A0, A1, RX, TX|TIM3: A4, A5, A6, A7|TIM4: D0, D1|
|---|---|---|---|
2|18000000|18000000|18000000|
3|9000000|9000000|9000000|
4|4500000|4500000|4500000|
5|2250000|2250000|2250000|
6|1125000|1125000|1125000|
7|562500|562500|562500|
8|281250|281250|281250|
9|140625|140625|140625|
10|70312|70312|70312|
11|35156|35156|35156|
12|17578|17578|17578|
13|8789|8789|8789|
14|4394|4394|4394|
15|2197|2197|2197|

Relevant tests:
- `wiring/no_fixture` `PWM*`
- `wiring/no_fixture_long_running` `PWM_CompherensiveResolutionFrequency`
- `wiring/adc_dac`

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)