### PR TITLE
USART configuration fixes

### DIFF
--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -2989,18 +2989,67 @@ _Since 0.5.0_
 
 As of 0.5.0 firmware, 28800 baud set on the Host will put the device in Listening Mode, where a YMODEM download can be started by additionally sending an `f` character.
 
-The configuration of the serial channel may also specify the number of data bits, stop bits and parity. The default is SERIAL_8N1 (8 data bits, no parity and 1 stop bit) and does not need to be specified to achieve this configuration.  To specify one of the following configurations, add one of these defines as the second parameter in the `begin()` function, e.g. `Serial.begin(9600, SERIAL_8E1);` for 8 data bits, even parity and 1 stop bit.
+The configuration of the serial channel may also specify the number of data bits, stop bits, parity, flow control and other settings. The default is SERIAL_8N1 (8 data bits, no parity and 1 stop bit) and does not need to be specified to achieve this configuration.  To specify one of the following configurations, add one of these defines as the second parameter in the `begin()` function, e.g. `Serial.begin(9600, SERIAL_8E1);` for 8 data bits, even parity and 1 stop bit.
 
-Serial configurations available:
+Pre-defined Serial configurations available:
 
-`SERIAL_8N1` - 8 data bits, no parity, 1 stop bit (default)
-`SERIAL_8N2` - 8 data bits, no parity, 2 stop bits
-`SERIAL_8E1` - 8 data bits, even parity, 1 stop bit
-`SERIAL_8E2` - 8 data bits, even parity, 2 stop bits
-`SERIAL_8O1` - 8 data bits, odd parity, 1 stop bit
-`SERIAL_8O2` - 8 data bits, odd parity, 2 stop bits
-`SERIAL_9N1` - 9 data bits, no parity, 1 stop bit
-`SERIAL_9N2` - 9 data bits, no parity, 2 stop bits
+- `SERIAL_8N1` - 8 data bits, no parity, 1 stop bit (default)
+- `SERIAL_8N2` - 8 data bits, no parity, 2 stop bits
+- `SERIAL_8E1` - 8 data bits, even parity, 1 stop bit
+- `SERIAL_8E2` - 8 data bits, even parity, 2 stop bits
+- `SERIAL_8O1` - 8 data bits, odd parity, 1 stop bit
+- `SERIAL_8O2` - 8 data bits, odd parity, 2 stop bits
+- `SERIAL_9N1` - 9 data bits, no parity, 1 stop bit
+- `SERIAL_9N2` - 9 data bits, no parity, 2 stop bits
+
+_Since 0.6.0_
+
+- `SERIAL_7O1` - 7 data bits, odd parity, 1 stop bit
+- `SERIAL_7O2` - 7 data bits, odd parity, 1 stop bit
+- `SERIAL_7E1` - 7 data bits, odd parity, 1 stop bit
+- `SERIAL_7E2` - 7 data bits, odd parity, 1 stop bit
+- `LIN_MASTER_13B` - 8 data bits, no parity, 1 stop bit, LIN Master mode with 13-bit break generation
+- `LIN_SLAVE_10B` - 8 data bits, no parity, 1 stop bit, LIN Slave mode with 10-bit break detection
+- `LIN_SLAVE_11B` - 8 data bits, no parity, 1 stop bit, LIN Slave mode with 11-bit break detection
+
+Alternatively, configuration may be constructed manually by ORing (`|`) the following configuration constants:
+
+Data bits:
+- `SERIAL_DATA_BITS_7` - 7 data bits
+- `SERIAL_DATA_BITS_8` - 8 data bits
+- `SERIAL_DATA_BITS_9` - 9 data bits
+
+Stop bits:
+- `SERIAL_STOP_BITS_1` - 1 stop bit
+- `SERIAL_STOP_BITS_2` - 2 stop bits
+- `SERIAL_STOP_BITS_0_5` - 0.5 stop bits
+- `SERIAL_STOP_BITS_1_5` - 1.5 stop bits
+
+Parity:
+- `SERIAL_PARITY_NO` - no parity
+- `SERIAL_PARITY_EVEN` - even parity
+- `SERIAL_PARITY_ODD` - odd parity
+
+{{#if core}}
+Hardware flow control, available only on Serial1 (`CTS` - `A0`, `RTS` - `A1`):
+{{/if}}
+{{#unless core}}
+Hardware flow control, available only on Serial2 (`CTS` - `A7`, `RTS` - `RGBR` ):
+{{/unless}}
+- `SERIAL_FLOW_CONTROL_NONE` - no flow control
+- `SERIAL_FLOW_CONTROL_RTS` - RTS flow control
+- `SERIAL_FLOW_CONTROL_CTS` - CTS flow control
+- `SERIAL_FLOW_CONTROL_RTS_CTS` - RTS/CTS flow control
+
+LIN configuration:
+- `LIN_MODE_MASTER` - LIN Master
+- `LIN_MODE_SLAVE` - LIN Slave
+- `LIN_BREAK_13B` - 13-bit break generation
+- `LIN_BREAK_10B` - 10-bit break detection
+- `LIN_BREAK_11B` - 10-bit break detection
+
+**NOTE:** LIN break detection may be enabled in both Master and Slave modes.
+
 
 ```C++
 // SYNTAX
@@ -3016,6 +3065,9 @@ Serial2.begin(speed);         // on Core via
                               // RGB-LED green(TX) and
                               // RGB-LED blue (RX) pins
 Serial2.begin(speed, config); //  "
+
+Serial1.begin(9600, SERIAL_9N1); // via TX/RX pins, 9600 9N1 mode
+Serial2.begin(9600, SERIAL_DATA_BITS_8 | SERIAL_STOP_BITS_1_5 | SERIAL_PARITY_EVEN); // via TX/RX pins, 9600 8E1.5
 {{#if electron}}
 
 Serial4.begin(speed);         // via C3(TX)/C2(RX) pins
@@ -3026,8 +3078,9 @@ Serial5.begin(speed, config); //  "
 {{/if}}
 ```
 
-`speed`: parameter that specifies the baud rate *(long)*
-`config`: parameter that specifies the number of data bits used, parity and stop bits *(long)*
+Parameters:
+- `speed`: parameter that specifies the baud rate *(long)*
+- `config`: parameter that specifies the number of data bits used, parity and stop bits *(long)*
 
 `begin()` does not return anything
 

--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -73,9 +73,10 @@ DYNALIB_FN(BASE_IDX + 12, hal_usart, USB_USART_Flush_Data, void(void))
 #define BASE_IDX2 (BASE_IDX+11)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, hal_usart,HAL_USART_BeginConfig,void(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr))
-DYNALIB_FN(BASE_IDX2 + 1, hal_usart,HAL_USART_Write_NineBitData, uint32_t(HAL_USART_Serial serial, uint16_t data))
-
+DYNALIB_FN(BASE_IDX2 + 0, hal_usart, HAL_USART_BeginConfig, void(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr))
+DYNALIB_FN(BASE_IDX2 + 1, hal_usart, HAL_USART_Write_NineBitData, uint32_t(HAL_USART_Serial serial, uint16_t data))
+DYNALIB_FN(BASE_IDX2 + 2, hal_usart, HAL_USART_Send_Break, void(HAL_USART_Serial, void*))
+DYNALIB_FN(BASE_IDX2 + 3, hal_usart, HAL_USART_Break_Detected, uint8_t(HAL_USART_Serial))
 
 DYNALIB_END(hal_usart)
 

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -40,32 +40,51 @@
 #endif
 #define SERIAL_BUFFER_SIZE      64
 
-// Available Serial Configurations for C
-#define SERIAL_8N1 (uint8_t)0b00000000
-#define SERIAL_8N2 (uint8_t)0b00000001
-#define SERIAL_8E1 (uint8_t)0b00000100
-#define SERIAL_8E2 (uint8_t)0b00000101
-#define SERIAL_8O1 (uint8_t)0b00001000
-#define SERIAL_8O2 (uint8_t)0b00001001
-#define SERIAL_9N1 (uint8_t)0b00010000
-#define SERIAL_9N2 (uint8_t)0b00010001
+// Pre-defined USART configurations
+#define SERIAL_7E1 (uint32_t)(SERIAL_DATA_BITS_7 | SERIAL_PARITY_EVEN | SERIAL_STOP_BITS_1)
+#define SERIAL_7E2 (uint32_t)(SERIAL_DATA_BITS_7 | SERIAL_PARITY_EVEN | SERIAL_STOP_BITS_2)
+#define SERIAL_7O1 (uint32_t)(SERIAL_DATA_BITS_7 | SERIAL_PARITY_ODD  | SERIAL_STOP_BITS_1)
+#define SERIAL_7O2 (uint32_t)(SERIAL_DATA_BITS_7 | SERIAL_PARITY_ODD  | SERIAL_STOP_BITS_2)
+#define SERIAL_8N1 (uint32_t)(SERIAL_DATA_BITS_8 | SERIAL_PARITY_NO   | SERIAL_STOP_BITS_1)
+#define SERIAL_8N2 (uint32_t)(SERIAL_DATA_BITS_8 | SERIAL_PARITY_NO   | SERIAL_STOP_BITS_2)
+#define SERIAL_8E1 (uint32_t)(SERIAL_DATA_BITS_8 | SERIAL_PARITY_EVEN | SERIAL_STOP_BITS_1)
+#define SERIAL_8E2 (uint32_t)(SERIAL_DATA_BITS_8 | SERIAL_PARITY_EVEN | SERIAL_STOP_BITS_2)
+#define SERIAL_8O1 (uint32_t)(SERIAL_DATA_BITS_8 | SERIAL_PARITY_ODD  | SERIAL_STOP_BITS_1)
+#define SERIAL_8O2 (uint32_t)(SERIAL_DATA_BITS_8 | SERIAL_PARITY_ODD  | SERIAL_STOP_BITS_2)
+#define SERIAL_9N1 (uint32_t)(SERIAL_DATA_BITS_9 | SERIAL_PARITY_NO   | SERIAL_STOP_BITS_1)
+#define SERIAL_9N2 (uint32_t)(SERIAL_DATA_BITS_9 | SERIAL_PARITY_NO   | SERIAL_STOP_BITS_2)
 
 // Serial Configuration masks
-#define SERIAL_VALID_CONFIG (uint8_t)0b00001100
-#define SERIAL_STOP_BITS (uint8_t)0b00000011
-#define SERIAL_PARITY_BITS (uint8_t)0b00001100
-#define SERIAL_NINE_BITS (uint8_t)0b00010000
-#define SERIAL_FLOW_CONTROL ((uint8_t)0b11000000)
+#define SERIAL_STOP_BITS      ((uint32_t)0b00000011)
+#define SERIAL_PARITY         ((uint32_t)0b00001100)
+#define SERIAL_DATA_BITS      ((uint32_t)0b00110000)
+#define SERIAL_FLOW_CONTROL   ((uint32_t)0b11000000)
+
+// Stop bits
+#define SERIAL_STOP_BITS_1    ((uint32_t)0b00000000)
+#define SERIAL_STOP_BITS_2    ((uint32_t)0b00000001)
+#define SERIAL_STOP_BITS_0_5  ((uint32_t)0b00000010)
+#define SERIAL_STOP_BITS_1_5  ((uint32_t)0b00000011)
+
+// Parity
+#define SERIAL_PARITY_NO      ((uint32_t)0b00000000)
+#define SERIAL_PARITY_EVEN    ((uint32_t)0b00000100)
+#define SERIAL_PARITY_ODD     ((uint32_t)0b00001000)
+
+// Data bits
+#define SERIAL_DATA_BITS_8    ((uint32_t)0b00000000)
+#define SERIAL_DATA_BITS_9    ((uint32_t)0b00010000)
+#define SERIAL_DATA_BITS_7    ((uint32_t)0b00100000)
 
 // Flow control settings
-#define SERIAL_FLOW_CONTROL_NONE ((uint8_t)0b00000000)
-#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b01000000)
-#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b10000000)
-#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b11000000)
+#define SERIAL_FLOW_CONTROL_NONE    ((uint32_t)0b00000000)
+#define SERIAL_FLOW_CONTROL_RTS     ((uint32_t)0b01000000)
+#define SERIAL_FLOW_CONTROL_CTS     ((uint32_t)0b10000000)
+#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint32_t)0b11000000)
 
 // LIN Configuration masks
-#define LIN_MODE ((uint32_t)0x0300)
-#define LIN_BREAK_BITS ((uint32_t)0x0C00)
+#define LIN_MODE        ((uint32_t)0x0300)
+#define LIN_BREAK_BITS  ((uint32_t)0x0C00)
 
 // LIN modes
 #define LIN_MODE_MASTER ((uint32_t)0x0100)
@@ -73,10 +92,10 @@
 
 // LIN break settings
 // Supported only in Master mode
-#define LIN_BREAK_13B ((uint32_t)0x0000)
+#define LIN_BREAK_13B   ((uint32_t)0x0000)
 // Supported only in Slave mode
-#define LIN_BREAK_10B ((uint32_t)0x0800)
-#define LIN_BREAK_11B ((uint32_t)0x0C00)
+#define LIN_BREAK_10B   ((uint32_t)0x0800)
+#define LIN_BREAK_11B   ((uint32_t)0x0C00)
 
 // Pre-defined LIN configurations
 #define LIN_MASTER_13B (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13B)

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -55,13 +55,13 @@
 #define SERIAL_STOP_BITS (uint8_t)0b00000011
 #define SERIAL_PARITY_BITS (uint8_t)0b00001100
 #define SERIAL_NINE_BITS (uint8_t)0b00010000
-#define SERIAL_FLOW_CONTROL ((uint8_t)0b01100000)
+#define SERIAL_FLOW_CONTROL ((uint8_t)0b11000000)
 
 // Flow control settings
 #define SERIAL_FLOW_CONTROL_NONE ((uint8_t)0b00000000)
-#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b00100000)
-#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b01000000)
-#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b01100000)
+#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b01000000)
+#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b10000000)
+#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b11000000)
 
 // LIN Configuration masks
 #define LIN_MODE ((uint32_t)0x0300)

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -55,6 +55,34 @@
 #define SERIAL_STOP_BITS (uint8_t)0b00000011
 #define SERIAL_PARITY_BITS (uint8_t)0b00001100
 #define SERIAL_NINE_BITS (uint8_t)0b00010000
+#define SERIAL_FLOW_CONTROL ((uint8_t)0b01100000)
+
+// Flow control settings
+#define SERIAL_FLOW_CONTROL_NONE ((uint8_t)0b00000000)
+#define SERIAL_FLOW_CONTROL_RTS ((uint8_t)0b00100000)
+#define SERIAL_FLOW_CONTROL_CTS ((uint8_t)0b01000000)
+#define SERIAL_FLOW_CONTROL_RTS_CTS ((uint8_t)0b01100000)
+
+// LIN Configuration masks
+#define LIN_MODE ((uint32_t)0x0300)
+#define LIN_BREAK_BITS ((uint32_t)0x0C00)
+
+// LIN modes
+#define LIN_MODE_MASTER ((uint32_t)0x0100)
+#define LIN_MODE_SLAVE  ((uint32_t)0x0200)
+
+// LIN break settings
+// Supported only in Master mode
+#define LIN_BREAK_13 ((uint32_t)0x0400)
+// Supported only in Slave mode
+#define LIN_BREAK_10 ((uint32_t)0x0800)
+#define LIN_BREAK_11 ((uint32_t)0x0C00)
+
+// Pre-defined LIN configurations
+#define LIN_MASTER_13 (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13)
+#define LIN_SLAVE_10  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_10)
+#define LIN_SLAVE_11  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_11)
+
 
 /* Exported types ------------------------------------------------------------*/
 typedef struct Ring_Buffer
@@ -97,6 +125,8 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial);
 void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable);
 void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void*);
 uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data);
+void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved);
+uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -73,15 +73,15 @@
 
 // LIN break settings
 // Supported only in Master mode
-#define LIN_BREAK_13 ((uint32_t)0x0400)
+#define LIN_BREAK_13B ((uint32_t)0x0000)
 // Supported only in Slave mode
-#define LIN_BREAK_10 ((uint32_t)0x0800)
-#define LIN_BREAK_11 ((uint32_t)0x0C00)
+#define LIN_BREAK_10B ((uint32_t)0x0800)
+#define LIN_BREAK_11B ((uint32_t)0x0C00)
 
 // Pre-defined LIN configurations
-#define LIN_MASTER_13 (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13)
-#define LIN_SLAVE_10  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_10)
-#define LIN_SLAVE_11  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE | LIN_BREAK_11)
+#define LIN_MASTER_13B (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_MASTER | LIN_BREAK_13B)
+#define LIN_SLAVE_10B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_10B)
+#define LIN_SLAVE_11B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_11B)
 
 
 /* Exported types ------------------------------------------------------------*/

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -450,13 +450,11 @@ void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 
 void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
 {
-  if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
-    int32_t state = HAL_disable_irq();
-    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-    USART_SendBreak(usartMap[serial]->usart_peripheral);
-    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-    HAL_enable_irq(state);
-  }
+  int32_t state = HAL_disable_irq();
+  while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+  USART_SendBreak(usartMap[serial]->usart_peripheral);
+  while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+  HAL_enable_irq(state);
 }
 
 uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -259,22 +259,25 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
     }
   }
 
+  // Disable LIN mode just in case
+  USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
+
   // Configure USART
   USART_Init(usartMap[serial]->usart_peripheral, &USART_InitStructure);
 
   // LIN configuration
-  if (config & LIN_MODE_MASTER) {
-    // Ignore break settings
-  } else if (config & LIN_MODE_SLAVE) {
+  if (config & LIN_MODE) {
+    // Enable break detection
     switch(config & LIN_BREAK_BITS) {
-      case LIN_BREAK_10:
+      case LIN_BREAK_10B:
         USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
         break;
-      case LIN_BREAK_11:
+      case LIN_BREAK_11B:
         USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
         break;
     }
   }
+
 
   // Enable USART Receive and Transmit interrupts
   USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, ENABLE);
@@ -299,6 +302,9 @@ void HAL_USART_End(HAL_USART_Serial serial)
 
   // Disable the USART
   USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
+
+  // Disable LIN mode
+  USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
 
   // Deinitialise USART
   USART_DeInit(usartMap[serial]->usart_peripheral);
@@ -445,7 +451,11 @@ void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
 {
   if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
+    int32_t state = HAL_disable_irq();
+    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
     USART_SendBreak(usartMap[serial]->usart_peripheral);
+    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+    HAL_enable_irq(state);
   }
 }
 

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -28,6 +28,7 @@
 #include "gpio_hal.h"
 #include "stm32f10x.h"
 #include <string.h>
+#include "interrupts_hal.h"
 
 /* Private typedef -----------------------------------------------------------*/
 typedef enum USART_Num_Def {

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -240,3 +240,12 @@ uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data)
 {
     return usartMap(serial).write((uint8_t) data);
 }
+
+void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
+{
+}
+
+uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)
+{
+  return 0;
+}

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -491,13 +491,11 @@ void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 
 void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
 {
-	if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
-		int32_t state = HAL_disable_irq();
-		while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-		USART_SendBreak(usartMap[serial]->usart_peripheral);
-		while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-		HAL_enable_irq(state);
-	}
+	int32_t state = HAL_disable_irq();
+	while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+	USART_SendBreak(usartMap[serial]->usart_peripheral);
+	while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+	HAL_enable_irq(state);
 }
 
 uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -44,8 +44,6 @@ typedef enum USART_Num_Def {
 
 /* Private macro -------------------------------------------------------------*/
 #define USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS 0  //Enabling this => 1 is not working at present
-// IS_USART_CONFIG_VALID(config) - returns true for 8 data bit, any flow control, any parity, any stop byte configurations
-#define IS_USART_CONFIG_VALID(CONFIG) (((CONFIG & SERIAL_VALID_CONFIG) >> 2) != 0b11)
 
 /* Private variables ---------------------------------------------------------*/
 typedef struct STM32_USART_Info {
@@ -115,8 +113,8 @@ static STM32_USART_Info *usartMap[TOTAL_USARTS]; // pointer to USART_MAP[] conta
 
 /* Private function prototypes -----------------------------------------------*/
 
-inline void store_char(unsigned char c, Ring_Buffer *buffer) __attribute__((always_inline));
-inline void store_char(unsigned char c, Ring_Buffer *buffer)
+inline void store_char(uint16_t c, Ring_Buffer *buffer) __attribute__((always_inline));
+inline void store_char(uint16_t c, Ring_Buffer *buffer)
 {
 	unsigned i = (unsigned int)(buffer->head + 1) % SERIAL_BUFFER_SIZE;
 
@@ -125,6 +123,72 @@ inline void store_char(unsigned char c, Ring_Buffer *buffer)
 		buffer->buffer[buffer->head] = c;
 		buffer->head = i;
 	}
+}
+
+static uint8_t HAL_USART_Calculate_Word_Length(uint32_t config, uint8_t noparity);
+static uint32_t HAL_USART_Calculate_Data_Bits_Mask(uint32_t config);
+static uint8_t HAL_USART_Validate_Config(uint32_t config);
+
+uint8_t HAL_USART_Calculate_Word_Length(uint32_t config, uint8_t noparity)
+{
+	// STM32F2 USARTs support only 8-bit or 9-bit communication, however
+	// the parity bit is included in the total word length, so for 8E1 mode
+	// the total word length would be 9 bits.
+	uint8_t wlen = 0;
+	switch (config & SERIAL_DATA_BITS) {
+		case SERIAL_DATA_BITS_7:
+			wlen += 7;
+			break;
+		case SERIAL_DATA_BITS_8:
+			wlen += 8;
+			break;
+		case SERIAL_DATA_BITS_9:
+			wlen += 9;
+			break;
+	}
+
+	if ((config & SERIAL_PARITY) && !noparity)
+		wlen++;
+
+	if (wlen > 9 || wlen < (noparity ? 7 : 8))
+		wlen = 0;
+
+	return wlen;
+}
+
+uint32_t HAL_USART_Calculate_Data_Bits_Mask(uint32_t config)
+{
+	return (1 << HAL_USART_Calculate_Word_Length(config, 1)) - 1;
+}
+
+uint8_t HAL_USART_Validate_Config(uint32_t config)
+{
+	// Total word length should be either 8 or 9 bits
+	if (HAL_USART_Calculate_Word_Length(config, 0) == 0)
+		return 0;
+
+	// Either No, Even or Odd parity
+	if ((config & SERIAL_PARITY) == (SERIAL_PARITY_EVEN | SERIAL_PARITY_ODD))
+		return 0;
+
+	if (config & LIN_MODE)
+	{
+		// Either Master or Slave mode
+		// Break detection can still be enabled in both Master and Slave modes
+		if ((config & LIN_MODE_MASTER) && (config & LIN_MODE_SLAVE))
+			return 0;
+		switch (config & LIN_BREAK_BITS)
+		{
+			case LIN_BREAK_13B:
+			case LIN_BREAK_10B:
+			case LIN_BREAK_11B:
+				break;
+			default:
+				return 0;
+		}
+	}
+
+	return 1;
 }
 
 void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
@@ -164,17 +228,17 @@ void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer
 
 void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud)
 {
-  HAL_USART_BeginConfig(serial, baud, 0, 0); // Default serial configuration is 8N1
+	HAL_USART_BeginConfig(serial, baud, 0, 0); // Default serial configuration is 8N1
 }
 
 void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr)
 {
-  // Verify UART configuration, exit if it's invalid.
-  if (!IS_USART_CONFIG_VALID(config)) {
-	usartMap[serial]->usart_enabled = false;
-	return;
-  }
-  
+	// Verify UART configuration, exit if it's invalid.
+	if (!HAL_USART_Validate_Config(config)) {
+		usartMap[serial]->usart_enabled = false;
+		return;
+	}
+
 	USART_DeInit(usartMap[serial]->usart_peripheral);
 
 	// Configure USART Rx and Tx as alternate function push-pull, and enable GPIOA clock
@@ -269,41 +333,41 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 
 	// Stop bit configuration.
 	switch (config & SERIAL_STOP_BITS) {
-	  case 0b00: // 1 stop bit
-		USART_InitStructure.USART_StopBits = USART_StopBits_1;
-		break;
-	  case 0b01: // 2 stop bits
-		USART_InitStructure.USART_StopBits = USART_StopBits_2;
-		break;
-	  case 0b10: // 0.5 stop bits
-		USART_InitStructure.USART_StopBits = USART_StopBits_0_5;
-		break;
-	  case 0b11: // 1.5 stop bits
-		USART_InitStructure.USART_StopBits = USART_StopBits_1_5;
-		break;
+		case SERIAL_STOP_BITS_1: // 1 stop bit
+			USART_InitStructure.USART_StopBits = USART_StopBits_1;
+			break;
+		case SERIAL_STOP_BITS_2: // 2 stop bits
+			USART_InitStructure.USART_StopBits = USART_StopBits_2;
+			break;
+		case SERIAL_STOP_BITS_0_5: // 0.5 stop bits
+			USART_InitStructure.USART_StopBits = USART_StopBits_0_5;
+			break;
+		case SERIAL_STOP_BITS_1_5: // 1.5 stop bits
+			USART_InitStructure.USART_StopBits = USART_StopBits_1_5;
+			break;
 	}
 
-	// Eight / Nine data bit configuration
-	if (config & SERIAL_NINE_BITS) {
-		// Nine data bits, no parity.
-		USART_InitStructure.USART_Parity = USART_Parity_No;
-		USART_InitStructure.USART_WordLength = USART_WordLength_9b;
-	} else {
-		// eight data bits, parity configuration (impacts word length)
-		switch ((config & SERIAL_PARITY_BITS) >> 2) {
-		  case 0b00: // none
-			USART_InitStructure.USART_Parity = USART_Parity_No;
+	// Data bits configuration
+	switch (HAL_USART_Calculate_Word_Length(config, 0)) {
+		case 8:
 			USART_InitStructure.USART_WordLength = USART_WordLength_8b;
 			break;
-		  case 0b01: // even
+		case 9:
+			USART_InitStructure.USART_WordLength = USART_WordLength_9b;
+			break;
+	}
+
+	// Parity configuration
+	switch (config & SERIAL_PARITY) {
+		case SERIAL_PARITY_NO:
+			USART_InitStructure.USART_Parity = USART_Parity_No;
+			break;
+		case SERIAL_PARITY_EVEN:
 			USART_InitStructure.USART_Parity = USART_Parity_Even;
-			USART_InitStructure.USART_WordLength = USART_WordLength_9b;
 			break;
-		  case 0b10: // odd
+		case SERIAL_PARITY_ODD:
 			USART_InitStructure.USART_Parity = USART_Parity_Odd;
-			USART_InitStructure.USART_WordLength = USART_WordLength_9b;
 			break;
-		}
 	}
 
 	// Disable LIN mode just in case
@@ -390,6 +454,8 @@ uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data)
 
 uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data)
 {
+	// Remove any bits exceeding data bits configured
+	data &= HAL_USART_Calculate_Data_Bits_Mask(usartMap[serial]->usart_config);
 	// interrupts are off and data in queue;
 	if ((USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) == RESET)
 		&& usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail) {
@@ -452,7 +518,7 @@ int32_t HAL_USART_Read_Data(HAL_USART_Serial serial)
 	}
 	else
 	{
-		unsigned char c = usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
+		uint16_t c = usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
 		usartMap[serial]->usart_rx_buffer->tail = (unsigned int)(usartMap[serial]->usart_rx_buffer->tail + 1) % SERIAL_BUFFER_SIZE;
 		return c;
 	}
@@ -516,7 +582,9 @@ static void HAL_USART_Handler(HAL_USART_Serial serial)
 	if(USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_RXNE) != RESET)
 	{
 		// Read byte from the receive data register
-		unsigned char c = USART_ReceiveData(usartMap[serial]->usart_peripheral);
+		uint16_t c = USART_ReceiveData(usartMap[serial]->usart_peripheral);
+		// Remove parity bits from data
+		c &= HAL_USART_Calculate_Data_Bits_Mask(usartMap[serial]->usart_config);
 		store_char(c, usartMap[serial]->usart_rx_buffer);
 	}
 
@@ -536,11 +604,11 @@ static void HAL_USART_Handler(HAL_USART_Serial serial)
 		}
 	}
 
-    	if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_ORE) != RESET)
-    	{
-    		// If Overrun flag is still set, clear it
-        	(void)USART_ReceiveData(usartMap[serial]->usart_peripheral);
-    	}
+		if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_ORE) != RESET)
+		{
+			// If Overrun flag is still set, clear it
+			(void)USART_ReceiveData(usartMap[serial]->usart_peripheral);
+		}
 
 }
 

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -63,12 +63,17 @@ typedef struct STM32_USART_Info {
 
 	uint8_t usart_af_map;
 
+	uint8_t usart_cts_pin;
+	uint8_t usart_rts_pin;
+
 	// Buffer pointers. These need to be global for IRQ handler access
 	Ring_Buffer* usart_tx_buffer;
 	Ring_Buffer* usart_rx_buffer;
 
 	bool usart_enabled;
 	bool usart_transmitting;
+
+	uint32_t usart_config;
 } STM32_USART_Info;
 
 /*
@@ -86,15 +91,17 @@ STM32_USART_Info USART_MAP[TOTAL_USARTS] =
 		 * TX pin source
 		 * RX pin source
 		 * GPIO AF map (GPIO_AF_USARTx/GPIO_AF_UARTx)
+		 * CTS pin
+		 * RTS pin
 		 * <tx_buffer pointer> used internally and does not appear below
 		 * <rx_buffer pointer> used internally and does not appear below
 		 * <usart enabled> used internally and does not appear below
 		 * <usart transmitting> used internally and does not appear below
 		 */
 		{ USART1, &RCC->APB2ENR, RCC_APB2Periph_USART1, USART1_IRQn, TX, RX, GPIO_PinSource9, GPIO_PinSource10, GPIO_AF_USART1 }, // USART 1
-		{ USART2, &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG, RGBB, GPIO_PinSource2, GPIO_PinSource3, GPIO_AF_USART2 } // USART 2
+		{ USART2, &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG, RGBB, GPIO_PinSource2, GPIO_PinSource3, GPIO_AF_USART2, A7, RGBR } // USART 2
 #if PLATFORM_ID == 10 // Electron
-		,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3 } // USART 3
+		,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3, CTS_UC, RTS_UC } // USART 3
 		,{ UART4, &RCC->APB1ENR, RCC_APB1Periph_UART4, UART4_IRQn, C3, C2, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_UART4 } // UART 4
 		,{ UART5, &RCC->APB1ENR, RCC_APB1Periph_UART5, UART5_IRQn, C1, C0, GPIO_PinSource12, GPIO_PinSource2, GPIO_AF_UART5 } // UART 5
 #endif
@@ -172,14 +179,6 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	// Configure USART Rx and Tx as alternate function push-pull, and enable GPIOA clock
 	HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, AF_OUTPUT_PUSHPULL);
 	HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
-#if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
-	if (serial == HAL_USART_SERIAL3)
-	{
-		// Configure USART RTS and CTS as alternate function push-pull
-		HAL_Pin_Mode(RTS_UC, AF_OUTPUT_PUSHPULL);
-		HAL_Pin_Mode(CTS_UC, AF_OUTPUT_PUSHPULL);
-	}
-#endif
 
 	// Enable USART Clock
 	*usartMap[serial]->usart_apbReg |=  usartMap[serial]->usart_clock_en;
@@ -188,13 +187,6 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
 	GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rx_pin].gpio_peripheral, usartMap[serial]->usart_rx_pinsource, usartMap[serial]->usart_af_map);
 	GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral, usartMap[serial]->usart_tx_pinsource, usartMap[serial]->usart_af_map);
-#if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
-	if (serial == HAL_USART_SERIAL3)
-	{
-		GPIO_PinAFConfig(PIN_MAP[RTS_UC].gpio_peripheral, PIN_MAP[RTS_UC].gpio_pin_source, usartMap[serial]->usart_af_map);
-		GPIO_PinAFConfig(PIN_MAP[CTS_UC].gpio_peripheral, PIN_MAP[CTS_UC].gpio_pin_source, usartMap[serial]->usart_af_map);
-	}
-#endif
 
 	// NVIC Configuration
 	NVIC_InitTypeDef NVIC_InitStructure;
@@ -217,14 +209,62 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	// USART configuration
 	USART_InitStructure.USART_BaudRate = baud;
 	USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-	USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
 
-  #if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
+	// Flow control configuration
+	switch (config & SERIAL_FLOW_CONTROL) {
+		case SERIAL_FLOW_CONTROL_CTS:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_CTS;
+			break;
+		case SERIAL_FLOW_CONTROL_RTS:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS;
+			break;
+		case SERIAL_FLOW_CONTROL_RTS_CTS:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
+			break;
+		case SERIAL_FLOW_CONTROL_NONE:
+		default:
+			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+			break;
+	}
+
+	if (serial == HAL_USART_SERIAL1) {
+		// USART1 supports hardware flow control, but RTS and CTS pins are not exposed
+		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+	}
+
+#if PLATFORM_ID == 10 // Electron
+	if (serial == HAL_USART_SERIAL4 || serial == HAL_USART_SERIAL5) {
+		// UART4 and UART5 do not support hardware flow control
+		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+	}
+#endif // PLATFORM_ID == 10
+
+#if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
 	if (serial == HAL_USART_SERIAL3)
 	{
-	  USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
+		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
 	}
-  #endif
+#endif
+
+	switch (USART_InitStructure.USART_HardwareFlowControl) {
+		case USART_HardwareFlowControl_CTS:
+			HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			break;
+		case USART_HardwareFlowControl_RTS:
+			HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			break;
+		case USART_HardwareFlowControl_RTS_CTS:
+			HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
+			HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+			break;
+		case USART_HardwareFlowControl_None:
+		default:
+			break;
+	}
 
 	// Stop bit configuration.
 	switch (config & SERIAL_STOP_BITS) {
@@ -268,9 +308,28 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 	// Configure USART
 	USART_Init(usartMap[serial]->usart_peripheral, &USART_InitStructure);
 
+	// LIN configuration
+	if (config & LIN_MODE_MASTER) {
+		// Ignore break settings
+	} else if (config & LIN_MODE_SLAVE) {
+		switch(config & LIN_BREAK_BITS) {
+			case LIN_BREAK_10:
+				USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
+				break;
+			case LIN_BREAK_11:
+				USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
+				break;
+		}
+	}
+
 	// Enable the USART
 	USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
 
+	if (config & LIN_MODE) {
+		USART_LINCmd(usartMap[serial]->usart_peripheral, ENABLE);
+	}
+
+	usartMap[serial]->usart_config = config;
 	usartMap[serial]->usart_enabled = true;
 	usartMap[serial]->usart_transmitting = false;
 
@@ -422,6 +481,24 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
 void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 {
 	USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, Enable ? ENABLE : DISABLE);
+}
+
+void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
+{
+	if (usartMap[serial]->usart_config & LIN_MODE_MASTER) {
+		USART_SendBreak(usartMap[serial]->usart_peripheral);
+	}
+}
+
+uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)
+{
+	if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_LBD)) {
+		// Clear LBD flag
+		USART_ClearFlag(usartMap[serial]->usart_peripheral, USART_FLAG_LBD);
+		return 1;
+	}
+
+	return 0;
 }
 
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -604,11 +604,11 @@ static void HAL_USART_Handler(HAL_USART_Serial serial)
 		}
 	}
 
-		if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_ORE) != RESET)
-		{
-			// If Overrun flag is still set, clear it
-			(void)USART_ReceiveData(usartMap[serial]->usart_peripheral);
-		}
+	if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_ORE) != RESET)
+	{
+		// If Overrun flag is still set, clear it
+		(void)USART_ReceiveData(usartMap[serial]->usart_peripheral);
+	}
 
 }
 

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -88,6 +88,17 @@ test(api_wiring_usartserial) {
     API_COMPILE(Serial1.end());
     API_COMPILE(Serial1.begin(9600, SERIAL_9N2));
     API_COMPILE(Serial1.end());
+
+    // LIN mode
+    API_COMPILE(Serial1.begin(9600, LIN_MASTER_13B));
+    API_COMPILE(Serial1.breakTx());
+    API_COMPILE(Serial1.end());
+    API_COMPILE(Serial1.begin(9600, LIN_SLAVE_10B));
+    API_COMPILE(Serial1.breakRx());
+    API_COMPILE(Serial1.end());
+    API_COMPILE(Serial1.begin(9600, LIN_SLAVE_11B));
+    API_COMPILE(Serial1.breakRx());
+    API_COMPILE(Serial1.end());
 }
 
 test(api_wiring_usbserial) {

--- a/user/tests/wiring/serial_loopback/application.cpp
+++ b/user/tests/wiring/serial_loopback/application.cpp
@@ -1,4 +1,6 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
+SYSTEM_MODE(MANUAL);
+
 UNIT_TEST_APP();

--- a/user/tests/wiring/serial_loopback/serial.cpp
+++ b/user/tests/wiring/serial_loopback/serial.cpp
@@ -50,8 +50,6 @@ test(SERIAL_ReadWriteSucceedsWithUserIntervention) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial.print("Type the following message and press Enter : ");
     Serial.println(test);
     serialReadLine(&Serial, message, 9, 10000);//10 sec timeout
@@ -65,8 +63,6 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -76,12 +72,10 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
 }
 
 test(SERIAL1_ReadWriteParity8N1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
+    //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8N1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -95,8 +89,6 @@ test(SERIAL1_ReadWriteParity8E1SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8E1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -110,8 +102,6 @@ test(SERIAL1_ReadWriteParity8O1SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8O1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -125,8 +115,6 @@ test(SERIAL1_ReadWriteParity8N2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8N2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -140,8 +128,6 @@ test(SERIAL1_ReadWriteParity8E2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8E2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -155,8 +141,6 @@ test(SERIAL1_ReadWriteParity8O2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_8O2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -170,8 +154,6 @@ test(SERIAL1_ReadWriteParity9N1SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_9N1);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -185,8 +167,6 @@ test(SERIAL1_ReadWriteParity9N2SucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial1.isEnabled())
-        Serial1.end();
     Serial1.begin(9600, SERIAL_9N2);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -202,8 +182,6 @@ test(SERIAL2_ReadWriteSucceedsInLoopbackWithD0D1Shorted) {
     char test[] = "hello";
     char message[10];
     // when
-    if (Serial2.isEnabled())
-        Serial2.end();
     Serial2.begin(9600);
     Serial2.println(test);
     serialReadLine(&Serial2, message, 9, 1000);//1 sec timeout

--- a/user/tests/wiring/serial_loopback/serial.cpp
+++ b/user/tests/wiring/serial_loopback/serial.cpp
@@ -29,8 +29,6 @@
 #endif
 #include "unit-test/unit-test.h"
 
-SYSTEM_MODE(MANUAL);
-
 /*
  * Serial1 Test requires TX to be jumpered to RX as follows:
  * valid for both Core and Photon
@@ -45,11 +43,63 @@ SYSTEM_MODE(MANUAL);
  *
  */
 
+/*
+ * Helper function that behaves almost like serialReadLine, but uses uint16_t buffer and
+ * doesn't echo anything back. Also doesn't handle "Delete" or "Backspace".
+ */
+int serialReadLine16NoEcho(Stream *serialObj, uint16_t *dst, int max_len, system_tick_t timeout)
+{
+    uint16_t c = 0, i = 0;
+    system_tick_t last_millis = millis();
+
+    while (1)
+    {
+        if((timeout > 0) && ((millis()-last_millis) > timeout))
+        {
+            //Abort after a specified timeout
+            break;
+        }
+
+        if (0 < serialObj->available())
+        {
+            c = serialObj->read();
+
+            if (i == max_len || c == '\r' || c == '\n')
+            {
+                *dst = '\0';
+                break;
+            }
+
+            *dst++ = c;
+            ++i;
+        }
+    }
+
+    return i;
+}
+
+void consume(Stream& serial)
+{
+    while (serial.available() > 0) {
+        (void)serial.read();
+    }
+}
+
+void printlnMasked(Stream& serial, char* str, uint16_t mask)
+{
+    for (unsigned i = 0; i < strlen(str); i++) {
+        serial.write(((uint16_t)str[i]) | mask);
+    }
+    serial.println();
+}
+
+
 test(SERIAL_ReadWriteSucceedsWithUserIntervention) {
     //The following code will test all the important USB Serial routines
     char test[] = "hello";
     char message[10];
     // when
+    consume(Serial);
     Serial.print("Type the following message and press Enter : ");
     Serial.println(test);
     serialReadLine(&Serial, message, 9, 10000);//10 sec timeout
@@ -58,137 +108,381 @@ test(SERIAL_ReadWriteSucceedsWithUserIntervention) {
     assertTrue(strncmp(test, message, 5)==0);
 }
 
+test(SERIAL1_IncorrectConfigurationPassed) {
+    Serial1.begin(9600, SERIAL_DATA_BITS_9 | SERIAL_PARITY_ODD | SERIAL_PARITY_EVEN | SERIAL_STOP_BITS_2);
+    assertEqual(Serial1.isEnabled(), false);
+}
+
 test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial1.begin(9600);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
     Serial1.end();
     // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 5)==0);
+}
+
+test(SERIAL1_ReadWriteParity7E1SucceedsInLoopbackWithTxRxShorted) {
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    uint16_t message16[10];
+    char message[10];
+    int len = 0;
+    // when
+    Serial1.begin(9600, SERIAL_7E1);
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
+    // then
+    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF80;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 5)==0);
+}
+
+test(SERIAL1_ReadWriteParity7E2SucceedsInLoopbackWithTxRxShorted) {
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    uint16_t message16[10];
+    char message[10];
+    int len = 0;
+    // when
+    Serial1.begin(9600, SERIAL_7E2);
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
+    // then
+    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF80;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 5)==0);
+}
+
+test(SERIAL1_ReadWriteParity7O1SucceedsInLoopbackWithTxRxShorted) {
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    uint16_t message16[10];
+    char message[10];
+    int len = 0;
+    // when
+    Serial1.begin(9600, SERIAL_7O1);
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
+    // then
+    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF80;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 5)==0);
+}
+
+test(SERIAL1_ReadWriteParity7O2SucceedsInLoopbackWithTxRxShorted) {
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    uint16_t message16[10];
+    char message[10];
+    int len = 0;
+    // when
+    Serial1.begin(9600, SERIAL_7E1);
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
+    // then
+    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF80;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8N1SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_8N1);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
     // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8E1SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_8E1);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
     // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8O1SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_8O1);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
     // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8N2SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_8N2);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
     // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8E2SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_8E2);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
     // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8O2SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_8O2);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
     // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity9N1SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    char message[10];
+    char test[] = "helloworld1234";
+    uint16_t test2 = ((uint16_t)'p' << 7) | (uint16_t)'a'; // "pa"
+    uint16_t message16[32];
+    char message[32];
+    uint16_t message2 = 0x0000;
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_9N1);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    for (int i = 0; i < strlen(test); i++) {
+        uint16_t c = test[i] | (((test2 >> i) & 0x0001) << 8);
+        Serial1.write(c);
+    }
+    Serial1.println();
+    len = serialReadLine16NoEcho(&Serial1, message16, 31, 1000);//1 sec timeout
+    Serial1.end();
     // then
-    assertTrue(strncmp(test, message, 5)==0);
+    // Copy into char buffer, construct uint16_t from 9th bits
+    for (int i = 0; i < len; i++) {
+        // Check that upper (16 - 9) bits are 0
+        uint16_t msb = message16[i] & 0xFE00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+        message2 |= (((message16[i] >> 8) & 0x01) << i);
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 14)==0);
+    // Compare uint16_t constructed from 9th bits and test2
+    assertEqual(test2, message2);
 }
 
 test(SERIAL1_ReadWriteParity9N2SucceedsInLoopbackWithTxRxShorted) {
     //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    char message[10];
+    char test[] = "helloworld1234";
+    uint16_t test2 = ((uint16_t)'p' << 7) | (uint16_t)'a'; // "pa"
+    uint16_t message16[32];
+    char message[32];
+    uint16_t message2 = 0x0000;
+    int len = 0;
     // when
     Serial1.begin(9600, SERIAL_9N2);
-    Serial1.println(test);
-    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
-	Serial1.end();
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    for (int i = 0; i < strlen(test); i++) {
+        uint16_t c = test[i] | (((test2 >> i) & 0x0001) << 8);
+        Serial1.write(c);
+    }
+    Serial1.println();
+    len = serialReadLine16NoEcho(&Serial1, message16, 31, 1000);//1 sec timeout
+    Serial1.end();
     // then
-    assertTrue(strncmp(test, message, 5)==0);
+    // Copy into char buffer, construct uint16_t from 9th bits
+    for (int i = 0; i < len; i++) {
+        // Check that upper (16 - 9) bits are 0
+        uint16_t msb = message16[i] & 0xFE00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+        message2 |= (((message16[i] >> 8) & 0x01) << i);
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 14)==0);
+    // Compare uint16_t constructed from 9th bits and test2
+    assertEqual(test2, message2);
 }
 
 
 #if (PLATFORM_ID == 0)
 test(SERIAL2_ReadWriteSucceedsInLoopbackWithD0D1Shorted) {
-    //The following code will test all the important USART Serial2 routines
+    //The following code will test all the important USART Serial1 routines
     char test[] = "hello";
+    uint16_t message16[10];
     char message[10];
+    int len = 0;
     // when
     Serial2.begin(9600);
-    Serial2.println(test);
-    serialReadLine(&Serial2, message, 9, 1000);//1 sec timeout
-    // then
-    assertTrue(strncmp(test, message, 5)==0);
-
+    assertEqual(Serial2.isEnabled(), true);
+    consume(Serial2);
+    printlnMasked(Serial2, test, (1 << 8)); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial2, message16, 9, 1000);//1 sec timeout
     Serial2.end();
+    // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 5)==0);
 }
 #endif
 
@@ -258,6 +552,7 @@ test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
     if (Serial1.isEnabled())
         Serial1.end();
     Serial1.begin(9600, LIN_MASTER_13B | LIN_BREAK_10B);
+    assertEqual(Serial1.isEnabled(), true);
     // then
 
     // Send 2 consecutive breaks
@@ -272,8 +567,7 @@ test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
     assertTrue(Serial1.breakRx());
 
     // Send message
-    while(Serial1.available())
-        (void)Serial1.read();
+    consume(Serial1);
     Serial1.println(test);
     Serial1.flush();
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -287,8 +581,7 @@ test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
     assertTrue(Serial1.breakRx());
 
     // Send message
-    while(Serial1.available())
-        (void)Serial1.read();
+    consume(Serial1);
     Serial1.println(test);
     Serial1.flush();
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout

--- a/user/tests/wiring/serial_loopback/serial.cpp
+++ b/user/tests/wiring/serial_loopback/serial.cpp
@@ -29,6 +29,8 @@
 #endif
 #include "unit-test/unit-test.h"
 
+SYSTEM_MODE(MANUAL);
+
 /*
  * Serial1 Test requires TX to be jumpered to RX as follows:
  * valid for both Core and Photon
@@ -48,6 +50,8 @@ test(SERIAL_ReadWriteSucceedsWithUserIntervention) {
     char test[] = "hello";
     char message[10];
     // when
+    if (Serial1.isEnabled())
+        Serial1.end();
     Serial.print("Type the following message and press Enter : ");
     Serial.println(test);
     serialReadLine(&Serial, message, 9, 10000);//10 sec timeout
@@ -61,6 +65,8 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
     char test[] = "hello";
     char message[10];
     // when
+    if (Serial1.isEnabled())
+        Serial1.end();
     Serial1.begin(9600);
     Serial1.println(test);
     serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
@@ -71,106 +77,122 @@ test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
 
 test(SERIAL1_ReadWriteParity8N1SucceedsInLoopbackWithTxRxShorted) {
         //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8N1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8N1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8E1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8E1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8E1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8O1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8O1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8O1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8N2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8N2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8N2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8E2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8E2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8E2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity8O2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_8O2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_8O2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity9N1SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_9N1);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_9N1);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_ReadWriteParity9N2SucceedsInLoopbackWithTxRxShorted) {
-        //The following code will test all the important USART Serial1 routines
-        char test[] = "hello";
-        char message[10];
-        // when
-        Serial1.begin(9600, SERIAL_9N2);
-        Serial1.println(test);
-        serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, SERIAL_9N2);
+    Serial1.println(test);
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
 	Serial1.end();
-        // then
-        assertTrue(strncmp(test, message, 5)==0);
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 
@@ -180,11 +202,15 @@ test(SERIAL2_ReadWriteSucceedsInLoopbackWithD0D1Shorted) {
     char test[] = "hello";
     char message[10];
     // when
+    if (Serial2.isEnabled())
+        Serial2.end();
     Serial2.begin(9600);
     Serial2.println(test);
     serialReadLine(&Serial2, message, 9, 1000);//1 sec timeout
     // then
     assertTrue(strncmp(test, message, 5)==0);
+
+    Serial2.end();
 }
 #endif
 
@@ -233,6 +259,69 @@ test(SERIAL1_AvailableForWriteWorksCorrectly) {
 
     // There should be SERIAL_BUFFER_SIZE available in TX buffer again
     assertEqual(Serial1.availableForWrite(), SERIAL_BUFFER_SIZE);
+
+    Serial1.end();
+}
+
+test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
+    // Test for LIN mode
+    // 1. The test will configure Serial1 in LIN Master mode (with 11 bit break detection
+    // enabled as in Slave mode)
+    // 2. Send and detect 2 consecutive breaks
+    // 3. Send/recv message
+    // 4. Send and detect a break
+    // 5. Send/recv message
+    // 6. Send and detect a break
+
+    char test[] = "hello";
+    char message[10];
+    memset(message, 0, sizeof(message));
+    // when
+    if (Serial1.isEnabled())
+        Serial1.end();
+    Serial1.begin(9600, LIN_MASTER_13B | LIN_BREAK_10B);
+    // then
+
+    // Send 2 consecutive breaks
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
+
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
+
+    // Send message
+    while(Serial1.available())
+        (void)Serial1.read();
+    Serial1.println(test);
+    Serial1.flush();
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    Serial1.println(message);
+    assertTrue(strncmp(test, message, 5)==0);
+
+    // Send break
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
+
+    // Send message
+    while(Serial1.available())
+        (void)Serial1.read();
+    Serial1.println(test);
+    Serial1.flush();
+    serialReadLine(&Serial1, message, 9, 1000);//1 sec timeout
+    Serial1.println(message);
+    assertTrue(strncmp(test, message, 5)==0);
+
+    // Send break
+    assertFalse(Serial1.breakRx());
+    Serial1.breakTx();
+    delay(1);
+    assertTrue(Serial1.breakRx());
 
     Serial1.end();
 }

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -54,6 +54,10 @@ public:
   size_t write(uint16_t);
   virtual size_t write(uint8_t);
 
+  // LIN
+  void breakTx(void);
+  bool breakRx(void);
+
   inline size_t write(unsigned long n) { return write((uint16_t)n); }
   inline size_t write(long n) { return write((uint16_t)n); }
   inline size_t write(unsigned int n) { return write((uint16_t)n); }

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -112,6 +112,14 @@ bool USARTSerial::isEnabled() {
   return HAL_USART_Is_Enabled(_serial);
 }
 
+void USARTSerial::breakTx() {
+  HAL_USART_Send_Break(_serial, NULL);
+}
+
+bool USARTSerial::breakRx() {
+  return (bool)HAL_USART_Break_Detected(_serial);
+}
+
 #ifndef SPARK_WIRING_NO_USART_SERIAL
 // Preinstantiate Objects //////////////////////////////////////////////////////
 static Ring_Buffer serial1_rx_buffer;


### PR DESCRIPTION
The PR is created on top of #930 (**LIN Bus support, USART hardware flow control configuration support**)

- Cleaned up USART settings
- Adds support for 7E1, 7E2, 7O1, 7O2 modes
- Fixes 9-bit receiving. Issue #968
- Extra bits are masked out when receiving/transmitting data
- Extend tests to verify correct transmission

---

Doneness:

- [X] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)