### PR TITLE
low-level queue API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Local build warns if crc32 is not present. [#941](https://github.com/spark/firmware/issues/941)
 - [Photon/Core] MAC address is available immediately after `WiFi.on()` [#879](https://github.com/spark/firmware/issues/879)
 - [virtual device] support for TCP Server [#1000](https://github.com/spark/firmware/pull/1000)
+- Low-level RTOS queues exposed in HAL [#1018](https://github.com/spark/firmware/pull/1018)
 
 ### BUGFIXES
 

--- a/hal/inc/concurrent_hal.h
+++ b/hal/inc/concurrent_hal.h
@@ -145,7 +145,7 @@ void os_condition_variable_notify_all(condition_variable_t var);
 
 const system_tick_t CONCURRENT_WAIT_FOREVER = (system_tick_t)-1;
 
-int os_queue_create(os_queue_t* queue, size_t item_size, size_t item_count);
+int os_queue_create(os_queue_t* queue, size_t item_size, size_t item_count, void* reserved);
 /**
  * Return 0 on success.
  * @param queue
@@ -153,7 +153,7 @@ int os_queue_create(os_queue_t* queue, size_t item_size, size_t item_count);
  * @param delay
  * @return
  */
-int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay);
+int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay, void* reserved);
 
 /**
  * Return 0 on success.
@@ -162,8 +162,8 @@ int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay);
  * @param delay
  * @return
  */
-int os_queue_take(os_queue_t queue, void* item, system_tick_t delay);
-void os_queue_destroy(os_queue_t queue);
+int os_queue_take(os_queue_t queue, void* item, system_tick_t delay, void* reserved);
+int os_queue_destroy(os_queue_t queue, void* reserved);
 
 int os_mutex_create(os_mutex_t* mutex);
 int os_mutex_destroy(os_mutex_t mutex);

--- a/hal/inc/hal_dynalib_concurrent.h
+++ b/hal/inc/hal_dynalib_concurrent.h
@@ -55,6 +55,12 @@ DYNALIB_FN(20, hal_concurrent, os_mutex_recursive_trylock, int(os_mutex_recursiv
 DYNALIB_FN(21, hal_concurrent, os_mutex_recursive_unlock, int(os_mutex_recursive_t))
 
 DYNALIB_FN(22, hal_concurrent, os_timer_is_active, int(os_timer_t, void*))
+
+DYNALIB_FN(23, hal_concurrent, os_queue_create, int(os_queue_t*, size_t, size_t, void*))
+DYNALIB_FN(24, hal_concurrent, os_queue_destroy, int(os_queue_t, void*))
+DYNALIB_FN(25, hal_concurrent, os_queue_put, int(os_queue_t, const void* item, system_tick_t, void*))
+DYNALIB_FN(26, hal_concurrent, os_queue_take, int(os_queue_t, void* item, system_tick_t, void*))
+
 #endif
 
 DYNALIB_END(hal_concurrent)

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -300,7 +300,7 @@ void os_condition_variable_notify_all(condition_variable_t cond)
 }
 
 
-int os_queue_create(os_queue_t* queue, size_t item_size, size_t item_count)
+int os_queue_create(os_queue_t* queue, size_t item_size, size_t item_count, void*)
 {
     *queue = xQueueCreate(item_count, item_size);
     return *queue==NULL;
@@ -308,7 +308,7 @@ int os_queue_create(os_queue_t* queue, size_t item_size, size_t item_count)
 
 static_assert(portMAX_DELAY==CONCURRENT_WAIT_FOREVER, "expected portMAX_DELAY==CONCURRENT_WAIT_FOREVER");
 
-int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay)
+int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay, void*)
 {
 	if (HAL_IsISR())
 		return xQueueSendFromISR(queue, item, nullptr)!=pdTRUE;
@@ -316,14 +316,15 @@ int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay)
 		return xQueueSend(queue, item, delay)!=pdTRUE;
 }
 
-int os_queue_take(os_queue_t queue, void* item, system_tick_t delay)
+int os_queue_take(os_queue_t queue, void* item, system_tick_t delay, void*)
 {
     return xQueueReceive(queue, item, delay)!=pdTRUE;
 }
 
-void os_queue_destroy(os_queue_t queue)
+int os_queue_destroy(os_queue_t queue, void*)
 {
     vQueueDelete(queue);
+    return 0;
 }
 
 

--- a/system/inc/active_object.h
+++ b/system/inc/active_object.h
@@ -365,17 +365,17 @@ protected:
 
     virtual bool take(Item& result)
     {
-        return !os_queue_take(queue, &result, configuration.take_wait);
+        return !os_queue_take(queue, &result, configuration.take_wait, nullptr);
     }
 
     virtual bool put(Item& item)
     {
-    		return !os_queue_put(queue, &item, configuration.put_wait);
+    		return !os_queue_put(queue, &item, configuration.put_wait, nullptr);
     }
 
     void createQueue()
     {
-        os_queue_create(&queue, sizeof(Item), configuration.queue_size);
+        os_queue_create(&queue, sizeof(Item), configuration.queue_size, nullptr);
     }
 
 public:


### PR DESCRIPTION
makes the os_queue interface extensible, and exposes it to the dynamic library.

fixes #1018 

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)