### PR TITLE
remove IP fallback

### DIFF
--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -955,14 +955,6 @@ int determine_connection_address(IPAddress& ip_addr, uint16_t& port, ServerAddre
     }
 #endif
 
-	if (ip_address_error && (!HAL_PLATFORM_CLOUD_UDP || !udp))
-	{
-		// TCP - final fallback in case where flash invalid
-		ip_addr = (54 << 24) | (208 << 16) | (229 << 8) | 4;
-		//ip_addr = (52<<24) | (0<<16) | (3<<8) | 40;
-		ip_address_error = false;
-	}
-
 	return ip_address_error;
 }
 


### PR DESCRIPTION
Removes the fallback IP that is used when DNS resolution fails. Instead, the cloud connection is failed and the system will have to retry.  This means DNS lookup failure is now consistent with other modes of connection failure. 

Addresses #139 

Related to #1024

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Internal

- Removed hardcoded server IP that was used when DNS resolution fails. Instead, the cloud connection is failed and the system will have to retry.  This means DNS lookup failure is now consistent with other modes of connection failure.  Addresses #139 Related to #1024