### PR TITLE
Fix soft AP suffix broken by the addition of device id in DCT

### DIFF
--- a/hal/src/photon/softap.cpp
+++ b/hal/src/photon/softap.cpp
@@ -727,31 +727,31 @@ void random_code(uint8_t* dest, unsigned len) {
     bytesToCode(value, (char*)dest, len);
 }
 
-const int DEVICE_ID_LEN = 4;
+const int DEVICE_CODE_LEN = 4;
 
-STATIC_ASSERT(device_id_len_is_same_as_dct_storage, DEVICE_ID_LEN<=DCT_DEVICE_ID_SIZE);
+STATIC_ASSERT(device_code_len_is_same_as_dct_storage, DEVICE_CODE_LEN<=DCT_DEVICE_CODE_SIZE);
 
 
 extern "C" bool fetch_or_generate_setup_ssid(wiced_ssid_t* SSID);
 
 /**
- * Copies the device ID to the destination, generating it if necessary.
+ * Copies the device code to the destination, generating it if necessary.
  * @param dest      A buffer with room for at least 6 characters. The
- *  device ID is copied here, without a null terminator.
- * @return true if the device ID was generated.
+ *  device code is copied here, without a null terminator.
+ * @return true if the device code was generated.
  */
-bool fetch_or_generate_device_id(wiced_ssid_t* SSID) {
-    const uint8_t* suffix = (const uint8_t*)dct_read_app_data(DCT_DEVICE_ID_OFFSET);
+bool fetch_or_generate_device_code(wiced_ssid_t* SSID) {
+    const uint8_t* suffix = (const uint8_t*)dct_read_app_data(DCT_DEVICE_CODE_OFFSET);
     int8_t c = (int8_t)*suffix;    // check out first byte
     bool generate = (!c || c<0);
     uint8_t* dest = SSID->value+SSID->length;
-    SSID->length += DEVICE_ID_LEN;
+    SSID->length += DEVICE_CODE_LEN;
     if (generate) {
-        random_code(dest, DEVICE_ID_LEN);
-        dct_write_app_data(dest, DCT_DEVICE_ID_OFFSET, DEVICE_ID_LEN);
+        random_code(dest, DEVICE_CODE_LEN);
+        dct_write_app_data(dest, DCT_DEVICE_CODE_OFFSET, DEVICE_CODE_LEN);
     }
     else {
-        memcpy(dest, suffix, DEVICE_ID_LEN);
+        memcpy(dest, suffix, DEVICE_CODE_LEN);
     }
     return generate;
 }
@@ -778,7 +778,7 @@ bool fetch_or_generate_ssid_prefix(wiced_ssid_t* SSID) {
 bool fetch_or_generate_setup_ssid(wiced_ssid_t* SSID) {
     bool result = fetch_or_generate_ssid_prefix(SSID);
     SSID->value[SSID->length++] = '-';
-    result |= fetch_or_generate_device_id(SSID);
+    result |= fetch_or_generate_device_code(SSID);
     return result;
 }
 


### PR DESCRIPTION
The soft AP name was broken by the renaming of the `device_id` field in DCT to `device_code` (that's the soft AP suffix) and the addition of a new `device_id` field (that's the 24 char device id). The soft AP code was still using the `device_id` field.

Test:
- Flash develop, put the device in soft AP and see that the soft AP name is Photon-$ (where $ is some weird suffix)
- Flash fix, see the soft AP name is Photon-AW23 (where AW23 is 4 device specific characters).

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
