### PR TITLE
Restore the default WICED country to Japan

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -56,13 +56,17 @@ wiced_country_code_t fetch_country_code()
 
     wiced_country_code_t result =
         wiced_country_code_t(MK_CNTRY(code[0], code[1], hex_nibble(code[2])));
-    if (code[0] == 0xFF || code[0] == 0)
-    {
-        result = WICED_COUNTRY_UNITED_KINGDOM; // default is UK, so channels 1-13 are available by default.
-    }
+
+    // if Japan explicitly configured, lower tx power for TELEC certification
     if (result == WICED_COUNTRY_JAPAN)
     {
-        wwd_select_nvram_image_resource(1, nullptr); // lower tx power for TELEC certification
+        wwd_select_nvram_image_resource(1, nullptr);
+    }
+
+    // if no country configured, use Japan WiFi config for compatibility with older firmware
+    if (code[0] == 0xFF || code[0] == 0)
+    {
+        result = WICED_COUNTRY_JAPAN;
     }
     return result;
 }
@@ -75,7 +79,9 @@ bool initialize_dct(platform_dct_wifi_config_t* wifi_config, bool force=false)
         wifi_config->country_code != country)
     {
         if (!wifi_config->device_configured)
-        memset(wifi_config, 0, sizeof(*wifi_config));
+        {
+            memset(wifi_config, 0, sizeof(*wifi_config));
+        }
         wifi_config->country_code = country;
         wifi_config->device_configured = WICED_TRUE;
         changed = true;


### PR DESCRIPTION
Proposal to make the WiFi country behavior backwards compatible with previous firmware versions.

For the country code, we can leave the default country code sent to WICED as JP2 (used in firmware <= 0.5.0). If someone explicitly sets the country code in the Particle DCT section, then we send that to WICED and if that country is Japan we decrease the power.

## <0.5.1 to 0.5.2 (upgrade)
| Behavior | Particle DCT country | returned WICED DCT country as | write WICED DCT country | WiFi NVRAM image |
|-------------|------------------|-------------|----------------------------|------------------------------|
| Default behavior | blank | jp2 | jp2 | full power |
| Japan | jp2 | jp2 | jp2 | reduced power |
| Other country (for example, UK) | gb0 | gb0 | gb0 | full power |
| Other country (for example, USA) | us4 | us4 | us4 | full power |

## 0.5.1 to 0.5.2 (upgrade)
| Behavior | Particle DCT country | returned WICED DCT country as | write WICED DCT country | WiFi NVRAM image |
|-------------|------------------|-------------|----------------------------|------------------------------|
| Default behavior | blank | jp2 | jp2 (dct will have previously contained gb0) | full power |
| Japan | jp2 | jp2 | jp2 | reduced power |
| Other country (for example, UK) | gb0 | gb0 | gb0 | full power |
| Other country (for example, USA) | us4 | us4 | us4 | full power |

## 0.5.2 to 0.5.0 (downgrade)
| Behavior | Particle DCT country (ignored) | returned WICED DCT country as | write WICED DCT country | WiFi NVRAM image |
|-------------|------------------|-------------|----------------------------|------------------------------|
| Default behavior | n/a | jp2 | jp2 | full power |

## 0.5.2 to 0.5.1 (downgrade)
| Behavior | Particle DCT country | returned WICED DCT country as | write WICED DCT country | WiFi NVRAM image |
|-------------|------------------|-------------|----------------------------|------------------------------|
| Default behavior | blank | jp2 | gb0 (dct will have previously contained jp2) | full power |
| Japan | jp2 | jp2 | jp2 | reduced power |
| Other country (for example, UK) | gb0 | gb0 | gb0 | full power |
| Other country (for example, USA) | us4 | us4 | us4 | full power |

This would also solve the credentials loss during downgrade, unless the user explicitly sets anything other than `jp2`,`0x00`, or `0xff` ( such as `gb0` or `us4`).

---

Doneness:

- [X] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
