### PR TITLE
replaces lost reset logic from 'feature/reset-network-flag' (fixes #1045)

### DIFF
--- a/services/inc/config.h
+++ b/services/inc/config.h
@@ -32,7 +32,6 @@
 #define LOG_INCLUDE_SOURCE_INFO
 #endif
 
-#define RESET_ON_CFOD                   1       // 1 Will do reset 0 will not
 #define MAX_SEC_WAIT_CONNECT            8       // Number of second a TCP, spark will wait
 #define MAX_FAILED_CONNECTS             2       // Number of time a connect can fail
 #define DEFAULT_SEC_INACTIVITY          0

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -97,7 +97,7 @@ void manage_network_connection()
     {
         if (SPARK_WLAN_STARTED)
         {
-            WARN("!! Resetting WLAN due to %s", (WLAN_WD_TO()) ? "WLAN_WD_TO()":((SPARK_WLAN_RESET) ? "SPARK_WLAN_RESET" : "SPARK_WLAN_SLEEP"));
+            WARN("Resetting WLAN due to %s", (WLAN_WD_TO()) ? "WLAN_WD_TO()":((SPARK_WLAN_RESET) ? "SPARK_WLAN_RESET" : "SPARK_WLAN_SLEEP"));
             auto was_sleeping = SPARK_WLAN_SLEEP;
             auto was_disconnected = network.manual_disconnect();
             cloud_disconnect();
@@ -146,18 +146,26 @@ inline uint8_t in_cloud_backoff_period()
 
 void handle_cloud_errors()
 {
+    WARN("Handling cloud error: %d", Spark_Error_Count);
+    int error = Spark_Error_Count;
     // cfod resets in orange since they are soft errors
+    // TODO: Spark_Error_Count is never equal to 1
     LED_SetRGBColor(Spark_Error_Count > 1 ? RGB_COLOR_ORANGE : RGB_COLOR_RED);
 
     while (Spark_Error_Count != 0)
     {
+        // HAL_Delay_Microseconds blocks properly
         LED_On(LED_RGB);
-        HAL_Delay_Milliseconds(500);
+        HAL_Delay_Microseconds(500000);
         LED_Off(LED_RGB);
-        HAL_Delay_Milliseconds(500);
+        HAL_Delay_Microseconds(500000);
         Spark_Error_Count--;
     }
-
+    if (error == 2) { // Internet test failed
+        LED_SetRGBColor(RGB_COLOR_GREEN);
+    } else if (error == 3) { // Internet connected, Cloud not reachable
+        LED_SetRGBColor(RGB_COLOR_CYAN);
+    }
     // TODO Send the Error Count to Cloud: NVMEM_Spark_File_Data[ERROR_COUNT_FILE_OFFSET]
 
     // Reset Error Count
@@ -166,32 +174,38 @@ void handle_cloud_errors()
 
 void handle_cfod()
 {
-    if (cfod_count < 255)
-        ++cfod_count;
-
     uint8_t reset = 0;
     system_get_flag(SYSTEM_FLAG_RESET_NETWORK_ON_CLOUD_ERRORS, &reset, nullptr);
-    if (reset && cfod_count >= MAX_FAILED_CONNECTS)
+    if (reset && ++cfod_count >= MAX_FAILED_CONNECTS)
     {
-        SPARK_WLAN_RESET = RESET_ON_CFOD;
-        ERROR("Resetting WLAN due to %d failed connect attempts", MAX_FAILED_CONNECTS);
+        SPARK_WLAN_RESET = 1;
+        WARN("Resetting WLAN due to %d failed connect attempts", MAX_FAILED_CONNECTS);
     }
 
     if (Internet_Test() < 0)
     {
-        // No Internet Connection
+        WARN("Internet Test Failed!");
+        if (reset && ++cfod_count >= MAX_FAILED_CONNECTS)
+        {
+            SPARK_WLAN_RESET = 1;
+            WARN("Resetting WLAN due to %d failed connect attempts", MAX_FAILED_CONNECTS);
+        }
         Spark_Error_Count = 2;
     }
     else
     {
-        // Cloud not Reachable
+        WARN("Internet available, Cloud not reachable!");
         Spark_Error_Count = 3;
+    }
+
+    if (reset == 0) {
+        CLR_WLAN_WD();
     }
 }
 
 /**
  * Establishes a socket connection to the cloud if not already present.
- * - handles previous connection errors by flashing the LED
+ * - handles connection errors by flashing the LED
  * - attempts to open a socket to the cloud
  * - handles the CFOD
  *
@@ -202,13 +216,12 @@ void establish_cloud_connection()
 {
     if (network.ready() && !SPARK_WLAN_SLEEP && !SPARK_CLOUD_SOCKETED)
     {
-        if (Spark_Error_Count)
-            handle_cloud_errors();
-
         SPARK_LED_FADE = 0;
         LED_SetRGBColor(RGB_COLOR_CYAN);
         if (in_cloud_backoff_period())
+        {
             return;
+        }
 
         INFO("Cloud: connecting");
         LED_On(LED_RGB);
@@ -226,11 +239,19 @@ void establish_cloud_connection()
             // if the user put the networkin listening mode via the button,
             // the cloud connect may have been cancelled.
             if (SPARK_WLAN_RESET || network.listening())
+            {
                 return;
+            }
 
             cloud_connection_failed();
             handle_cfod();
             network.set_error_count(Spark_Error_Count);
+        }
+
+        // Handle errors last to ensure they are shown
+        if (Spark_Error_Count > 0)
+        {
+            handle_cloud_errors();
         }
     }
 }


### PR DESCRIPTION
- replaces lost reset logic from 'feature/reset-network-flag' (fixes #1045)
- also adds CLR_WLAN_WD() when SYSTEM_FLAG_RESET_NETWORK_ON_CLOUD_ERRORS is disabled
- handle_cloud_errors() was not displaying orange blinks due to HAL_Delay_Milliseconds() not blocking
- handle_cloud_errors() was moved to the end of establish_cloud_connection() to ensure errors are shown
- added debugging info for all of the places ARM_WLAN_WD/CLR_WLAN_WD is called
- added new logic for notify_connected() to ensure ARM_WLAN_WD is not called after DHCP resolves successfully
- handle_cloud_errors() was fixed by making its process atomic, so that background system LED signaling did not interfere.
- Because this fix causes a slight 1 to 1.5 second delay in system code execution, even when multi-threading is enabled.  Not desirable, so for now we will disable this routine completely and defer enabling it again until the new LED handling routine is in place (0.6.x or 0.7.x).  Also these particular blinks were never seen in the past, so existing behavior is preserved.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)