### PR TITLE
[0.5.x] HAL_IsISR backport (original PR #959)

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -211,21 +211,45 @@ int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, si
 #ifdef USE_STDPERIPH_DRIVER
 #if defined(STM32F10X_MD) || defined(STM32F10X_HD)
 #include "stm32f10x.h"
-inline bool HAL_IsISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
 #elif defined(STM32F2XX)
 #include "stm32f2xx.h"
+#endif // defined(STM32F10X_MD) || defined(STM32F10X_HD)
+
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD) || defined(STM32F2XX)
 inline bool HAL_IsISR()
 {
 	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
 }
 
+inline int32_t HAL_ServicedIRQn()
+{
+  return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) - 16;
+}
+
+static inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2)
+{
+  if (irqn1 == irqn2)
+    return false;
+
+  uint32_t priorityGroup = NVIC_GetPriorityGrouping();
+  uint32_t priority1 = NVIC_GetPriority((IRQn_Type)irqn1);
+  uint32_t priority2 = NVIC_GetPriority((IRQn_Type)irqn2);
+  uint32_t p1, sp1, p2, sp2;
+  NVIC_DecodePriority(priority1, priorityGroup, &p1, &sp1);
+  NVIC_DecodePriority(priority2, priorityGroup, &p2, &sp2);
+  if (p1 < p2)
+    return true;
+
+  return false;
+}
 #elif PLATFORM_ID==60000
 inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
 #elif PLATFORM_ID==3
 inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
 #else
 #error "*** MCU architecture not supported by HAL_IsISR(). ***"
 #endif

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -208,53 +208,6 @@ extern void module_user_init_hook(void);
 int HAL_System_Backup_Save(size_t offset, const void* buffer, size_t length, void* reserved);
 int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, size_t* length, void* reserved);
 
-#ifdef USE_STDPERIPH_DRIVER
-#if defined(STM32F10X_MD) || defined(STM32F10X_HD)
-#include "stm32f10x.h"
-#elif defined(STM32F2XX)
-#include "stm32f2xx.h"
-#endif // defined(STM32F10X_MD) || defined(STM32F10X_HD)
-
-#if defined(STM32F10X_MD) || defined(STM32F10X_HD) || defined(STM32F2XX)
-inline bool HAL_IsISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
-
-inline int32_t HAL_ServicedIRQn()
-{
-  return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) - 16;
-}
-
-static inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2)
-{
-  if (irqn1 == irqn2)
-    return false;
-
-  uint32_t priorityGroup = NVIC_GetPriorityGrouping();
-  uint32_t priority1 = NVIC_GetPriority((IRQn_Type)irqn1);
-  uint32_t priority2 = NVIC_GetPriority((IRQn_Type)irqn2);
-  uint32_t p1, sp1, p2, sp2;
-  NVIC_DecodePriority(priority1, priorityGroup, &p1, &sp1);
-  NVIC_DecodePriority(priority2, priorityGroup, &p2, &sp2);
-  if (p1 < p2)
-    return true;
-
-  return false;
-}
-#elif PLATFORM_ID==60000
-inline bool HAL_IsISR() { return false; }
-inline int32_t HAL_ServicedIRQn() { return 0; }
-inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
-#elif PLATFORM_ID==3
-inline bool HAL_IsISR() { return false; }
-inline int32_t HAL_ServicedIRQn() { return 0; }
-inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
-#else
-#error "*** MCU architecture not supported by HAL_IsISR(). ***"
-#endif
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -208,6 +208,25 @@ extern void module_user_init_hook(void);
 int HAL_System_Backup_Save(size_t offset, const void* buffer, size_t length, void* reserved);
 int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, size_t* length, void* reserved);
 
+#ifdef USE_STDPERIPH_DRIVER
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD)
+#include "stm32f10x.h"
+inline bool HAL_IsISR()
+{
+	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+#elif defined(STM32F2XX)
+#include "stm32f2xx.h"
+inline bool HAL_IsISR()
+{
+	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+
+#else
+#warning "*** MCU architecture not supported by HAL_IsISR(). ***"
+inline bool HAL_IsISR() { return false; }
+#endif
+#endif
 
 #ifdef __cplusplus
 }

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -224,6 +224,8 @@ inline bool HAL_IsISR()
 
 #elif PLATFORM_ID==60000
 inline bool HAL_IsISR() { return false; }
+#elif PLATFORM_ID==3
+inline bool HAL_IsISR() { return false; }
 #else
 #error "*** MCU architecture not supported by HAL_IsISR(). ***"
 #endif

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -222,9 +222,10 @@ inline bool HAL_IsISR()
 	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
 }
 
-#else
-#warning "*** MCU architecture not supported by HAL_IsISR(). ***"
+#elif PLATFORM_ID==60000
 inline bool HAL_IsISR() { return false; }
+#else
+#error "*** MCU architecture not supported by HAL_IsISR(). ***"
 #endif
 #endif
 

--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -79,6 +79,54 @@ void HAL_System_Interrupt_Trigger(hal_irq_t irq, void* reserved);
 int HAL_disable_irq();
 void HAL_enable_irq(int mask);
 
+#ifdef USE_STDPERIPH_DRIVER
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD)
+#include "stm32f10x.h"
+#elif defined(STM32F2XX)
+#include "stm32f2xx.h"
+#endif // defined(STM32F10X_MD) || defined(STM32F10X_HD)
+
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD) || defined(STM32F2XX)
+inline bool HAL_IsISR()
+{
+	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+
+inline int32_t HAL_ServicedIRQn()
+{
+  return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) - 16;
+}
+
+static inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2)
+{
+  if (irqn1 == irqn2)
+    return false;
+
+  uint32_t priorityGroup = NVIC_GetPriorityGrouping();
+  uint32_t priority1 = NVIC_GetPriority((IRQn_Type)irqn1);
+  uint32_t priority2 = NVIC_GetPriority((IRQn_Type)irqn2);
+  uint32_t p1, sp1, p2, sp2;
+  NVIC_DecodePriority(priority1, priorityGroup, &p1, &sp1);
+  NVIC_DecodePriority(priority2, priorityGroup, &p2, &sp2);
+  if (p1 < p2)
+    return true;
+
+  return false;
+}
+#elif PLATFORM_ID==60000
+inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
+#elif PLATFORM_ID==3
+inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
+#else
+#error "*** MCU architecture not supported by HAL_IsISR(). ***"
+#endif
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -79,8 +79,6 @@ void HAL_System_Interrupt_Trigger(hal_irq_t irq, void* reserved);
 int HAL_disable_irq();
 void HAL_enable_irq(int mask);
 
-uint8_t HAL_IsISR();
-
 #ifdef __cplusplus
 }
 #endif

--- a/hal/src/core/interrupts_hal.c
+++ b/hal/src/core/interrupts_hal.c
@@ -249,15 +249,3 @@ void HAL_enable_irq(int is) {
 }
 
 
-inline bool isISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
-
-uint8_t HAL_IsISR()
-{
-	return isISR();
-}
-
-
-

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -33,17 +33,6 @@
 #include "interrupts_hal.h"
 #include <mutex>
 
-inline bool isISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
-
-uint8_t HAL_IsISR()
-{
-	return isISR();
-}
-
-
 // For OpenOCD FreeRTOS support
 extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
 
@@ -321,7 +310,7 @@ static_assert(portMAX_DELAY==CONCURRENT_WAIT_FOREVER, "expected portMAX_DELAY==C
 
 int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay)
 {
-	if (isISR())
+	if (HAL_IsISR())
 		return xQueueSendFromISR(queue, item, nullptr)!=pdTRUE;
 	else
 		return xQueueSend(queue, item, delay)!=pdTRUE;

--- a/hal/src/template/interrupts_hal.cpp
+++ b/hal/src/template/interrupts_hal.cpp
@@ -72,7 +72,3 @@ void HAL_enable_irq(int is)
 {
 }
 
-uint8_t HAL_IsISR()
-{
-	return 0;
-}

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -28,6 +28,7 @@
 #include "system_update.h"
 #include "spark_macros.h"
 #include "string.h"
+#include "core_hal.h"
 #include "system_tick_hal.h"
 #include "watchdog_hal.h"
 #include "wlan_hal.h"
@@ -406,8 +407,8 @@ void system_delay_ms(unsigned long ms, bool force_no_background_loop=false)
 {
 	// if not threading, or we are the application thread, then implement delay
 	// as a background message pump
-    if (!system_thread_get_state(NULL) ||
-        APPLICATION_THREAD_CURRENT()) {
+    if ((!system_thread_get_state(NULL) || APPLICATION_THREAD_CURRENT()) && !HAL_IsISR())
+    {
     		system_delay_pump(ms, force_no_background_loop);
     }
     else


### PR DESCRIPTION
Original PR #959.

- Fixes #673 
- Requirement for #1073 (`HAL_IsISR()/HAL_WillPreempt()/HAL_ServicedIRQn()`)

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

BUGFIX

- added HAL_IsISR() which is used to skip calling the background loop from delay(). fixes [#673](https://github.com/spark/firmware/issue/673)