### PR TITLE
photon backup memory

### DIFF
--- a/hal/src/photon/wiced/platform/MCU/STM32F2xx/GCC/app_no_bootloader.ld
+++ b/hal/src/photon/wiced/platform/MCU/STM32F2xx/GCC/app_no_bootloader.ld
@@ -164,8 +164,8 @@ SECTIONS
         link_stack_end = .;
     }> SRAM AT> SRAM
 
-    INCLUDE backup_ram_system.ld
     INCLUDE backup_ram_user.ld
+    INCLUDE backup_ram_system.ld
 
     /DISCARD/ :
     {

--- a/modules/photon/system-part2/linker.ld
+++ b/modules/photon/system-part2/linker.ld
@@ -14,6 +14,8 @@ MEMORY
        The value given here is the sum of system_static_ram_size and stack_size
     */
     SRAM      (rwx) : ORIGIN = 0x20020000 - 42K, LENGTH = 42K
+    
+   	INCLUDE backup_ram_memory.ld
 }
 
 

--- a/user/tests/app/backup_ram/backup_ram.cpp
+++ b/user/tests/app/backup_ram/backup_ram.cpp
@@ -18,19 +18,25 @@
  */
 #include "application.h"
 
-retained int variable = 10;
+retained int app_backup = 10;
+int app_ram = 10;
+
+STARTUP(System.disableFeature(FEATURE_RETAINED_MEMORY));
 
 void setup()
 {
-	System.enableFeature(FEATURE_RETAINED_MEMORY);
-	Serial.begin(9600);
-	while (!Serial.available()) Particle.process();
+    Serial.begin(9600);
+    while (!Serial.available()) Particle.process();
 
-	if (int(&variable) < 0x30000000) {
-		Serial.printlnf("ERROR: expected variable in backup memory, but was at %x", &variable);
-		return;
-	}
+    if (int(&app_backup) < 0x40024000) {
+        Serial.printlnf("ERROR: expected app_backup in backup memory, but was at %x", &app_backup);
+    }
 
-	Serial.println(variable);
-	variable++;
+    if (int(&app_ram) >= 0x40024000) {
+        Serial.printlnf("ERROR: expected app_ram in sram memory, but was at %x", &app_ram);
+    }
+
+    Serial.printlnf("app_backup(%x):%d, app_ram(%x):%d", &app_backup, app_backup, &app_ram, app_ram);
+    app_backup++;
+    app_ram++;
 }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -183,3 +183,23 @@ test(system_flags)
     API_COMPILE(System.disable(SYSTEM_FLAG_MAX));
     API_COMPILE(System.enabled(SYSTEM_FLAG_MAX));
 }
+
+// todo - use platform feature flags
+#if defined(STM32F2XX)
+#define USER_BACKUP_RAM (1024*3)
+#endif
+
+#if defined(USER_BACKUP_RAM)
+// 4 bytes for signature
+static retained uint8_t app_backup[USER_BACKUP_RAM-4];
+
+test(backup_ram)
+{
+	int total = 0;
+	for (unsigned i=0; i<sizeof(app_backup); i++) {
+		total += app_backup[i];		// 8 bytes for the
+	}
+	Serial.println(total);
+}
+
+#endif

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -186,15 +186,17 @@ test(system_flags)
 
 // todo - use platform feature flags
 #if defined(STM32F2XX)
-#define USER_BACKUP_RAM (1024*3)
-#endif
+    // subtract 4 bytes for signature (3068 bytes)
+    #define USER_BACKUP_RAM ((1024*3)-4)
+#endif // defined(STM32F2XX)
 
 #if defined(USER_BACKUP_RAM)
-// 4 bytes for signature
-static retained uint8_t app_backup[USER_BACKUP_RAM-4];
+static retained uint8_t app_backup[USER_BACKUP_RAM];
 
 test(backup_ram)
 {
+    // Not designed to be run!
+    // only here to prevent compiler from optimizing out the app_backup array.
 	int total = 0;
 	for (unsigned i=0; i<sizeof(app_backup); i++) {
 		total += app_backup[i];		// 8 bytes for the
@@ -202,4 +204,4 @@ test(backup_ram)
 	Serial.println(total);
 }
 
-#endif
+#endif // defined(USER_BACKUP_RAM)

--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -4,7 +4,7 @@
 
 
 #if PLATFORM_ID >= 3
-test(System_FreeMemory)
+test(SYSTEM_01_freeMemory)
 {
     // this test didn't work on the core attempting to allocate the current value of
     // freeMemory(), presumably because of fragmented heap from
@@ -22,7 +22,7 @@ test(System_FreeMemory)
 }
 #endif
 
-test(system_version)
+test(SYSTEM_02_version)
 {
     uint32_t versionNumber = System.versionNumber();
     // Serial.println(System.versionNumber()); // 328193 -> 0x00050201
@@ -35,3 +35,44 @@ test(system_version)
 
     assertTrue(strcmp(expected,System.version().c_str())==0);
 }
+
+// todo - use platform feature flags
+#if defined(STM32F2XX)
+    // subtract 4 bytes for signature (3068 bytes)
+    #define USER_BACKUP_RAM ((1024*3)-4)
+#endif // defined(STM32F2XX)
+
+#if defined(USER_BACKUP_RAM)
+
+STARTUP(System.enableFeature(FEATURE_RETAINED_MEMORY));
+
+static retained uint8_t app_backup[USER_BACKUP_RAM];
+static uint8_t app_ram[USER_BACKUP_RAM];
+
+test(SYSTEM_03_user_backup_ram)
+{
+    int total_backup = 0;
+    int total_ram = 0;
+    for (unsigned i=0; i<(sizeof(app_backup)/sizeof(app_backup[0])); i++) {
+        app_backup[i] = 1;
+        app_ram[i] = 1;
+        total_backup += app_backup[i];
+        total_ram += app_ram[i];
+    }
+    // Serial.printlnf("app_backup(0x%x), app_ram(0x%x)", &app_backup, &app_ram);
+    // Serial.printlnf("total_backup: %d, total_ram: %d", total_backup, total_ram);
+    assertTrue(total_backup==(USER_BACKUP_RAM));
+    assertTrue(total_ram==(USER_BACKUP_RAM));
+
+    if (int(&app_backup) < 0x40024000) {
+        Serial.printlnf("ERROR: expected app_backup in user backup memory, but was at %x", &app_backup);
+    }
+    assertTrue(int(&app_backup)>=0x40024000);
+
+    if (int(&app_ram) >= 0x40024000) {
+        Serial.printlnf("ERROR: expected app_ram in user sram memory, but was at %x", &app_ram);
+    }
+    assertTrue(int(&app_ram)<0x40024000);
+}
+
+#endif // defined(USER_BACKUP_RAM)


### PR DESCRIPTION
adds system backup memory on the Photon (1K - same size as electron) reducing user backup memory to 3K.  api tests confirm that 3K is available for the user app.


---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)