### PR TITLE
Remove accidental SYSTEM_MODE(MANUAL) from pwm.cpp in wiring/no_fixture

### DIFF
--- a/hal/src/stm32/pwm_hal.c
+++ b/hal/src/stm32/pwm_hal.c
@@ -31,7 +31,7 @@
 
 #define DIV_ROUND_CLOSEST(n, d) ((n + d/2)/d)
 
-#if PLATFORM_ID == 10
+#if 0/* PLATFORM_ID == 10 */
 # include <math.h>
 # define PWM_USE_FLOATING_POINT_ARITHMETICS
 #endif // PLATFORM_ID == 10

--- a/user/tests/wiring/no_fixture/pwm.cpp
+++ b/user/tests/wiring/no_fixture/pwm.cpp
@@ -27,8 +27,6 @@
 #include "pwm_hal.h"
 #include "unit-test/unit-test.h"
 
-SYSTEM_MODE(MANUAL);
-
 uint8_t pwm_pins[] = {
 
 #if defined(STM32F2XX)


### PR DESCRIPTION
Removes accidental SYSTEM_MODE(MANUAL) from pwm.cpp in wiring/no_fixture. Also restores usage of uint64_t division on Electron for PWM calculations as system-part2 no longer overflows.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)
