### PR TITLE
[0.5.x] feature/electron/system-part-3

### DIFF
--- a/hal/src/electron/ota_flash_hal.cpp
+++ b/hal/src/electron/ota_flash_hal.cpp
@@ -36,9 +36,10 @@
 const module_bounds_t module_bootloader = { 0x4000, 0x8000000, 0x8004000, MODULE_FUNCTION_BOOTLOADER, 0, MODULE_STORE_MAIN };
 const module_bounds_t module_system_part1 = { 0x20000, 0x8020000, 0x8040000, MODULE_FUNCTION_SYSTEM_PART, 1, MODULE_STORE_MAIN };
 const module_bounds_t module_system_part2 = { 0x20000, 0x8040000, 0x8060000, MODULE_FUNCTION_SYSTEM_PART, 2, MODULE_STORE_MAIN };
+const module_bounds_t module_system_part3 = { 0x20000, 0x8060000, 0x8080000, MODULE_FUNCTION_SYSTEM_PART, 3, MODULE_STORE_MAIN };
 const module_bounds_t module_user = { 0x20000, 0x8080000, 0x80A0000, MODULE_FUNCTION_USER_PART, 1, MODULE_STORE_MAIN};
-const module_bounds_t module_factory = { 0x20000, 0x80E0000, 0x8100000, MODULE_FUNCTION_USER_PART, 1, MODULE_STORE_FACTORY};
-const module_bounds_t* module_bounds[] = { &module_bootloader, &module_system_part1, &module_system_part2, &module_user, &module_factory };
+const module_bounds_t module_factory = { 0x20000, 0x80A0000, 0x80C0000, MODULE_FUNCTION_USER_PART, 1, MODULE_STORE_FACTORY};
+const module_bounds_t* module_bounds[] = { &module_bootloader, &module_system_part1, &module_system_part2, &module_system_part3, &module_user, &module_factory };
 
 const module_bounds_t module_ota = { 0x20000, 0x80C0000, 0x80E0000, MODULE_FUNCTION_NONE, 0, MODULE_STORE_SCRATCHPAD};
 #else


### PR DESCRIPTION
0.5.x Electron should be aware of system-part3 to allow OTA/YModem updates to >=0.6.0

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation

Need to add somewhere that OTA/YModem updates to >=0.6.0 are not possibly on electron until first upgrading to 0.5.3 (default).

- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

ENHANCEMENT

- [Electron] System firmware is now aware of system-part3 to allow OTA/YModem updates to >=0.6.0