### PR TITLE
Daylight Saving Time support

### DIFF
--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -5673,6 +5673,9 @@ Retrieve the current time in the configured timezone as seconds since January 1,
 
 Note that the functions in the `Time` class expect times in UTC time, so the result from this should be used carefully.
 
+_Since 0.6.0_
+
+Local time is also affected by the Daylight Saving Time (DST) settings.
 
 ### zone()
 
@@ -5686,8 +5689,59 @@ The device will remember this offset until reboot.
 Time.zone(-4);
 ```
 
-Parameters: floating point offset from UTC in hours, from -12.0 to 13.0
+Parameters: floating point offset from UTC in hours, from -12.0 to 14.0
 
+### isDST()
+
+_Since 0.6.0_
+
+Returns true if Daylight Saving Time (DST) is in effect.
+
+```cpp
+// Print true or false depending on whether the DST in in effect
+Serial.print(Time.isDST());
+```
+
+Returns: Unsigned 8-bit integer: 0 = false, 1 = true
+
+### getDSTOffset()
+
+_Since 0.6.0_
+
+Retrieve the current Daylight Saving Time (DST) offset that is added to the current local time when Time.beginDST() has been called. The default is 1 hour.
+
+```cpp
+// Get current DST offset
+float offset = Time.getDSTOffset();
+```
+
+Returns: floating point DST offset in hours (default is +1.0 hours)
+
+### setDSTOffset()
+
+_Since 0.6.0_
+
+Set a custom Daylight Saving Time (DST) offset.
+The device will remember this offset until reboot.
+
+```cpp
+// Set DST offset to 30 minutes
+Time.setDSTOffset(0.5);
+```
+
+Parameters: floating point offset in hours, from 0.0 to 2.0
+
+### beginDST()
+
+_Since 0.6.0_
+
+Start applying Daylight Saving Time (DST) offset to the current time.
+
+### endDST()
+
+_Since 0.6.0_
+
+Stop applying Daylight Saving Time (DST) offset to the current time.
 
 ### setTime()
 

--- a/user/tests/wiring/api/time.cpp
+++ b/user/tests/wiring/api/time.cpp
@@ -29,3 +29,17 @@ test(time_zone)
     (void)time++; // avoid unused warning
 }
 
+test(time_dst)
+{
+    float dst;
+    time_t time;
+    API_COMPILE(Time.setDSTOffset(1.0f));
+    API_COMPILE(Time.setDSTOffset(-0.5));
+    API_COMPILE(dst=Time.getDSTOffset());
+    API_COMPILE(time=Time.now());
+    API_COMPILE(time=Time.local());
+    API_COMPILE(Time.isDST());
+    (void)dst;
+    (void)time;
+}
+

--- a/wiring/inc/spark_wiring_time.h
+++ b/wiring/inc/spark_wiring_time.h
@@ -61,7 +61,20 @@ public:
 	static void    zone(float GMT_Offset);		// set the time zone (+/-) offset from GMT
 	static float	   zone();						// retrieve the current timezone
 	static void    setTime(time_t t);			// set the given time as unix/rtc time
-
+  
+  /* Retrieve the current DST offset that is added to the current local time when
+   * Time.beginDST() has been called.
+   * The default is 1 hour.
+   */
+  static float getDSTOffset();
+  /* Set a custom DST offset */
+  static void setDSTOffset(float offset);
+  /* Add the offset from getDSTOffset() to the current time */
+  static void beginDST();
+  /* Do not add the offset from getDSTOffset() to the current time */
+  static void endDST();
+  /* Returns true if DST is in effect (beginDST() was called previously) */
+  static uint8_t isDST();
 
         /* return string representation of the current time */
         inline String timeStr()


### PR DESCRIPTION
Implements initial Daylight Saving Time (DST) API proposed in #211.

Added Wiring functions:
```cpp
  /* Retrieve the current DST offset that is added to the current local time when
   * Time.beginDST() has been called.
   * The default is 1 hour.
   */
  float TimeClass::getDSTOffset();
  /* Set a custom DST offset */
  void TimeClass::setDSTOffset(float offset);
  /* Add the offset from getDSTOffset() to the current time */
  void TimeClass::beginDST();
  /* Do not add the offset from getDSTOffset() to the current time */
  void TimeClass::endDST();
  /* Returns true if DST is in effect (beginDST() was called previously) */
  uint8_t TimeClass::isDST();
```

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

FEATURE
- added Daylight Saving Time support [#1058](https://github.com/spark/firmware/pull/1058) per proposed [#211](https://github.com/spark/firmware/issues/211)