### PR TITLE
feature/full-deps-validation

### DIFF
--- a/hal/inc/ota_flash_hal.h
+++ b/hal/inc/ota_flash_hal.h
@@ -54,6 +54,7 @@ typedef enum {
     MODULE_VALIDATION_RANGE            = 1<<3,
     MODULE_VALIDATION_PLATFORM         = 1<<4,
     MODULE_VALIDATION_PRODUCT          = 1<<5,
+    MODULE_VALIDATION_DEPENDENCIES_FULL= 1<<6,
     MODULE_VALIDATION_END = 0x7FFF
 } module_validation_flags_t;
 

--- a/hal/src/stm32/ota_module.cpp
+++ b/hal/src/stm32/ota_module.cpp
@@ -71,8 +71,8 @@ bool fetch_module(hal_module_t* target, const module_bounds_t* bounds, bool user
             // the suffix ends at module_end, and the crc starts after module end
             target->crc = (module_info_crc_t*)module_end;
             target->suffix = (module_info_suffix_t*)(module_end-sizeof(module_info_suffix_t));
-            if (validate_module_dependencies(bounds, userDepsOptional))
-                target->validity_result |= MODULE_VALIDATION_DEPENDENCIES;
+            if (validate_module_dependencies(bounds, userDepsOptional, target->validity_checked & MODULE_VALIDATION_DEPENDENCIES_FULL))
+                target->validity_result |= MODULE_VALIDATION_DEPENDENCIES | (target->validity_checked & MODULE_VALIDATION_DEPENDENCIES_FULL);
             if ((target->validity_checked & MODULE_VALIDATION_INTEGRITY) && FLASH_VerifyCRC32(FLASH_INTERNAL, bounds->start_address, module_length(target->info)))
                 target->validity_result |= MODULE_VALIDATION_INTEGRITY;
         }

--- a/hal/src/stm32/ota_module.h
+++ b/hal/src/stm32/ota_module.h
@@ -26,7 +26,7 @@
  * @param bounds    The bounds of the module to check.
  * @return {@code true} if the dependencies are satisfied, {@code false} otherwise.
  */
-bool validate_module_dependencies(const module_bounds_t* bounds, bool userPartOptional);
+bool validate_module_dependencies(const module_bounds_t* bounds, bool userPartOptional, bool fullDeps);
 const module_bounds_t* find_module_bounds(uint8_t module_function, uint8_t module_index);
 bool fetch_module(hal_module_t* target, const module_bounds_t* bounds, bool userDepsOptional, uint16_t check_flags=0);
 const module_info_t* locate_module(const module_bounds_t* bounds);

--- a/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
+++ b/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
@@ -84,7 +84,58 @@ void HAL_System_Info(hal_system_info_t* info, bool construct, void* reserved)
     HAL_OTA_Add_System_Info(info, construct, reserved);
 }
 
-bool validate_module_dependencies(const module_bounds_t* bounds, bool userOptional)
+bool validate_module_dependencies_full(const module_info_t* module, const module_bounds_t* bounds)
+{
+    if (module_function(module) != MODULE_FUNCTION_SYSTEM_PART)
+        return true;
+
+    bool valid = true;
+
+    // When updating system-parts
+    // If MODULE_VALIDATION_DEPENDENCIES_FULL was requested, validate that the dependecies
+    // would still be satisfied after the module from the "ota_module" replaces the current one
+    hal_system_info_t sysinfo;
+    memset(&sysinfo, 0, sizeof(sysinfo));
+    sysinfo.size = sizeof(sysinfo);
+    HAL_System_Info(&sysinfo, true, nullptr);
+    for (unsigned i=0; i<sysinfo.module_count; i++) {
+        const hal_module_t& smod = sysinfo.modules[i];
+        const module_info_t* info = smod.info;
+        if (!info)
+            continue;
+
+        // Just in case
+        if (!memcmp((const void*)&smod.bounds, (const void*)bounds, sizeof(module_bounds_t))) {
+            // Do not validate against self
+            continue;
+        }
+
+        // Validate only system parts
+        if (module_function(info) != MODULE_FUNCTION_SYSTEM_PART)
+            continue;
+
+        if (info->module_start_address == module->module_start_address &&
+            module_function(module) == module_function(info) &&
+            module_index(module) == module_index(info)) {
+            // Do not validate replaced module
+            continue;
+        }
+
+        if (info->dependency.module_function != MODULE_FUNCTION_NONE) {
+            if (info->dependency.module_function == module->module_function &&
+                info->dependency.module_index == module->module_index) {
+                valid = module->module_version >= info->dependency.module_version;
+                if (!valid)
+                    break;
+            }
+        }
+    }
+    HAL_System_Info(&sysinfo, false, nullptr);
+
+    return valid;
+}
+
+bool validate_module_dependencies(const module_bounds_t* bounds, bool userOptional, bool fullDeps)
 {
     bool valid = false;
     const module_info_t* module = locate_module(bounds);
@@ -100,6 +151,10 @@ bool validate_module_dependencies(const module_bounds_t* bounds, bool userOption
             const module_info_t* dependency = locate_module(dependency_bounds);
             valid = dependency && (dependency->module_version>=module->dependency.module_version);
         }
+
+        if (fullDeps && valid) {
+            valid = valid && validate_module_dependencies_full(module, bounds);
+        }
     }
     return valid;
 }
@@ -108,7 +163,7 @@ bool validate_module_dependencies(const module_bounds_t* bounds, bool userOption
 bool HAL_Verify_User_Dependencies()
 {
     const module_bounds_t* bounds = find_module_bounds(MODULE_FUNCTION_USER_PART, 1);
-    return validate_module_dependencies(bounds, false);
+    return validate_module_dependencies(bounds, false, false);
 }
 
 bool HAL_OTA_CheckValidAddressRange(uint32_t startAddress, uint32_t length)
@@ -167,7 +222,7 @@ hal_update_complete_t HAL_FLASH_End(void* reserved)
     hal_module_t module;
     hal_update_complete_t result = HAL_UPDATE_ERROR;
 
-    bool module_fetched = fetch_module(&module, &module_ota, true, MODULE_VALIDATION_INTEGRITY);
+    bool module_fetched = fetch_module(&module, &module_ota, true, MODULE_VALIDATION_INTEGRITY | MODULE_VALIDATION_DEPENDENCIES_FULL);
 	DEBUG("module fetched %d, checks=%d, result=%d", module_fetched, module.validity_checked, module.validity_result);
     if (module_fetched && (module.validity_checked==module.validity_result))
     {


### PR DESCRIPTION
Validates that module dependencies would still be satisfied after the module from the "ota_module" location is flashed.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

BUGFIX
- Validates that module dependencies would still be satisfied after the module from the "ota_module" location is flashed (via OTA or YMODEM flashing) [#1063](https://github.com/spark/firmware/pull/1063) 