### PR TITLE
Enable bootloader OTA updates on Electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `millis()`/`micros()` are now atomic to ensure monotonic values. Fixes [#916](https://github.com/spark/firmware/issues/916) and [#925](https://github.com/spark/firmware/issues/925)
 - availableForWrite() was reporting bytes available instead of bytes available for write [#1020](https://github.com/spark/firmware/pull/1020) and [#1017](https://github.com/spark/firmware/issues/1017)
 - `digitalRead()` interferes with `analogRead()` [#993](https://github.com/spark/firmware/issues/993)
-
+- [electron] reinstated OTA bootloader updates [#1002](https://github.com/spark/firmware/pull/1002)
 
 
 ## v0.5.1 (same as v0.5.1-rc.2)

--- a/hal/src/stm32f2xx/bootloader.cpp
+++ b/hal/src/stm32f2xx/bootloader.cpp
@@ -9,7 +9,27 @@
 #if PLATFORM_ID==6 || PLATFORM_ID==8
 #define HAL_REPLACE_BOOTLOADER
 #endif
+#if PLATFORM_ID==6 || PLATFORM_ID==8 || PLATFORM_ID==10
+#define HAL_REPLACE_BOOTLOADER_OTA
 #endif
+#endif
+
+#ifdef HAL_REPLACE_BOOTLOADER_OTA
+bool bootloader_update(const void* bootloader_image, unsigned length)
+{
+    HAL_Bootloader_Lock(false);
+    bool result =  (FLASH_CopyMemory(FLASH_INTERNAL, (uint32_t)bootloader_image,
+        FLASH_INTERNAL, 0x8000000, length, MODULE_FUNCTION_BOOTLOADER,
+        MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION));
+    HAL_Bootloader_Lock(true);
+    return result;
+}
+#else
+bool bootloader_update(const void*, unsigned)
+{
+    return false;
+}
+#endif // HAL_REPLACE_BOOTLOADER_OTA
 
 #ifdef HAL_REPLACE_BOOTLOADER
 
@@ -37,16 +57,6 @@ bool bootloader_requires_update()
     return requires_update;
 }
 
-bool bootloader_update(const void* bootloader_image, unsigned length)
-{
-    HAL_Bootloader_Lock(false);
-    bool result =  (FLASH_CopyMemory(FLASH_INTERNAL, (uint32_t)bootloader_image,
-        FLASH_INTERNAL, 0x8000000, length, MODULE_FUNCTION_BOOTLOADER,
-        MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION));
-    HAL_Bootloader_Lock(true);
-    return result;
-}
-
 bool bootloader_update_if_needed()
 {
     bool updated = false;
@@ -56,16 +66,9 @@ bool bootloader_update_if_needed()
     return updated;
 }
 
-
-
 #else
 
 bool bootloader_requires_update()
-{
-    return false;
-}
-
-bool bootloader_update(const void*, unsigned)
 {
     return false;
 }


### PR DESCRIPTION
Bootloader OTA updates were NOPed on Electron when bootloader image was removed from system-part2.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)