### PR TITLE
discard buffer still needed in a few places in UDP library

### DIFF
--- a/wiring/src/spark_wiring_udp.cpp
+++ b/wiring/src/spark_wiring_udp.cpp
@@ -67,7 +67,7 @@ void UDP::releaseBuffer()
     _buffer = NULL;
     _buffer_allocated = false;
     _buffer_size = 0;
-    flush_buffer();
+    flush_buffer(); // clear buffer
 }
 
 uint8_t UDP::begin(uint16_t port, network_interface_t nif)
@@ -79,7 +79,7 @@ uint8_t UDP::begin(uint16_t port, network_interface_t nif)
         DEBUG("socket=%d",_sock);
         if (socket_handle_valid(_sock))
         {
-            flush();
+            flush_buffer(); // clear buffer
             _port = port;
             _nif = nif;
             bound = true;
@@ -106,7 +106,7 @@ void UDP::stop()
     }
     _sock = socket_handle_invalid();
 
-    flush();
+    flush_buffer(); // clear buffer
 }
 
 int UDP::beginPacket(const char *host, uint16_t port)
@@ -133,14 +133,14 @@ int UDP::beginPacket(IPAddress ip, uint16_t port)
 
     _remoteIP = ip;
     _remotePort = port;
-    flush();
+    flush_buffer(); // clear buffer
     return _buffer_size;
 }
 
 int UDP::endPacket()
 {
     int result = sendPacket(_buffer, _offset, _remoteIP, _remotePort);
-    flush();
+    flush(); // wait for send to complete
     return result;
 }
 
@@ -183,7 +183,7 @@ int UDP::parsePacket()
         setBuffer(_buffer_size);
     }
 
-    flush();         // start a new read - discard the old data
+    flush_buffer();         // start a new read - discard the old data
     if (_buffer && _buffer_size) {
         int result = receivePacket(_buffer, _buffer_size);
         if (result>0) {


### PR DESCRIPTION
After recent changes in #932, `TEST=wiring/networking` was stalling on electron and photon.  Cause was due to buffer not being cleared (i.e. `flush_buffer()`) for `parsePacket()`.  Also made this change in `beginPacket()`... and a couple other places which are probably not critical.  This is in contrast to just using `flush()` which will block while sending data in the future, in functions like endPacket().

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [ ] Code peer reviewed ( @avtolstoy please review )
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A, already in #932)
- [x] Add to CHANGELOG.md after merging (add links to docs and issues) (N/A, already in CHANGELOG for #932)
