### PR TITLE
Sync time and unsubscribe called on the system thread

### DIFF
--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -141,6 +141,8 @@ bool spark_function(const char *funcKey, p_user_function_int_str_t pFunc, void* 
 bool spark_send_event(const char* name, const char* data, int ttl, uint32_t flags, void* reserved);
 bool spark_subscribe(const char *eventName, EventHandler handler, void* handler_data,
         Spark_Subscription_Scope_TypeDef scope, const char* deviceID, void* reserved);
+void spark_unsubscribe(void *reserved);
+bool spark_sync_time(void *reserved);
 
 
 void spark_process(void);

--- a/system/inc/system_dynalib_cloud.h
+++ b/system/inc/system_dynalib_cloud.h
@@ -43,6 +43,8 @@ DYNALIB_FN(6, system_cloud, system_cloud_protocol_instance, ProtocolFacade*(void
 DYNALIB_FN(7, system_cloud, spark_deviceID, String(void))
 DYNALIB_FN(8, system_cloud, spark_send_event, bool(const char*, const char*, int, uint32_t, void*))
 DYNALIB_FN(9, system_cloud, spark_subscribe, bool(const char*, EventHandler, void*, Spark_Subscription_Scope_TypeDef, const char*, void*))
+DYNALIB_FN(10, system_cloud, spark_unsubscribe, void(void*))
+DYNALIB_FN(11, system_cloud, spark_sync_time, bool(void*))
 
 DYNALIB_END(system_cloud)
 

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -69,6 +69,18 @@ bool spark_subscribe(const char *eventName, EventHandler handler, void* handler_
     return success;
 }
 
+void spark_unsubscribe(void *reserved)
+{
+    SYSTEM_THREAD_CONTEXT_ASYNC(spark_unsubscribe(reserved));
+    spark_protocol_remove_event_handlers(sp, NULL);
+}
+
+bool spark_sync_time(void *reserved)
+{
+    SYSTEM_THREAD_CONTEXT_SYNC(spark_sync_time(reserved));
+    return spark_protocol_send_time_request(sp);
+}
+
 /**
  * Convert from the API flags to the communications lib flags
  * The event visibility flag (public/private) is encoded differently. The other flags map directly.

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -276,12 +276,12 @@ public:
 
     void unsubscribe()
     {
-        CLOUD_FN(spark_protocol_remove_event_handlers(sp(), NULL), (void)0);
+        CLOUD_FN(spark_unsubscribe(NULL), (void)0);
     }
 
     bool syncTime(void)
     {
-        return CLOUD_FN(spark_protocol_send_time_request(sp()),false);
+        return CLOUD_FN(spark_sync_time(NULL), false);
     }
 
     static void sleep(long seconds) __attribute__ ((deprecated("Please use System.sleep() instead.")))


### PR DESCRIPTION
Calling `Particle.syncTime()` in a multithreaded app has a small chance of crashing the system if the system thread is currently calling network functions too.

The fix is to call `Particle.syncTime()` on the system thread.

App to reproduce:
```
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);

void setup()
{
  Serial.blockOnOverrun(true); //don't ever block for serial integrity
  Serial.begin(9600);

  WiFi.on();
  WiFi.connect();
  Particle.connect();
  
  Serial.println("breatheGreen5");
}

static unsigned long millisOfLastPublish = 0;
static unsigned long millisOfLastTimeSync = 0;

void loop()
{
  Particle.process();

  if( Particle.connected() )
  {
    if( ( millis() - millisOfLastPublish ) > (unsigned long)random(260, 500) )
    {
      millisOfLastPublish = millis();
      Serial.println("Publishing event");
      Particle.publish("event", " fjksdas " + String(millisOfLastPublish) );
    }

    if( ( millis() - millisOfLastTimeSync ) > 1 )
    {
      Serial.println("timeSync: " + String( Particle.syncTime() ) );
      millisOfLastTimeSync = millis(); 
    }
  }
}
```

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
Prevents issues when multiple threads try to send messages through the cloud connection or manage the network state shared memory.