### PR TITLE
automatically adds vendored libraries for extended application projects

### DIFF
--- a/build/test/core.bats
+++ b/build/test/core.bats
@@ -26,7 +26,7 @@ load build
     [ -d $outdir ]
     [ -s $outdir/main.bin ]
     [ -s $outdir/main.elf ]
-    file_size_range $outdir/main.bin 70 86 K
+    file_size_range $outdir/main.bin 70 89 K
 }
 
 @test "repeat core main build silent outputs size" {

--- a/build/test/libs.bats
+++ b/build/test/libs.bats
@@ -6,7 +6,7 @@ load build
    run make $make_args PLATFORM=photon APPDIR=../build/test/files/applibs/app "APPLIBSV1=../build/test/files/applibs/lib1/ ../build/test/files/applibs/lib2/"
     outdir=../build/test/files/applibs/app/target
     [ -s $outdir/app.bin ]
-    file_size_range $outdir/app.bin 2 4 K 
+    file_size_range $outdir/app.bin 2 5 K 
 }
 
 
@@ -16,7 +16,7 @@ load build
    run make $make_args PLATFORM=photon "APPDIR=../build/test/files/applibs spaces/app1" "\"APPLIBSV1=../build/test/files/applibs spaces/lib1/\" \"../build/test/files/applibs spaces/lib2/\""
     outdir=../build/test/files/applibs\ spaces/app1/target
     [ -s $outdir/app1.bin ]
-    file_size_range $outdir/app1.bin 2 4 K 
+    file_size_range $outdir/app1.bin 2 5 K 
 }
 
 
@@ -25,14 +25,24 @@ load build
    run make $make_args PLATFORM=photon APPDIR=../build/test/files/applibs_v2/app "APPLIBSV2=../build/test/files/applibs_v2/lib1/ ../build/test/files/applibs_v2/lib2"
     outdir=../build/test/files/applibs_v2/app/target
     [ -s $outdir/app.bin ]
-    file_size_range $outdir/app.bin 2 4 K 
+    file_size_range $outdir/app.bin 2 5 K 
 }
 
 
-@test "can build a v2 project with vendored v2 libraries" {
-   cd modules/photon/user-part
-   run make $make_args PLATFORM=photon APPDIR=../build/test/files/applibs_v2_vendored/app/src "APPLIBSV2=../build/test/files/applibs_v2_vendored/app/lib/lib1/ ../build/test/files/applibs_v2_vendored/app/lib/lib2"
-    outdir=../build/test/files/applibs_v2_vendored/app/src/target
+@test "can build a v2 project with explicitly set vendored v2 libraries" {
+    cd modules/photon/user-part
+    run make $make_args PLATFORM=photon APPDIR=../build/test/files/applibs_v2_vendored/app_explicit/src "APPLIBSV2=../build/test/files/applibs_v2_vendored/app/lib/lib1/ ../build/test/files/applibs_v2_vendored/app/lib/lib2"
+    outdir=../build/test/files/applibs_v2_vendored/app_explicit/src/target
     [ -s $outdir/src.bin ]
-    file_size_range $outdir/src.bin 2 4 K 
+	file_size_range $outdir/src.bin 2 5 K 
 }
+
+@test "can build a v2 project with implicity set vendored v2 libraries" {
+    cd modules/photon/user-part
+    run make $make_args PLATFORM=photon APPDIR=../build/test/files/applibs_v2_vendored/app
+    outdir=../build/test/files/applibs_v2_vendored/app/target
+    [ -s $outdir/app.bin ]
+    file_size_range $outdir/app.bin 2 5 K 
+}
+
+

--- a/user/build.mk
+++ b/user/build.mk
@@ -7,9 +7,8 @@
 # propagate the APPLIBV1s to module libs only when building this user module
 # (otherwise if we used APPLIBs directly in the module build each recursively
 # built module would build the libs.)
-MODULE_LIBSV1 += $(call remove_slash,$(APPLIBSV1))
-MODULE_LIBSV2 += $(call remove_slash,$(APPLIBSV2))
-
+MODULE_LIBSV1+=$(call remove_slash,$(APPLIBSV1))
+MODULE_LIBSV2+=$(call remove_slash,$(APPLIBSV2))
 
 ifdef APP
 USER_MAKEFILE ?= $(APP).mk
@@ -20,14 +19,33 @@ ifdef APPDIR
 # APPDIR is where the sources are found
 # if TARGET_DIR is not defined defaults to $(APPDIR)/target
 # if TARGET_FILE_NAME is not defined, defaults to the name of the $(APPDIR)
-SOURCE_PATH = $(APPDIR)
+SOURCE_PATH = $(call remove_slash,$(APPDIR))
 endif
-
 
 ifdef TEST
 INCLUDE_PLATFORM?=1
 include $(MODULE_PATH)/tests/tests.mk
 -include $(MODULE_PATH)/$(USRSRC)/test.mk
+endif
+
+# the root of the application
+APPROOT := $(SOURCE_PATH)$(USRSRC)
+
+ifneq ($(wildcard $(APPROOT)/project.properties),)
+	ifneq ($(wildcard $(APPROOT)/src),)
+	   APPLAYOUT=extended
+	else
+	   APPLAYOUT=simple
+	endif
+else
+   APPLAYOUT=legacy
+endif
+
+ifeq ($(APPLAYOUT),extended)
+# add vendored libraries to module libraries
+MODULE_LIBSV2 += $(wildcard $(APPROOT)/lib/*)
+SOURCE_PATH := $(APPROOT)/
+USRSRC = src
 endif
 
 USRSRC_SLASH = $(and $(USRSRC),$(USRSRC)/)


### PR DESCRIPTION
Adds libraries from the `lib` directory in extended projects. 

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

ENHANCEMENT
- automatically adds vendored libraries from the `lib` directory for extended application projects [#1053](https://github.com/spark/firmware/pull/1053)