### PR TITLE
I2C improvements

### DIFF
--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -350,16 +350,18 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
 
             return 0;
         }
-    }
-    /* Send START condition */
-    I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
-    if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
-    {
-        /* SW Reset the I2C Peripheral */
-        HAL_I2C_SoftwareReset(i2c);
+        /* Send START condition */
+        I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
-        return 0;
+        if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
+        {
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
+
+            return 0;
+        }
+
     }
 
     /* Initialized variables here to minimize delays
@@ -402,6 +404,8 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
         (void)i2cMap[i2c]->I2C_Peripheral->SR2;
         if (stop)
             I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+        else
+            I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
         HAL_enable_irq(state);
 
         // Wait for RXNE
@@ -437,6 +441,8 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
         state = HAL_disable_irq();
         if (stop)
             I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+        else
+            I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
         *(pBuffer++) = I2C_ReceiveData(i2cMap[i2c]->I2C_Peripheral);
         HAL_enable_irq(state);
@@ -499,6 +505,8 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
 
         if (stop)
             I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+        else
+            I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
         // Byte N-1
         *(pBuffer++) = I2C_ReceiveData(i2cMap[i2c]->I2C_Peripheral);
@@ -516,6 +524,8 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
         (void)i2cMap[i2c]->I2C_Peripheral->SR2;
         if (stop)
             I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+        else
+            I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
     }
 
     if (stop)
@@ -533,6 +543,14 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
     else
     {
         i2cMap[i2c]->prevEnding = I2C_ENDING_START;
+
+        if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
+        {
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
+
+            return 0;
+        }
     }
 
     // set rx buffer iterator vars
@@ -565,16 +583,17 @@ uint8_t HAL_I2C_End_Transmission(HAL_I2C_Interface i2c, uint8_t stop, void* rese
 
             return 1;
         }
-    }
-    /* Send START condition */
-    I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
-    if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
-    {
-        /* SW Reset the I2C Peripheral */
-        HAL_I2C_SoftwareReset(i2c);
+        /* Send START condition */
+        I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
-        return 2;
+        if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
+        {
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
+
+            return 2;
+        }
     }
 
     /* Ensure ackFailure flag is cleared */
@@ -646,13 +665,24 @@ uint8_t HAL_I2C_End_Transmission(HAL_I2C_Interface i2c, uint8_t stop, void* rese
             /* SW Reset the I2C Peripheral */
             HAL_I2C_SoftwareReset(i2c);
 
-            return 0;
+            return 6;
         }
         i2cMap[i2c]->prevEnding = I2C_ENDING_STOP;
     }
     else
     {
         i2cMap[i2c]->prevEnding = I2C_ENDING_START;
+
+        /* Send START condition */
+        I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+
+        if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
+        {
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
+
+            return 7;
+        }
     }
 
     // reset tx buffer iterator vars

--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -32,6 +32,8 @@
 #include "service_debug.h"
 #include "interrupts_hal.h"
 
+LOG_SOURCE_CATEGORY("hal.i2c")
+
 /* Private typedef -----------------------------------------------------------*/
 
 /* Private define ------------------------------------------------------------*/
@@ -49,6 +51,27 @@
 #else
 #define TOTAL_I2C   1
 #endif
+
+#define I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED_NO_ADDR ((uint32_t)0x00070080)
+
+#define WAIT_TIMED(what) ({ \
+    uint32_t _micros = HAL_Timer_Get_Micro_Seconds();                           \
+    bool res = true;                                                            \
+    while((what))                                                               \
+    {                                                                           \
+        int32_t dt = (HAL_Timer_Get_Micro_Seconds() - _micros);                 \
+        bool nok = ((EVENT_TIMEOUT < dt)                                         \
+                   && (what))                                                   \
+                   || (dt < 0);                                                   \
+        if (nok)                                                                \
+        {                                                                       \
+            res = false;                                                        \
+            break;                                                              \
+        }                                                                       \
+    }                                                                           \
+    res;                                                                        \
+})
+
 
 /* Private typedef -----------------------------------------------------------*/
 typedef enum I2C_Num_Def {
@@ -298,7 +321,6 @@ void HAL_I2C_End(HAL_I2C_Interface i2c, void* reserved)
 
 uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t quantity, uint8_t stop, void* reserved)
 {
-    uint32_t _micros;
     uint8_t bytesRead = 0;
     int state;
 
@@ -318,32 +340,24 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
 
     if (i2cMap[i2c]->prevEnding != I2C_ENDING_START)
     {
-        _micros = HAL_Timer_Get_Micro_Seconds();
         /* While the I2C Bus is busy */
-        while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BUSY))
-        {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
-
-                return 0;
-            }
-        }
-    }
-    /* Send START condition */
-    I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
-
-    _micros = HAL_Timer_Get_Micro_Seconds();
-    while(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT))
-    {
-        if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
+        if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BUSY)))
         {
             /* SW Reset the I2C Peripheral */
             HAL_I2C_SoftwareReset(i2c);
 
             return 0;
         }
+    }
+    /* Send START condition */
+    I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+
+    if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
+    {
+        /* SW Reset the I2C Peripheral */
+        HAL_I2C_SoftwareReset(i2c);
+
+        return 0;
     }
 
     /* Initialized variables here to minimize delays
@@ -358,33 +372,23 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
     /* Send Slave address for read */
     I2C_Send7bitAddress(i2cMap[i2c]->I2C_Peripheral, address << 1, I2C_Direction_Receiver);
 
-    _micros = HAL_Timer_Get_Micro_Seconds();
-    while(!I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_ADDR))
+    if((!WAIT_TIMED(!I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_ADDR) && !i2cMap[i2c]->ackFailure)) ||
+        i2cMap[i2c]->ackFailure)
     {
-        /* STOP/RESET immediately if ACK failure detected */
-        if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros) || i2cMap[i2c]->ackFailure)
+        /* Send STOP Condition */
+        I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+
+        /* Wait to make sure that STOP control bit has been cleared */
+        if (!WAIT_TIMED(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP))
         {
-            /* Send STOP Condition */
-            I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
-
-            /* Wait to make sure that STOP control bit has been cleared */
-            _micros = HAL_Timer_Get_Micro_Seconds();
-            while(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP)
-            {
-                if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-                {
-                    break;
-                }
-            }
-
             /* SW Reset the I2C Peripheral */
             HAL_I2C_SoftwareReset(i2c);
-
-            /* Ensure ackFailure flag is cleared */
-            i2cMap[i2c]->ackFailure = false;
-
-            return 0;
         }
+
+        /* Ensure ackFailure flag is cleared */
+        i2cMap[i2c]->ackFailure = false;
+
+        return 0;
     }
 
     if (quantity == 1)
@@ -399,15 +403,12 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
         HAL_enable_irq(state);
 
         // Wait for RXNE
-        while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_RXNE) == RESET)
+        if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_RXNE) == RESET))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 0;
-            }
+            return 0;
         }
 
         *(pBuffer++) = I2C_ReceiveData(i2cMap[i2c]->I2C_Peripheral);
@@ -423,15 +424,12 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
         I2C_AcknowledgeConfig(i2cMap[i2c]->I2C_Peripheral, DISABLE);
         HAL_enable_irq(state);
 
-        while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET)
+        if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 0;
-            }
+            return 0;
         }
 
         state = HAL_disable_irq();
@@ -463,16 +461,12 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
         (void)i2cMap[i2c]->I2C_Peripheral->SR2;
         while(numByteToRead > 3)
         {
-            _micros = HAL_Timer_Get_Micro_Seconds();
-            while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET)
+            if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET))
             {
-                if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-                {
-                    /* SW Reset the I2C Peripheral */
-                    HAL_I2C_SoftwareReset(i2c);
+                /* SW Reset the I2C Peripheral */
+                HAL_I2C_SoftwareReset(i2c);
 
-                    return 0;
-                }
+                return 0;
             }
 
             *(pBuffer++) = I2C_ReceiveData(i2cMap[i2c]->I2C_Peripheral);
@@ -481,31 +475,24 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
         }
 
         // Last 3 bytes
-        _micros = HAL_Timer_Get_Micro_Seconds();
-        while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET)
+        if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 0;
-            }
+            return 0;
         }
 
         I2C_AcknowledgeConfig(i2cMap[i2c]->I2C_Peripheral, DISABLE);
 
         // Byte N-2
         *(pBuffer++) = I2C_ReceiveData(i2cMap[i2c]->I2C_Peripheral);
-        while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET)
+        if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 0;
-            }
+            return 0;
         }
 
         if (stop)
@@ -532,16 +519,12 @@ uint32_t HAL_I2C_Request_Data(HAL_I2C_Interface i2c, uint8_t address, uint8_t qu
     if (stop)
     {
         /* Wait to make sure that STOP control bit has been cleared */
-        _micros = HAL_Timer_Get_Micro_Seconds();
-        while(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP)
+        if (!WAIT_TIMED(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 0;
-            }
+            return 0;
         }
         i2cMap[i2c]->prevEnding = I2C_ENDING_STOP;
     }
@@ -570,36 +553,26 @@ void HAL_I2C_Begin_Transmission(HAL_I2C_Interface i2c, uint8_t address, void* re
 
 uint8_t HAL_I2C_End_Transmission(HAL_I2C_Interface i2c, uint8_t stop, void* reserved)
 {
-    uint32_t _micros;
-
     if (i2cMap[i2c]->prevEnding != I2C_ENDING_START)
     {
-        _micros = HAL_Timer_Get_Micro_Seconds();
         /* While the I2C Bus is busy */
-        while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BUSY))
+        if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BUSY)))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 1;
-            }
+            return 1;
         }
     }
     /* Send START condition */
     I2C_GenerateSTART(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
-    _micros = HAL_Timer_Get_Micro_Seconds();
-    while(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT))
+    if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_MODE_SELECT)))
     {
-        if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-        {
-            /* SW Reset the I2C Peripheral */
-            HAL_I2C_SoftwareReset(i2c);
+        /* SW Reset the I2C Peripheral */
+        HAL_I2C_SoftwareReset(i2c);
 
-            return 2;
-        }
+        return 2;
     }
 
     /* Ensure ackFailure flag is cleared */
@@ -608,70 +581,56 @@ uint8_t HAL_I2C_End_Transmission(HAL_I2C_Interface i2c, uint8_t stop, void* rese
     /* Send Slave address for write */
     I2C_Send7bitAddress(i2cMap[i2c]->I2C_Peripheral, i2cMap[i2c]->txAddress, I2C_Direction_Transmitter);
 
-    _micros = HAL_Timer_Get_Micro_Seconds();
-    while(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED))
+    if((!WAIT_TIMED(!I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_ADDR) && !i2cMap[i2c]->ackFailure)) ||
+        i2cMap[i2c]->ackFailure)
     {
-        /* STOP/RESET immediately if ACK failure detected */
-        if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros) || i2cMap[i2c]->ackFailure)
+        /* Send STOP Condition */
+        I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
+
+        /* Wait to make sure that STOP control bit has been cleared */
+        if (!WAIT_TIMED(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP))
         {
-            /* Send STOP Condition */
-            I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
-
-            /* Wait to make sure that STOP control bit has been cleared */
-            _micros = HAL_Timer_Get_Micro_Seconds();
-            while(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP)
-            {
-                if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-                {
-                    break;
-                }
-            }
-
             /* SW Reset the I2C Peripheral */
             HAL_I2C_SoftwareReset(i2c);
-
-            /* Ensure ackFailure flag is cleared */
-            i2cMap[i2c]->ackFailure = false;
-
-            return 3;
         }
+
+        /* Ensure ackFailure flag is cleared */
+        i2cMap[i2c]->ackFailure = false;
+
+        return 3;
+    }
+
+    if (!WAIT_TIMED(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED_NO_ADDR)))
+    {
+        /* SW Reset the I2C Peripheral */
+        HAL_I2C_SoftwareReset(i2c);
+
+        return 31;
     }
 
     uint8_t *pBuffer = i2cMap[i2c]->txBuffer;
     uint8_t NumByteToWrite = i2cMap[i2c]->txBufferLength;
 
+    if (NumByteToWrite)
+    {
+        // Send first byte
+        I2C_SendData(i2cMap[i2c]->I2C_Peripheral, *pBuffer);
+        pBuffer++;
+        NumByteToWrite--;
+    }
+
     /* While there is data to be written */
     while(NumByteToWrite--)
     {
-        /* Send the current byte to slave */
-        I2C_SendData(i2cMap[i2c]->I2C_Peripheral, *pBuffer);
-
-        /* Point to the next byte to be written */
-        pBuffer++;
-
-        _micros = HAL_Timer_Get_Micro_Seconds();
-        while(!I2C_CheckEvent(i2cMap[i2c]->I2C_Peripheral, I2C_EVENT_MASTER_BYTE_TRANSMITTING))
+        if (!WAIT_TIMED(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 4;
-            }
+            return 5;
         }
 
-        _micros = HAL_Timer_Get_Micro_Seconds();
-        while(I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_BTF) == RESET)
-        {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
-
-                return 5;
-            }
-        }
+        I2C_SendData(i2cMap[i2c]->I2C_Peripheral, *(pBuffer++));
     }
 
     /* Send STOP Condition */
@@ -680,16 +639,12 @@ uint8_t HAL_I2C_End_Transmission(HAL_I2C_Interface i2c, uint8_t stop, void* rese
         /* Send STOP condition */
         I2C_GenerateSTOP(i2cMap[i2c]->I2C_Peripheral, ENABLE);
 
-        _micros = HAL_Timer_Get_Micro_Seconds();
-        while(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP)
+        if (!WAIT_TIMED(i2cMap[i2c]->I2C_Peripheral->CR1 & I2C_CR1_STOP))
         {
-            if(EVENT_TIMEOUT < (HAL_Timer_Get_Micro_Seconds() - _micros))
-            {
-                /* SW Reset the I2C Peripheral */
-                HAL_I2C_SoftwareReset(i2c);
+            /* SW Reset the I2C Peripheral */
+            HAL_I2C_SoftwareReset(i2c);
 
-                return 0;
-            }
+            return 0;
         }
         i2cMap[i2c]->prevEnding = I2C_ENDING_STOP;
     }

--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -32,7 +32,9 @@
 #include "service_debug.h"
 #include "interrupts_hal.h"
 
+#ifdef LOG_SOURCE_CATEGORY
 LOG_SOURCE_CATEGORY("hal.i2c")
+#endif // LOG_SOURCE_CATEGORY
 
 /* Private typedef -----------------------------------------------------------*/
 

--- a/user/tests/app/weather3/HTU21D.cpp
+++ b/user/tests/app/weather3/HTU21D.cpp
@@ -13,8 +13,6 @@ bool HTU21D::begin(void)
 {
 	// Only join the I2C bus as master if needed
 	if(! Wire.isEnabled()) {
-		// Wire.setSpeed(100000);   // Tried lower frequencies, did not help
-		// Wire.stretchClock(true); // Did not help
 		Wire.begin();
 	}
 
@@ -67,11 +65,11 @@ float HTU21D::readTemperature(){
 //	Serial.println("Slave Address...");
 	Wire.beginTransmission(HTDU21D_ADDRESS);
 //	Serial.print("Write: ");
-	// rv = 
+	// rv =
 	Wire.write(TRIGGER_TEMP_MEASURE_NOHOLD);
 //	Serial.println(rv);
 //	Serial.print("End Transmission: ");
-	// rv = 
+	// rv =
 	Wire.endTransmission(true);
 //	Serial.println(rv);
 
@@ -79,7 +77,7 @@ float HTU21D::readTemperature(){
 	delay(55); // 50ms measure time for 14bit measures
 
 //	Serial.print("Request From: ");
-	// rv = 
+	// rv =
 	if (Wire.requestFrom(HTDU21D_ADDRESS, 3) != 3)
 		return HTU21D_I2C_TIMEOUT; // if all data not received
 //	Serial.println(rv);
@@ -118,7 +116,7 @@ void HTU21D::setResolution(byte resolution)
   userRegister &= 0b01111110; //Turn off the resolution bits
   resolution &= 0b10000001; //Turn off all other bits but resolution bits
   userRegister |= resolution; //Mask in the requested resolution bits
-  
+
   //Request a write to user register
   Wire.beginTransmission(HTDU21D_ADDRESS);
   Wire.write(WRITE_USER_REG); //Write to the user register

--- a/user/tests/app/weather3/SparkFun_MPL3115A2.cpp
+++ b/user/tests/app/weather3/SparkFun_MPL3115A2.cpp
@@ -47,8 +47,6 @@ bool MPL3115A2::begin()
 {
 	// Only join the I2C bus as master if needed
 	if(! Wire.isEnabled()) {
-		// Wire.setSpeed(100000);   // Tried lower frequencies, did not help
-		// Wire.stretchClock(true); // Did not help
 		Wire.begin();
 	}
 
@@ -69,10 +67,10 @@ float MPL3115A2::readAltitude()
 	toggleOneShot(); //Toggle the OST bit causing the sensor to immediately take another reading
 
 	//Wait for PDR bit, indicates we have new pressure data
-	int counter = 0;
+	uint32_t startTime = millis();
 	while( (IIC_Read(STATUS) & (1<<1)) == 0)
 	{
-		if(++counter > 600) return(-999); //Error out after max of 512ms for a read
+		if(millis() - startTime > 512UL) return(-999); //Error out after max of 512ms for a read
 		delayMicroseconds(1000);
 	}
 
@@ -285,38 +283,50 @@ void MPL3115A2::toggleOneShot(void)
 // These are the two I2C functions in this sketch.
 byte MPL3115A2::IIC_Read(byte regAddr)
 {
-//  uint8_t rv = 0;
-//  This function reads one byte over IIC
-//  Serial.print("SA");
+ // uint8_t rv = 0;
+ //This function reads one byte over IIC
+ 	//Serial.print("RD-SA");
   	Wire.beginTransmission(MPL3115A2_ADDRESS);
-//  Serial.print(",W:");
-//  rv = 
-	Wire.write(regAddr);  // Address of CTRL_REG1
-//  Serial.print(rv);
-//  Serial.print(",ET:");
-//  rv = 
-	Wire.endTransmission(false); // Send data to I2C dev with option for a repeated start. THIS IS NECESSARY and not supported before Arduino V1.0.1!
-//  Serial.print(rv);
-//  delay(5);
-//  Serial.print(",RF:");
-  	if (Wire.requestFrom(MPL3115A2_ADDRESS, 1) == 1) // Request the data...
-  		return (Wire.read());
+ // Serial.print(",W:");
+ // rv =
+ 	Wire.write(regAddr);  // Address of CTRL_REG1
+ // Serial.print(rv);
+ // Serial.print(",ET:");
+    byte rv = Wire.endTransmission(false); // Send data to I2C dev with option for a repeated start. THIS IS NECESSARY and not supported before Arduino V1.0.1!
+    byte rv2 = Wire.requestFrom(MPL3115A2_ADDRESS, 1);
+    // Serial.print(rv);
+    // Serial.print(",RF:");
+  	if (rv2 == 1) { // Request the data...
+  		// Serial.print(rv2);
+  		// Serial.print(",R:");
+		byte rv3 = Wire.read();
+ 		// Serial.println(rv3);
+  		return rv3;
+  	}
   	else
+  	{
+  		// Serial.println(0);
   		return 0; // 0 will keep STATUS waiting
-//  Serial.print(rv);
-//  Serial.print(",R:");
-// 	byte rv2 = Wire.read();
-//  Serial.println(rv2);
-//  delay(5);
-// 	return rv2;
+  	}
 }
 
 void MPL3115A2::IIC_Write(byte regAddr, byte value)
 {
   // This function writes one byto over IIC
+  // uint8_t rv = 0;
+  // Serial.print("WR-SA");
   Wire.beginTransmission(MPL3115A2_ADDRESS);
+  // Serial.print(",W:");
+  // rv =
   Wire.write(regAddr);
+  // Serial.print(rv);
+  // Serial.print(",W:");
+  // rv =
   Wire.write(value);
+  // Serial.print(rv);
+  // Serial.print(",ET:");
+  // rv =
   Wire.endTransmission(true);
+  // Serial.println(rv);
   //delay(5);
 }

--- a/user/tests/app/weather3/SparkFun_MPL3115A2.cpp
+++ b/user/tests/app/weather3/SparkFun_MPL3115A2.cpp
@@ -292,7 +292,8 @@ byte MPL3115A2::IIC_Read(byte regAddr)
  	Wire.write(regAddr);  // Address of CTRL_REG1
  // Serial.print(rv);
  // Serial.print(",ET:");
-    byte rv = Wire.endTransmission(false); // Send data to I2C dev with option for a repeated start. THIS IS NECESSARY and not supported before Arduino V1.0.1!
+    // byte rv = 
+    Wire.endTransmission(false); // Send data to I2C dev with option for a repeated start. THIS IS NECESSARY and not supported before Arduino V1.0.1!
     byte rv2 = Wire.requestFrom(MPL3115A2_ADDRESS, 1);
     // Serial.print(rv);
     // Serial.print(",RF:");

--- a/user/tests/app/weather3/SparkFun_Photon_Weather_Basic.cpp
+++ b/user/tests/app/weather3/SparkFun_Photon_Weather_Basic.cpp
@@ -40,6 +40,13 @@
 SYSTEM_MODE(MANUAL);
 SYSTEM_THREAD(ENABLED);
 
+#if Wiring_WiFi
+  STARTUP(WiFi.selectAntenna(ANT_INTERNAL));
+#endif
+
+// ALL_LEVEL, TRACE_LEVEL, DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, PANIC_LEVEL, NO_LOG_LEVEL
+// SerialDebugOutput debugOutput(115200, DEBUG_LEVEL);
+
 float humidity = 0;
 float tempf = 0;
 float pascals = 0;
@@ -51,6 +58,7 @@ int count = 0;
 HTU21D htu = HTU21D();//create instance of HTU21D Temp and humidity sensor
 MPL3115A2 baro = MPL3115A2();//create instance of MPL3115A2 barrometric sensor
 
+void setupBaro();
 void printInfo();
 void getTempHumidity();
 void getBaro();
@@ -59,9 +67,8 @@ void calcWeather();
 //---------------------------------------------------------------
 void setup()
 {
-    Serial.begin(9600);   // open serial over USB at 9600 baud
+    //Serial.begin(9600);   // open serial over USB at 9600 baud
 
-    //Initialize both on-board sensors
     //Initialize both on-board sensors
     while(! htu.begin()){
   	    Serial.println("HTU21D not found");
@@ -75,25 +82,20 @@ void setup()
      }
      Serial.println("MPL3115A2 OK");
 
-     //MPL3115A2 Settings
-     //baro.setModeBarometer();//Set to Barometer Mode
-     baro.setModeAltimeter();//Set to altimeter Mode
-
-     baro.setOversampleRate(7); // Set Oversample to the recommended 128
-     baro.enableEventFlags(); //Necessary register calls to enble temp, baro ansd alt
-
+    // MPL3115A2 Settings
+    setupBaro();
 }
 //---------------------------------------------------------------
 void loop()
 {
     // Button press needs to be 1 second long
     if (HAL_Core_Mode_Button_Pressed(1000)) {
-        if (!Spark.connected()) {
+        if (!Particle.connected()) {
             WiFi.on();
-            Spark.connect();
+            Particle.connect();
         }
         else {
-            Spark.disconnect();
+            Particle.disconnect();
             WiFi.off();
         }
         // delay 2.1 more seconds before resetting debounce time
@@ -102,7 +104,9 @@ void loop()
         HAL_Core_Mode_Button_Reset();
     }
 
-    //Get readings from all sensors
+    // in case of bus errors, re-setup baro sensor to auto recover
+    setupBaro();
+    // Get readings from all sensors
     calcWeather();
     printInfo();
 
@@ -117,7 +121,16 @@ void loop()
        count = 0;
     }
     */
-    Spark.process();
+    Particle.process();
+}
+//---------------------------------------------------------------
+void setupBaro()
+{
+    //MPL3115A2 Settings
+    //baro.setModeBarometer();//Set to Barometer Mode
+    baro.setModeAltimeter();//Set to altimeter Mode
+    baro.setOversampleRate(7); // Set Oversample to the recommended 128
+    baro.enableEventFlags(); //Necessary register calls to enble temp, baro ansd alt
 }
 //---------------------------------------------------------------
 void printInfo()
@@ -137,28 +150,28 @@ void printInfo()
     //return;
 
     //Or you can print each temp separately
-    Serial.print("HTU21D Temp:");
+    Serial.print("HTU21D T:");
     Serial.print(tempf);
     Serial.print("F, ");
     if (abs(tempf)>1000) errors++;
 
-    Serial.print("Humidity:");
+    Serial.print("H:");
     Serial.print(humidity);
     Serial.print("%, ");
     if (abs(humidity)>200) errors++;
 
-    Serial.print("Baro Temp:");
+    Serial.print("| MPL3115A2 T:");
     Serial.print(baroTemp);
     Serial.print("F, ");
     //Serial.println();
     if (abs(baroTemp)>1000) errors++;
 
-    Serial.print("Pressure:");
+    Serial.print("P:");
     Serial.print(pascals);
     Serial.print("Pa, ");
-    if (abs(pascals)>900) errors++;
+    if (pascals < -990) errors++;
 
-    Serial.print("Altitude:");
+    Serial.print("A:");
     Serial.print(altf);
     Serial.print("ft, ");
     if (abs(altf)>3200) errors++;
@@ -185,13 +198,8 @@ void getTempHumidity()
 void getBaro()
 {
   baroTemp = baro.readTempF();//get the temperature in F
-  //delay(100);
-
   pascals = baro.readPressure();//get pressure in Pascals
-  //delay(20);
-
   altf = baro.readAltitudeFt();//get altitude in feet
-  //delay(100);
 }
 //---------------------------------------------------------------
 void calcWeather()

--- a/user/tests/wiring/i2c_mcp23017/application.cpp
+++ b/user/tests/wiring/i2c_mcp23017/application.cpp
@@ -1,6 +1,7 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
-SYSTEM_MODE(SEMI_AUTOMATIC);
+SYSTEM_MODE(AUTOMATIC);
+SYSTEM_THREAD(ENABLED);
 
 UNIT_TEST_APP();

--- a/user/tests/wiring/i2c_mcp23017/i2c.cpp
+++ b/user/tests/wiring/i2c_mcp23017/i2c.cpp
@@ -1,0 +1,31 @@
+#include <algorithm>
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "i2c_helper.h"
+
+test(0_I2C_scanBus) {
+    i2c::reset();
+
+    uint32_t ts1 = 0, ts2 = 0;
+    // Scan I2C bus
+    for (uint8_t addr = 0x01; addr < 0x7f; addr++) {
+        ts1 = millis();
+        Wire.beginTransmission(addr);
+        int32_t err = Wire.endTransmission();
+        ts2 = millis();
+
+        if (err == 0) {
+            i2c::devices.push_back(addr);
+            DEBUG("I2C device @ 0x%02x", addr);
+        } else if (err == 0x03) {
+            // No one ACKed the address
+            // Check that this doesn't cause standard 100ms delay in I2C HAL
+            assertMoreOrEqual(ts2, ts1);
+            assertLessOrEqual(ts2 - ts1, 50);
+        } else {
+            DEBUG("err @ 0x%02x %d", addr, err);
+        }
+    }
+
+    assertEqual(i2c::errorCount, 0);
+}

--- a/user/tests/wiring/i2c_mcp23017/i2c_helper.cpp
+++ b/user/tests/wiring/i2c_mcp23017/i2c_helper.cpp
@@ -1,0 +1,97 @@
+#include "application.h"
+#include "i2c_helper.h"
+
+namespace i2c {
+
+uint32_t errorCount = 0;
+std::vector<uint8_t> devices;
+
+void reset() {
+    Wire.setSpeed(400000);
+    Wire.begin();
+    // Just in case reset the bus
+    Wire.reset();
+
+    errorCount = 0;
+}
+
+int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t val, bool stop) {
+    Wire.beginTransmission(slaveAddress);
+    Wire.write(addr);
+    Wire.write(val);
+    int32_t err = -Wire.endTransmission(stop);
+    if (err < 0) {
+        ++errorCount;
+        ERROR("%d e %d 0x%02x 0x%02x 1 %d", errorCount, err, slaveAddress, addr, stop);
+    }
+    return err;
+}
+
+int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_t len, bool stop) {
+    Wire.beginTransmission(slaveAddress);
+    Wire.write(addr);
+    Wire.write(buffer, len);
+    int32_t err = -Wire.endTransmission(stop);
+    if (err < 0) {
+        ++errorCount;
+        ERROR("%d e %d 0x%02x 0x%02x %d %d", errorCount, err, slaveAddress, addr, len, stop);
+    }
+    return err;
+}
+
+int32_t readRegister(uint8_t slaveAddress, uint8_t addr, bool stop, bool stopAfterWrite) {
+    Wire.beginTransmission(slaveAddress);
+    Wire.write(addr);
+    int32_t err = -Wire.endTransmission(stopAfterWrite);
+    if (err == 0) {
+        err = Wire.requestFrom(slaveAddress, (uint8_t)1, stop);
+        if (err == 1) {
+            return Wire.read();
+        } else {
+            ++errorCount;
+            ERROR("%d r %d 0x%02x 0x%02x %d", errorCount, err, slaveAddress, addr, stop);
+        }
+    } else {
+        ++errorCount;
+        ERROR("%d e %d 0x%02x 0x%02x %d", errorCount, err, slaveAddress, addr, stop);
+    }
+    return err;
+}
+
+int32_t readRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_t len, bool stop, bool stopAfterWrite) {
+    Wire.beginTransmission(slaveAddress);
+    Wire.write(addr);
+    int32_t err = -Wire.endTransmission(stopAfterWrite);
+    if (err == 0) {
+        err = Wire.requestFrom(slaveAddress, len, stop);
+        if (err == len) {
+            while (len-- > 0) {
+                uint8_t b = Wire.read();
+                if (buffer != nullptr)
+                    (*buffer++) = b;
+            }
+        } else {
+            ++errorCount;
+            ERROR("%d r %d 0x%02x 0x%02x %d %d", errorCount, err, slaveAddress, addr, len, stop);
+        }
+    } else {
+        ++errorCount;
+        ERROR("%d e %d 0x%02x 0x%02x %d %d", errorCount, err, slaveAddress, addr, len, stop);
+    }
+    return err;
+}
+
+int32_t readAddr(uint8_t slaveAddress, uint8_t* buffer, uint8_t len, bool stop) {
+    int32_t err = Wire.requestFrom(slaveAddress, len, stop);
+    if (err == len) {
+        while(len-- > 0) {
+            (*buffer++) = Wire.read();
+        }
+    } else {
+        ++errorCount;
+        ERROR("%d, r %d 0x%02x %d %d", errorCount, err, slaveAddress, len, stop);
+    }
+    return err;
+}
+
+} // namespace i2c

--- a/user/tests/wiring/i2c_mcp23017/i2c_helper.cpp
+++ b/user/tests/wiring/i2c_mcp23017/i2c_helper.cpp
@@ -44,7 +44,7 @@ int32_t readRegister(uint8_t slaveAddress, uint8_t addr, bool stop, bool stopAft
     Wire.write(addr);
     int32_t err = -Wire.endTransmission(stopAfterWrite);
     if (err == 0) {
-        err = Wire.requestFrom(slaveAddress, (uint8_t)1, stop);
+        err = Wire.requestFrom(slaveAddress, (uint8_t)1, (uint8_t)stop);
         if (err == 1) {
             return Wire.read();
         } else {
@@ -63,7 +63,7 @@ int32_t readRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_
     Wire.write(addr);
     int32_t err = -Wire.endTransmission(stopAfterWrite);
     if (err == 0) {
-        err = Wire.requestFrom(slaveAddress, len, stop);
+        err = Wire.requestFrom(slaveAddress, len, (uint8_t)stop);
         if (err == len) {
             while (len-- > 0) {
                 uint8_t b = Wire.read();
@@ -82,7 +82,7 @@ int32_t readRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_
 }
 
 int32_t readAddr(uint8_t slaveAddress, uint8_t* buffer, uint8_t len, bool stop) {
-    int32_t err = Wire.requestFrom(slaveAddress, len, stop);
+    int32_t err = Wire.requestFrom(slaveAddress, len, (uint8_t)stop);
     if (err == len) {
         while(len-- > 0) {
             (*buffer++) = Wire.read();

--- a/user/tests/wiring/i2c_mcp23017/i2c_helper.h
+++ b/user/tests/wiring/i2c_mcp23017/i2c_helper.h
@@ -9,14 +9,14 @@
 namespace i2c {
 void reset();
 
-int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t val, bool stop = true);
-int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_t len, bool stop = true);
+int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t val, bool stop);
+int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_t len, bool stop);
 
-int32_t readRegister(uint8_t slaveAddress, uint8_t addr, bool stop = true, bool stopAfterWrite = true);
+int32_t readRegister(uint8_t slaveAddress, uint8_t addr, bool stop, bool stopAfterWrite);
 int32_t readRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_t len,
-                     bool stop = true,
-                     bool stopAfterWrite = true);
-int32_t readAddr(uint8_t slaveAddress, uint8_t* buffer, uint8_t len, bool stop = true);
+                     bool stop,
+                     bool stopAfterWrite);
+int32_t readAddr(uint8_t slaveAddress, uint8_t* buffer, uint8_t len, bool stop);
 
 extern uint32_t errorCount;
 extern std::vector<uint8_t> devices;

--- a/user/tests/wiring/i2c_mcp23017/i2c_helper.h
+++ b/user/tests/wiring/i2c_mcp23017/i2c_helper.h
@@ -1,0 +1,25 @@
+#ifndef I2C_REG_H_
+#define I2C_REG_H_
+
+#include <cstdint>
+#include <vector>
+
+// Some helper functions
+
+namespace i2c {
+void reset();
+
+int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t val, bool stop = true);
+int32_t writeRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_t len, bool stop = true);
+
+int32_t readRegister(uint8_t slaveAddress, uint8_t addr, bool stop = true, bool stopAfterWrite = true);
+int32_t readRegister(uint8_t slaveAddress, uint8_t addr, uint8_t* buffer, uint8_t len,
+                     bool stop = true,
+                     bool stopAfterWrite = true);
+int32_t readAddr(uint8_t slaveAddress, uint8_t* buffer, uint8_t len, bool stop = true);
+
+extern uint32_t errorCount;
+extern std::vector<uint8_t> devices;
+} // namespace i2c
+
+#endif // I2C_REG_H_

--- a/user/tests/wiring/i2c_mcp23017/interferer.h
+++ b/user/tests/wiring/i2c_mcp23017/interferer.h
@@ -1,0 +1,67 @@
+#ifndef INTERFERER_H_
+#define INTERFERER_H_
+
+#include "application.h"
+
+struct HighPriorityInterruptInterferer {
+    HighPriorityInterruptInterferer() {
+#if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
+        // Enable some high priority interrupt to run interference
+        pinMode(D0, OUTPUT);
+        // D0 uses TIM2 and channel 2 equally on Core and Photon/Electron
+        // Run at 4khz (T=250us)
+        analogWrite(D0, 1, 4000);
+        randomSeed(micros());
+        // Set higher than SysTick_IRQn priority for TIM4_IRQn
+        NVIC_SetPriority(TIM4_IRQn, 3);
+        TIM_ITConfig(TIM4, TIM_IT_CC2, ENABLE);
+        NVIC_EnableIRQ(TIM4_IRQn);
+        attachSystemInterrupt(SysInterrupt_TIM4_IRQ, [&] {
+            // Do some work up to 200 microseconds
+            delayMicroseconds(random(200));
+            TIM_ClearITPendingBit(TIM4, TIM_IT_CC2);
+        });
+#endif
+    };
+
+    ~HighPriorityInterruptInterferer() {
+#if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
+    NVIC_DisableIRQ(TIM4_IRQn);
+    detachSystemInterrupt(SysInterrupt_TIM4_IRQ);
+    TIM_ITConfig(TIM4, TIM_IT_CC2, DISABLE);
+    digitalWrite(D0, HIGH);
+#endif
+    };
+};
+
+struct ContextSwitchBlockingInteferer {
+    ContextSwitchBlockingInteferer() {
+        exit_ = 0;
+        bool& exitFlag = exit_;
+        thread_ = new Thread("", [&exitFlag]{
+            while (!exitFlag) {
+                uint32_t block = random(50, 150);
+                {
+                    SINGLE_THREADED_SECTION();
+                    uint32_t startMillis = millis();
+                    while ((millis() - startMillis) < block);
+                }
+                delayMicroseconds(1000 * 1000);
+            }
+        });
+    };
+
+    ~ContextSwitchBlockingInteferer() {
+        if (thread_) {
+            exit_ = 1;
+            thread_->join();
+            delete thread_;
+        }
+    };
+
+private:
+    bool exit_;
+    Thread* thread_;
+};
+
+#endif // INTERFERER_H_

--- a/user/tests/wiring/i2c_mcp23017/mcp23017.cpp
+++ b/user/tests/wiring/i2c_mcp23017/mcp23017.cpp
@@ -1,129 +1,261 @@
+#include <algorithm>
 #include "application.h"
 #include "unit-test/unit-test.h"
+#include "i2c_helper.h"
+#include "interferer.h"
 
-#define MCP23017_ADDRESS 0x40
-#define BASE_REGISTER 0x00
+#define MCP23017_BASE_ADDRESS 0x20
 
-static int doRequest(uint8_t addr, uint8_t reg, int len, bool ctrlStop, bool recvStop) {
-    Wire.beginTransmission(addr >> 1);
-    Wire.write(BASE_REGISTER + reg);
-    Wire.endTransmission(ctrlStop);
-    return Wire.requestFrom(addr >> 1, len, recvStop);
-}
+static bool s_skip = false;
+static void mcp23017_looped_test();
+static uint8_t s_mcpAddress = 0x00;
 
-test(I2C_MCP23017_doRequestControlNoStopReadNoStop) {
+#define LOOP_COUNT 10000
+
+externTest(0_I2C_scanBus);
+
+test(1_I2C_MCP23017_doRequestControlNoStopReadNoStop) {
+    assertTestPass(0_I2C_scanBus);
+
+    // Check whether we have found the MCP23017
+    for (uint8_t addr = MCP23017_BASE_ADDRESS; addr <= MCP23017_BASE_ADDRESS + 0b111; addr++) {
+        if (std::find(i2c::devices.begin(), i2c::devices.end(), addr) != i2c::devices.end()) {
+            s_mcpAddress = addr;
+            break;
+        }
+    }
+
+    if (s_mcpAddress == 0x00) {
+        // Skip the tests if not
+        s_skip = true;
+        skip();
+        return;
+    }
+
     // The test ends all transactions with repeated START condition
     // and only ends the last transaction with STOP condition
-    int totalCount = 0;
 
-    Wire.setSpeed(400000);
-    Wire.begin();
+    i2c::reset();
 
-    SINGLE_THREADED_SECTION();
     // Perform 4 consecutive 1-byte reads without STOPs
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 1, false, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x01, 1, false, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 1, false, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x03, 1, false, false);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 1, false, false);
+    i2c::readRegister(s_mcpAddress, 0x01, nullptr, 1, false, false);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 1, false, false);
+    i2c::readRegister(s_mcpAddress, 0x03, nullptr, 1, false, false);
 
     // Perform 2 consecutive 2-byte reads without STOPs
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 2, false, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 2, false, false);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 2, false, false);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 2, false, false);
 
     // Perform single 4-byte read and end it with STOP
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 4, false, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 4, true, false);
 
     Wire.end();
 
-    assertEqual(totalCount, 4 * 3);
+    assertEqual(i2c::errorCount, 0);
 }
 
-test(I2C_MCP23017_doRequestControlStopReadStop) {
+test(2_I2C_MCP23017_doRequestControlStopReadStop) {
+    if (s_skip) {
+        skip();
+        return;
+    }
     // The test ends all transactions with STOP condition
-    int totalCount = 0;
+    i2c::reset();
 
-    Wire.setSpeed(400000);
-    Wire.begin();
-
-    SINGLE_THREADED_SECTION();
     // Perform 4 consecutive 1-byte reads with STOP after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 1, true, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x01, 1, true, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 1, true, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x03, 1, true, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 1, true, true);
+    i2c::readRegister(s_mcpAddress, 0x01, nullptr, 1, true, true);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 1, true, true);
+    i2c::readRegister(s_mcpAddress, 0x03, nullptr, 1, true, true);
 
     // Perform 2 consecutive 2-byte reads with STOP after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 2, true, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 2, true, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 2, true, true);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 2, true, true);
 
     // Perform single 4-byte read with STOP after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 4, true, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 4, true, true);
 
     Wire.end();
 
-    assertEqual(totalCount, 4 * 3);
+    assertEqual(i2c::errorCount, 0);
 }
 
-test(I2C_MCP23017_doRequestControlNoStopReadStop) {
+test(3_I2C_MCP23017_doRequestControlNoStopReadStop) {
+    if (s_skip) {
+        skip();
+        return;
+    }
     // The test performs all transactions with repeated START condition
     // after control sequence and STOP condition after read
-    int totalCount = 0;
+    i2c::reset();
 
-    Wire.setSpeed(400000);
-    Wire.begin();
-
-    SINGLE_THREADED_SECTION();
     // Perform 4 consecutive 1-byte reads with repeated START after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 1, false, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x01, 1, false, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 1, false, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x03, 1, false, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 1, true, false);
+    i2c::readRegister(s_mcpAddress, 0x01, nullptr, 1, true, false);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 1, true, false);
+    i2c::readRegister(s_mcpAddress, 0x03, nullptr, 1, true, false);
 
     // Perform 2 consecutive 2-byte reads with repeated START after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 2, false, true);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 2, false, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 2, true, false);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 2, true, false);
 
     // Perform single 4-byte read with repeated START after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 4, false, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 4, true, false);
 
     Wire.end();
 
-    assertEqual(totalCount, 4 * 3);
+    assertEqual(i2c::errorCount, 0);
 }
 
-test(I2C_MCP23017_doRequestControlStopReadNoStop) {
+test(4_I2C_MCP23017_doRequestControlStopReadNoStop) {
+    if (s_skip) {
+        skip();
+        return;
+    }
     // The test performs all transactions with STOP condition
     // after control sequence and repeated START condition after read
     // Last transaction is ended with STOP condition
-    int totalCount = 0;
+    i2c::reset();
 
-    Wire.setSpeed(400000);
-    Wire.begin();
-
-    SINGLE_THREADED_SECTION();
     // Perform 4 consecutive 1-byte reads with repeated START after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 1, true, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x01, 1, true, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 1, true, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x03, 1, true, false);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 1, false, true);
+    i2c::readRegister(s_mcpAddress, 0x01, nullptr, 1, false, true);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 1, false, true);
+    i2c::readRegister(s_mcpAddress, 0x03, nullptr, 1, false, true);
 
     // Perform 2 consecutive 2-byte reads with repeated START after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 2, true, false);
-    totalCount += doRequest(MCP23017_ADDRESS, 0x02, 2, true, false);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 2, false, true);
+    i2c::readRegister(s_mcpAddress, 0x02, nullptr, 2, false, true);
 
     // Perform single 4-byte read with repeated START after control sequence
     // and STOP after read
-    totalCount += doRequest(MCP23017_ADDRESS, 0x00, 4, true, true);
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 4, true, true);
 
     Wire.end();
 
-    assertEqual(totalCount, 4 * 3);
+    assertEqual(i2c::errorCount, 0);
+}
+
+/*
+ * Tests for https://github.com/spark/firmware/issues/1042
+ */
+test(5_I2C_MCP23017_HighPriorityInterruptsDoNotInterfere) {
+    if (s_skip) {
+        skip();
+        return;
+    }
+
+    HighPriorityInterruptInterferer interferer;
+
+    i2c::reset();
+
+    // Switch MCP23017 GPIOs to OUTPUT
+    i2c::writeRegister(s_mcpAddress, 0x00, 0x00, true);
+    i2c::writeRegister(s_mcpAddress, 0x01, 0x00, true);
+
+    assertEqual(i2c::errorCount, 0);
+
+    for (int i = 0; i < LOOP_COUNT; i++) {
+        mcp23017_looped_test();
+        assertEqual(i2c::errorCount, 0);
+    }
+
+    assertEqual(i2c::errorCount, 0);
+}
+
+/*
+ * Tests for https://github.com/spark/firmware/issues/1042
+ */
+test(6_I2C_MCP23017_NastyThreadDisablingContextSwitchingDoesNotInterfere) {
+    if (s_skip) {
+        skip();
+        return;
+    }
+
+    ContextSwitchBlockingInteferer interferer;
+
+    i2c::reset();
+
+    // Switch MCP23017 GPIOs to OUTPUT
+    i2c::writeRegister(s_mcpAddress, 0x00, 0x00, true);
+    i2c::writeRegister(s_mcpAddress, 0x01, 0x00, true);
+
+    assertEqual(i2c::errorCount, 0);
+
+    for (int i = 0; i < LOOP_COUNT; i++) {
+        mcp23017_looped_test();
+        assertEqual(i2c::errorCount, 0);
+    }
+
+    assertEqual(i2c::errorCount, 0);
+}
+
+/*
+ * Tests for https://github.com/spark/firmware/issues/1042
+ */
+test(7_I2C_MCP23017_HighPriorityInterruptsAndNastyThreadDisablingContextSwitchingDoNotInterfere) {
+    if (s_skip) {
+        skip();
+        return;
+    }
+
+    ContextSwitchBlockingInteferer interferer;
+    HighPriorityInterruptInterferer interferer1;
+
+    i2c::reset();
+
+    // Switch MCP23017 GPIOs to OUTPUT
+    i2c::writeRegister(s_mcpAddress, 0x00, 0x00, true);
+    i2c::writeRegister(s_mcpAddress, 0x01, 0x00, true);
+
+    assertEqual(i2c::errorCount, 0);
+
+    for (int i = 0; i < LOOP_COUNT; i++) {
+        mcp23017_looped_test();
+        assertEqual(i2c::errorCount, 0);
+    }
+
+    assertEqual(i2c::errorCount, 0);
+}
+
+void mcp23017_looped_test() {
+    // With STOP conditions
+    // Read GPIO state
+    uint8_t gpioa = i2c::readRegister(s_mcpAddress, 0x12);
+    uint8_t gpiob = i2c::readRegister(s_mcpAddress, 0x13);
+    assertEqual(i2c::errorCount, 0);
+
+    // Invert GPIO state
+    i2c::writeRegister(s_mcpAddress, 0x12, ~gpioa);
+    i2c::writeRegister(s_mcpAddress, 0x13, ~gpiob);
+    assertEqual(i2c::errorCount, 0);
+
+    // With repeated-START conditions
+    // Read GPIO state
+    gpioa = i2c::readRegister(s_mcpAddress, 0x12, false, false);
+    gpiob = i2c::readRegister(s_mcpAddress, 0x13, false, false);
+    assertEqual(i2c::errorCount, 0);
+
+    // Invert GPIO state
+    i2c::writeRegister(s_mcpAddress, 0x12, ~gpioa, false);
+    i2c::writeRegister(s_mcpAddress, 0x13, ~gpiob, false);
+    assertEqual(i2c::errorCount, 0);
+
+    // With STOP conditions
+    // Read out 0x15 consecutive registers starting from 0x00
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 0x15, true, true);
+
+    // With repeated-START conditions
+    // Read out 0x15 consecutive registers starting from 0x00
+    i2c::readRegister(s_mcpAddress, 0x00, nullptr, 0x15, false, false);
+    assertEqual(i2c::errorCount, 0);
 }

--- a/user/tests/wiring/i2c_mcp23017/mcp23017.cpp
+++ b/user/tests/wiring/i2c_mcp23017/mcp23017.cpp
@@ -230,13 +230,13 @@ test(7_I2C_MCP23017_HighPriorityInterruptsAndNastyThreadDisablingContextSwitchin
 void mcp23017_looped_test() {
     // With STOP conditions
     // Read GPIO state
-    uint8_t gpioa = i2c::readRegister(s_mcpAddress, 0x12);
-    uint8_t gpiob = i2c::readRegister(s_mcpAddress, 0x13);
+    uint8_t gpioa = i2c::readRegister(s_mcpAddress, 0x12, true, true);
+    uint8_t gpiob = i2c::readRegister(s_mcpAddress, 0x13, true, true);
     assertEqual(i2c::errorCount, 0);
 
     // Invert GPIO state
-    i2c::writeRegister(s_mcpAddress, 0x12, ~gpioa);
-    i2c::writeRegister(s_mcpAddress, 0x13, ~gpiob);
+    i2c::writeRegister(s_mcpAddress, 0x12, ~gpioa, true);
+    i2c::writeRegister(s_mcpAddress, 0x13, ~gpiob, true);
     assertEqual(i2c::errorCount, 0);
 
     // With repeated-START conditions


### PR DESCRIPTION
- Additional flag check after EVENT_TIMEOUT
- Correct handling of NACK after sending address in HAL_I2C_End_Transmission (write)
- First data byte should be loaded in DR before checking BTF flag in HAL_I2C_End_Transmission
- I2C_FLAG_BTF should be used in place of I2C_EVENT_MASTER_BYTE_TRANSMITTING while transmitting bytes in HAL_I2C_End_Transmission

Slightly connected with #1042. The issue described in #1042 was mainly caused (after removal of `SINGLE_THREADED_SECTION` from wiring i2c functions) by non-monotonic millis()/micros() behavior that was fixed in PR #943, which isn't in 0.5.1. While debugging that, several other non-critical issues were found in I2C HAL.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)