### PR TITLE
[0.5.x] USB Serial implementation backport

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -211,21 +211,45 @@ int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, si
 #ifdef USE_STDPERIPH_DRIVER
 #if defined(STM32F10X_MD) || defined(STM32F10X_HD)
 #include "stm32f10x.h"
-inline bool HAL_IsISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
 #elif defined(STM32F2XX)
 #include "stm32f2xx.h"
+#endif // defined(STM32F10X_MD) || defined(STM32F10X_HD)
+
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD) || defined(STM32F2XX)
 inline bool HAL_IsISR()
 {
 	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
 }
 
+inline int32_t HAL_ServicedIRQn()
+{
+  return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) - 16;
+}
+
+static inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2)
+{
+  if (irqn1 == irqn2)
+    return false;
+
+  uint32_t priorityGroup = NVIC_GetPriorityGrouping();
+  uint32_t priority1 = NVIC_GetPriority((IRQn_Type)irqn1);
+  uint32_t priority2 = NVIC_GetPriority((IRQn_Type)irqn2);
+  uint32_t p1, sp1, p2, sp2;
+  NVIC_DecodePriority(priority1, priorityGroup, &p1, &sp1);
+  NVIC_DecodePriority(priority2, priorityGroup, &p2, &sp2);
+  if (p1 < p2)
+    return true;
+
+  return false;
+}
 #elif PLATFORM_ID==60000
 inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
 #elif PLATFORM_ID==3
 inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
 #else
 #error "*** MCU architecture not supported by HAL_IsISR(). ***"
 #endif

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -208,53 +208,6 @@ extern void module_user_init_hook(void);
 int HAL_System_Backup_Save(size_t offset, const void* buffer, size_t length, void* reserved);
 int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, size_t* length, void* reserved);
 
-#ifdef USE_STDPERIPH_DRIVER
-#if defined(STM32F10X_MD) || defined(STM32F10X_HD)
-#include "stm32f10x.h"
-#elif defined(STM32F2XX)
-#include "stm32f2xx.h"
-#endif // defined(STM32F10X_MD) || defined(STM32F10X_HD)
-
-#if defined(STM32F10X_MD) || defined(STM32F10X_HD) || defined(STM32F2XX)
-inline bool HAL_IsISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
-
-inline int32_t HAL_ServicedIRQn()
-{
-  return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) - 16;
-}
-
-static inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2)
-{
-  if (irqn1 == irqn2)
-    return false;
-
-  uint32_t priorityGroup = NVIC_GetPriorityGrouping();
-  uint32_t priority1 = NVIC_GetPriority((IRQn_Type)irqn1);
-  uint32_t priority2 = NVIC_GetPriority((IRQn_Type)irqn2);
-  uint32_t p1, sp1, p2, sp2;
-  NVIC_DecodePriority(priority1, priorityGroup, &p1, &sp1);
-  NVIC_DecodePriority(priority2, priorityGroup, &p2, &sp2);
-  if (p1 < p2)
-    return true;
-
-  return false;
-}
-#elif PLATFORM_ID==60000
-inline bool HAL_IsISR() { return false; }
-inline int32_t HAL_ServicedIRQn() { return 0; }
-inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
-#elif PLATFORM_ID==3
-inline bool HAL_IsISR() { return false; }
-inline int32_t HAL_ServicedIRQn() { return 0; }
-inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
-#else
-#error "*** MCU architecture not supported by HAL_IsISR(). ***"
-#endif
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -208,6 +208,25 @@ extern void module_user_init_hook(void);
 int HAL_System_Backup_Save(size_t offset, const void* buffer, size_t length, void* reserved);
 int HAL_System_Backup_Restore(size_t offset, void* buffer, size_t max_length, size_t* length, void* reserved);
 
+#ifdef USE_STDPERIPH_DRIVER
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD)
+#include "stm32f10x.h"
+inline bool HAL_IsISR()
+{
+	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+#elif defined(STM32F2XX)
+#include "stm32f2xx.h"
+inline bool HAL_IsISR()
+{
+	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+
+#else
+#warning "*** MCU architecture not supported by HAL_IsISR(). ***"
+inline bool HAL_IsISR() { return false; }
+#endif
+#endif
 
 #ifdef __cplusplus
 }

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -224,6 +224,8 @@ inline bool HAL_IsISR()
 
 #elif PLATFORM_ID==60000
 inline bool HAL_IsISR() { return false; }
+#elif PLATFORM_ID==3
+inline bool HAL_IsISR() { return false; }
 #else
 #error "*** MCU architecture not supported by HAL_IsISR(). ***"
 #endif

--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -222,9 +222,10 @@ inline bool HAL_IsISR()
 	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
 }
 
-#else
-#warning "*** MCU architecture not supported by HAL_IsISR(). ***"
+#elif PLATFORM_ID==60000
 inline bool HAL_IsISR() { return false; }
+#else
+#error "*** MCU architecture not supported by HAL_IsISR(). ***"
 #endif
 #endif
 

--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -79,6 +79,54 @@ void HAL_System_Interrupt_Trigger(hal_irq_t irq, void* reserved);
 int HAL_disable_irq();
 void HAL_enable_irq(int mask);
 
+#ifdef USE_STDPERIPH_DRIVER
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD)
+#include "stm32f10x.h"
+#elif defined(STM32F2XX)
+#include "stm32f2xx.h"
+#endif // defined(STM32F10X_MD) || defined(STM32F10X_HD)
+
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD) || defined(STM32F2XX)
+inline bool HAL_IsISR()
+{
+	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+}
+
+inline int32_t HAL_ServicedIRQn()
+{
+  return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) - 16;
+}
+
+static inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2)
+{
+  if (irqn1 == irqn2)
+    return false;
+
+  uint32_t priorityGroup = NVIC_GetPriorityGrouping();
+  uint32_t priority1 = NVIC_GetPriority((IRQn_Type)irqn1);
+  uint32_t priority2 = NVIC_GetPriority((IRQn_Type)irqn2);
+  uint32_t p1, sp1, p2, sp2;
+  NVIC_DecodePriority(priority1, priorityGroup, &p1, &sp1);
+  NVIC_DecodePriority(priority2, priorityGroup, &p2, &sp2);
+  if (p1 < p2)
+    return true;
+
+  return false;
+}
+#elif PLATFORM_ID==60000
+inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
+#elif PLATFORM_ID==3
+inline bool HAL_IsISR() { return false; }
+inline int32_t HAL_ServicedIRQn() { return 0; }
+inline bool HAL_WillPreempt(int32_t irqn1, int32_t irqn2) { return false; }
+#else
+#error "*** MCU architecture not supported by HAL_IsISR(). ***"
+#endif
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -79,8 +79,6 @@ void HAL_System_Interrupt_Trigger(hal_irq_t irq, void* reserved);
 int HAL_disable_irq();
 void HAL_enable_irq(int mask);
 
-uint8_t HAL_IsISR();
-
 #ifdef __cplusplus
 }
 #endif

--- a/hal/src/core/interrupts_hal.c
+++ b/hal/src/core/interrupts_hal.c
@@ -249,15 +249,3 @@ void HAL_enable_irq(int is) {
 }
 
 
-inline bool isISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
-
-uint8_t HAL_IsISR()
-{
-	return isISR();
-}
-
-
-

--- a/hal/src/core/usb_settings.h
+++ b/hal/src/core/usb_settings.h
@@ -1,0 +1,26 @@
+/**
+  Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#ifndef USB_SETTINGS_H_
+#define USB_SETTINGS_H_
+
+#define USB_RX_BUFFER_SIZE              256
+
+//#define USB_SERIAL_USERSPACE_BUFFERS    0
+
+#endif /* USB_SETTINGS_H_ */

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -33,17 +33,6 @@
 #include "interrupts_hal.h"
 #include <mutex>
 
-inline bool isISR()
-{
-	return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-}
-
-uint8_t HAL_IsISR()
-{
-	return isISR();
-}
-
-
 // For OpenOCD FreeRTOS support
 extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
 
@@ -321,7 +310,7 @@ static_assert(portMAX_DELAY==CONCURRENT_WAIT_FOREVER, "expected portMAX_DELAY==C
 
 int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay)
 {
-	if (isISR())
+	if (HAL_IsISR())
 		return xQueueSendFromISR(queue, item, nullptr)!=pdTRUE;
 	else
 		return xQueueSend(queue, item, delay)!=pdTRUE;

--- a/hal/src/stm32f2xx/usb_settings.h
+++ b/hal/src/stm32f2xx/usb_settings.h
@@ -1,0 +1,28 @@
+/**
+  Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#ifndef USB_SETTINGS_H_
+#define USB_SETTINGS_H_
+
+#define USB_TX_BUFFER_SIZE              129  /* Total size of IN buffer:
+                                                APP_RX_DATA_SIZE*8/MAX_BAUDARATE*1000 should be > CDC_IN_FRAME_INTERVAL */
+#define USB_RX_BUFFER_SIZE              257
+
+//#define USB_SERIAL_USERSPACE_BUFFERS    1
+
+#endif /* USB_SETTINGS_H_ */

--- a/hal/src/stm32f2xx/usb_settings.h
+++ b/hal/src/stm32f2xx/usb_settings.h
@@ -21,7 +21,7 @@
 
 #define USB_TX_BUFFER_SIZE              129  /* Total size of IN buffer:
                                                 APP_RX_DATA_SIZE*8/MAX_BAUDARATE*1000 should be > CDC_IN_FRAME_INTERVAL */
-#define USB_RX_BUFFER_SIZE              257
+#define USB_RX_BUFFER_SIZE              256
 
 //#define USB_SERIAL_USERSPACE_BUFFERS    1
 

--- a/hal/src/template/interrupts_hal.cpp
+++ b/hal/src/template/interrupts_hal.cpp
@@ -72,7 +72,3 @@ void HAL_enable_irq(int is)
 {
 }
 
-uint8_t HAL_IsISR()
-{
-	return 0;
-}

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_conf.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_conf.h
@@ -86,9 +86,9 @@
 #define CDC_CMD_PACKET_SZE              8    /* Control Endpoint Packet size */
 
 #define CDC_IN_FRAME_INTERVAL           1    /* Number of micro-frames between IN transfers */
-#define USB_TX_BUFFER_SIZE              128  /* Total size of IN buffer:
-                                                APP_RX_DATA_SIZE*8/MAX_BAUDARATE*1000 should be > CDC_IN_FRAME_INTERVAL */
-#define USB_RX_BUFFER_SIZE              256
+// #define USB_TX_BUFFER_SIZE              128  /* Total size of IN buffer:
+//                                                 APP_RX_DATA_SIZE*8/MAX_BAUDARATE*1000 should be > CDC_IN_FRAME_INTERVAL */
+// #define USB_RX_BUFFER_SIZE              256
 
 #define APP_FOPS                        APP_fops
 

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/usbd_mcdc.h
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/usbd_mcdc.h
@@ -1,0 +1,101 @@
+#ifndef USBD_MCDC_H_
+#define USBD_MCDC_H_
+
+#include <stdint.h>
+#include "usbd_ioreq.h"
+
+#define USBD_MCDC_CONFIG_DESC_SIZE              (67)
+#define USBD_MCDC_DESC_SIZE                     (USBD_MCDC_CONFIG_DESC_SIZE - 9)
+
+#define CDC_DESCRIPTOR_TYPE                     0x21
+
+#define DEVICE_CLASS_CDC                        0x02
+#define DEVICE_SUBCLASS_CDC                     0x00
+
+#define USB_DEVICE_DESCRIPTOR_TYPE              0x01
+#define USB_CONFIGURATION_DESCRIPTOR_TYPE       0x02
+#define USB_STRING_DESCRIPTOR_TYPE              0x03
+#define USB_INTERFACE_DESCRIPTOR_TYPE           0x04
+#define USB_ENDPOINT_DESCRIPTOR_TYPE            0x05
+
+#define STANDARD_ENDPOINT_DESC_SIZE             0x09
+
+#define CDC_DATA_IN_PACKET_SIZE                 CDC_DATA_MAX_PACKET_SIZE
+
+#define CDC_DATA_OUT_PACKET_SIZE                CDC_DATA_MAX_PACKET_SIZE
+
+/*---------------------------------------------------------------------*/
+/*  CDC definitions                                                    */
+/*---------------------------------------------------------------------*/
+
+/**************************************************/
+/* CDC Requests                                   */
+/**************************************************/
+#define SEND_ENCAPSULATED_COMMAND               0x00
+#define GET_ENCAPSULATED_RESPONSE               0x01
+#define SET_COMM_FEATURE                        0x02
+#define GET_COMM_FEATURE                        0x03
+#define CLEAR_COMM_FEATURE                      0x04
+#define SET_LINE_CODING                         0x20
+#define GET_LINE_CODING                         0x21
+#define SET_CONTROL_LINE_STATE                  0x22
+#define SEND_BREAK                              0x23
+#define NO_CMD                                  0xFF
+#define ACM_SERIAL_STATE                        0x20
+
+#define CDC_DTR                                 0x01
+#define CDC_RTS                                 0x02
+
+typedef struct USBD_MCDC_Instance_Data {
+  // // Back-reference to USBD_Composite_Class_Data
+  // void* cls;
+
+  LINE_CODING linecoding;
+  uint8_t ep_in_data;
+  uint8_t ep_out_data;
+  uint8_t ep_in_int;
+
+  __ALIGN_BEGIN volatile uint32_t alt_set __ALIGN_END;
+  
+  uint8_t* rx_buffer;
+  uint16_t rx_buffer_size;
+  volatile uint32_t rx_buffer_head;
+  volatile uint32_t rx_buffer_tail;
+  volatile uint32_t rx_buffer_length;
+
+  uint8_t* tx_buffer;
+  uint16_t tx_buffer_size;
+  volatile uint32_t tx_buffer_head;
+  volatile uint32_t tx_buffer_tail;
+  volatile uint32_t tx_failed_counter;
+  volatile uint32_t tx_buffer_last;
+
+  __ALIGN_BEGIN uint8_t cmd_buffer[CDC_CMD_PACKET_SZE] __ALIGN_END;
+
+  volatile uint8_t rx_state;
+  volatile uint8_t tx_state;
+  volatile uint8_t serial_open;
+
+  uint8_t configured;
+
+  uint32_t cmd;
+  uint32_t cmd_len;
+
+  uint32_t frame_count;
+
+  uint8_t ctrl_line;
+
+  uint16_t (*req_handler) (/*USBD_Composite_Class_Data* cls, */uint32_t cmd, uint8_t* buf, uint32_t len);
+
+  const char* name;
+
+  #ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  // Temporary aligned buffer
+  __ALIGN_BEGIN uint8_t descriptor[USBD_MCDC_CONFIG_DESC_SIZE] __ALIGN_END;
+  #endif
+} USBD_MCDC_Instance_Data;
+
+// extern USBD_Multi_Instance_cb_Typedef USBD_MCDC_cb;
+extern USBD_Class_cb_TypeDef USBD_MCDC_cb;
+
+#endif /* USBD_MCDC_H_ */

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/sources.mk
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/sources.mk
@@ -30,8 +30,7 @@ CSRC += $(TARGET_USB_FS_SRC_PATH)/usbd_sflash_if.c
 endif
 
 # cdc/usbserial specific files
-CSRC += $(TARGET_USB_FS_SRC_PATH)/usbd_cdc_core.c
-CSRC += $(TARGET_USB_FS_SRC_PATH)/usbd_cdc_if.c
+CSRC += $(TARGET_USB_FS_SRC_PATH)/usbd_mcdc.c
 
 # C++ source files included in this build.
 CPPSRC +=

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_mcdc.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_mcdc.c
@@ -1,0 +1,664 @@
+#include <string.h>
+#include "usbd_mcdc.h"
+#include "usbd_desc.h"
+#include "usbd_req.h"
+#include "debug.h"
+#include "ringbuf_helper.h"
+
+// LOG_SOURCE_CATEGORY("usb.mcdc")
+
+#define USBD_MCDC_USRSTR_BASE 10
+
+#ifndef MIN
+#define MIN(a, b) (a) < (b) ? (a) : (b)
+#endif
+#ifndef MAX
+#define MAX(a, b) (a) > (b) ? (a) : (b)
+#endif
+
+static uint8_t  USBD_MCDC_Init        (void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t cfgidx);
+static uint8_t  USBD_MCDC_DeInit      (void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t cfgidx);
+static uint8_t  USBD_MCDC_Setup       (void* pdev/*, USBD_Composite_Class_Data* cls*/, USB_SETUP_REQ *req);
+static uint8_t  USBD_MCDC_EP0_RxReady (void* pdev/*, USBD_Composite_Class_Data* cls*/);
+static uint8_t  USBD_MCDC_DataIn      (void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t epnum);
+static uint8_t  USBD_MCDC_DataOut     (void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t epnum);
+static uint8_t  USBD_MCDC_SOF         (void* pdev/*, USBD_Composite_Class_Data* cls*/);
+
+static uint8_t* USBD_MCDC_GetCfgDesc (uint8_t speed/*, USBD_Composite_Class_Data* cls*/, uint16_t *length);
+static uint8_t* USBD_MCDC_GetUsrStrDescriptor(uint8_t speed/*, USBD_Composite_Class_Data* cls*/, uint8_t index, uint16_t* length);
+
+static uint16_t USBD_MCDC_Request_Handler(void* pdev/*, USBD_Composite_Class_Data* cls*/, uint32_t cmd, uint8_t* buf, uint32_t len);
+static int USBD_MCDC_Start_Rx(void *pdev, USBD_MCDC_Instance_Data* priv);
+static void USBD_MCDC_Schedule_Out(void *pdev, USBD_MCDC_Instance_Data* priv);
+
+static const uint8_t USBD_MCDC_CfgDesc[USBD_MCDC_CONFIG_DESC_SIZE] __ALIGN_END;
+
+#ifdef CDC_CMD_EP_SHARED
+static uint8_t USBD_MCDC_Cmd_Ep_Refcount = 0;
+#endif
+
+extern USBD_MCDC_Instance_Data USBD_MCDC;
+
+/* CDC interface class callbacks structure */
+USBD_Class_cb_TypeDef USBD_MCDC_cb =
+{
+  USBD_MCDC_Init,
+  USBD_MCDC_DeInit,
+  USBD_MCDC_Setup,
+  NULL,                 /* EP0_TxSent, */
+  USBD_MCDC_EP0_RxReady,
+  USBD_MCDC_DataIn,
+  USBD_MCDC_DataOut,
+  USBD_MCDC_SOF,
+  NULL,
+  NULL,
+  USBD_MCDC_GetCfgDesc,
+#ifdef USE_USB_OTG_HS
+  USBD_MCDC_GetCfgDesc, /* use same cobfig as per FS */
+#endif /* USE_USB_OTG_HS  */
+  USBD_MCDC_GetUsrStrDescriptor,
+};
+// USBD_Multi_Instance_cb_Typedef USBD_MCDC_cb =
+// {
+//   USBD_MCDC_Init,
+//   USBD_MCDC_DeInit,
+//   USBD_MCDC_Setup,
+//   NULL,                 /* EP0_TxSent, */
+//   USBD_MCDC_EP0_RxReady,
+//   USBD_MCDC_DataIn,
+//   USBD_MCDC_DataOut,
+//   USBD_MCDC_SOF,
+//   NULL,
+//   NULL,
+//   USBD_MCDC_GetCfgDesc,
+// #ifdef USE_USB_OTG_HS
+//   USBD_MCDC_GetCfgDesc, /* use same cobfig as per FS */
+// #endif /* USE_USB_OTG_HS  */
+//   USBD_MCDC_GetUsrStrDescriptor,
+
+// };
+
+static const uint8_t USBD_MCDC_CfgDesc[USBD_MCDC_CONFIG_DESC_SIZE] __ALIGN_END =
+{
+  /*Configuration Descriptor*/
+  0x09,   /* bLength: Configuration Descriptor size */
+  USB_CONFIGURATION_DESCRIPTOR_TYPE,      /* bDescriptorType: Configuration */
+  USBD_MCDC_CONFIG_DESC_SIZE,                /* wTotalLength:no of returned bytes */
+  0x00,
+  0x02,   /* bNumInterfaces: 2 interface */
+  0x01,   /* bConfigurationValue: Configuration value */
+  0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
+  0xC0,   /* bmAttributes: self powered */
+  0x32,   /* MaxPower 100 mA */
+
+  /*---------------------------------------------------------------------------*/
+
+  /*Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_INTERFACE_DESCRIPTOR_TYPE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+  0x00,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x01,   /* bNumEndpoints: One endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+  0x01,   /* bDataInterface: 1 */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+  0x00,   /* bMasterInterface: Communication class interface */
+  0x01,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_ENDPOINT_DESCRIPTOR_TYPE,   /* bDescriptorType: Endpoint */
+  CDC_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SZE),
+#ifdef USE_USB_OTG_HS
+  0x10,                           /* bInterval: */
+#else
+  0xFF,                           /* bInterval: */
+#endif /* USE_USB_OTG_HS */
+
+  /*---------------------------------------------------------------------------*/
+
+  /*Data class interface descriptor*/
+  0x09,   /* bLength: Endpoint Descriptor size */
+  USB_INTERFACE_DESCRIPTOR_TYPE,  /* bDescriptorType: */
+  0x01,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints: Two endpoints used */
+  0x0A,   /* bInterfaceClass: CDC */
+  0x00,   /* bInterfaceSubClass: */
+  0x00,   /* bInterfaceProtocol: */
+  0x00,   /* iInterface: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_ENDPOINT_DESCRIPTOR_TYPE,      /* bDescriptorType: Endpoint */
+  CDC_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_MAX_PACKET_SIZE),
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_ENDPOINT_DESCRIPTOR_TYPE,      /* bDescriptorType: Endpoint */
+  CDC_IN_EP,                         /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_MAX_PACKET_SIZE),
+  0x00                               /* bInterval: ignore for Bulk transfer */
+};
+
+static void USBD_MCDC_Change_Open_State(void* pdev, USBD_MCDC_Instance_Data* priv, uint8_t state) {
+  if (state != priv->serial_open) {
+    // USBD_Composite_Class_Data* cls = (USBD_Composite_Class_Data*)priv->cls;
+    // (void)cls;
+    //LOG_DEBUG(TRACE, "[%s] USB Serial state: %d", priv->name, state);
+    if (state) {
+      priv->tx_failed_counter = 0;
+      // Also flush everything in TX buffer
+      priv->tx_buffer_head = priv->tx_buffer_tail = priv->tx_buffer_last = 0;
+
+      priv->tx_state = 0;
+      USBD_MCDC_Schedule_Out(pdev, priv);
+    }
+    priv->serial_open = state;
+  }
+}
+
+static uint8_t USBD_MCDC_Init(void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t cfgidx)
+{
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+  USBD_MCDC_DeInit(pdev, /*cls,*/ cfgidx);
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  memcpy(priv->descriptor, /*cls->cfg,*/ USBD_MCDC_CfgDesc, USBD_MCDC_DESC_SIZE);
+#endif
+
+  /* Open EP IN */
+  DCD_EP_Open(pdev,
+              priv->ep_in_data,
+              CDC_DATA_IN_PACKET_SIZE,
+              USB_OTG_EP_BULK);
+
+  /* Open EP OUT */
+  DCD_EP_Open(pdev,
+              priv->ep_out_data,
+              CDC_DATA_OUT_PACKET_SIZE,
+              USB_OTG_EP_BULK);
+
+#ifdef CDC_CMD_EP_SHARED
+  if (USBD_MCDC_Cmd_Ep_Refcount++ == 0) {
+#endif
+  if (priv->ep_in_int != priv->ep_in_data) {
+    /* Open Command IN EP */
+    DCD_EP_Open(pdev,
+                priv->ep_in_int,
+                CDC_CMD_PACKET_SZE,
+                USB_OTG_EP_INT);
+  }
+#ifdef CDC_CMD_EP_SHARED
+  }
+#endif
+  priv->configured = 1;
+  priv->rx_state = 1;
+
+  USBD_MCDC_Start_Rx(pdev, priv);
+
+  return USBD_OK;
+}
+
+static uint8_t USBD_MCDC_DeInit(void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t cfgidx)
+{
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+  USBD_MCDC_Change_Open_State(pdev, priv, 0);
+
+  if (priv->configured) {
+    if (priv->tx_state) {
+      DCD_EP_Flush(pdev, priv->ep_in_data);
+    }
+
+    /* Close EP IN */
+    DCD_EP_Close(pdev,
+                 priv->ep_in_data);
+
+    /* Close EP OUT */
+    DCD_EP_Close(pdev,
+                 priv->ep_out_data);
+#ifdef CDC_CMD_EP_SHARED
+    if (--USBD_MCDC_Cmd_Ep_Refcount == 0) {
+#endif
+    if (priv->ep_in_int != priv->ep_in_data) {
+      /* Close Command IN EP */
+      DCD_EP_Close(pdev,
+                   priv->ep_in_int);
+    }
+#ifdef CDC_CMD_EP_SHARED
+    }
+#endif
+  }
+
+  USBD_MCDC_Change_Open_State(pdev, priv, 0);
+
+  priv->configured = 0;
+  priv->tx_state = 0;
+  priv->rx_state = 0;
+  priv->rx_buffer_head = 0;
+  priv->rx_buffer_tail = 0;
+  priv->rx_buffer_length = priv->rx_buffer_size;
+  priv->tx_buffer_head = 0;
+  priv->tx_buffer_tail = 0;
+  priv->tx_buffer_last = 0;
+  priv->frame_count = 0;  
+  priv->cmd = NO_CMD;
+  priv->ctrl_line = 0x00;
+
+  return USBD_OK;
+}
+
+static uint8_t USBD_MCDC_Setup(void* pdev/*, USBD_Composite_Class_Data* cls*/, USB_SETUP_REQ *req)
+{
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+  uint16_t len = 0;
+  uint8_t* pbuf = NULL;
+
+  switch (req->bmRequest & USB_REQ_TYPE_MASK)
+  {
+    /* CDC Class Requests -------------------------------*/
+  case USB_REQ_TYPE_CLASS :
+      /* Check if the request is a data setup packet */
+      if (req->wLength)
+      {
+        /* Check if the request is Device-to-Host */
+        if (req->bmRequest & 0x80)
+        {
+          /* Get the data to be sent to Host from interface layer */
+          USBD_MCDC_Request_Handler(pdev, /*cls,*/ req->bRequest, priv->cmd_buffer, req->wLength);
+
+          /* Send the data to the host */
+          USBD_CtlSendData (pdev,
+                            priv->cmd_buffer,
+                            req->wLength);
+        }
+        else /* Host-to-Device requeset */
+        {
+          /* Set the value of the current command to be processed */
+          priv->cmd = req->bRequest;
+          priv->cmd_len = req->wLength;
+
+          /* Prepare the reception of the buffer over EP0
+          Next step: the received data will be managed in usbd_cdc_EP0_TxSent()
+          function. */
+          USBD_CtlPrepareRx (pdev,
+                             priv->cmd_buffer,
+                             req->wLength);
+        }
+      }
+      else /* No Data request */
+      {
+        /* Transfer the command to the interface layer */
+        USBD_MCDC_Request_Handler(pdev, /*cls,*/ req->bRequest, (uint8_t*)&req->wValue, sizeof(req->wValue));
+      }
+
+      return USBD_OK;
+
+  /* Standard Requests -------------------------------*/
+  case USB_REQ_TYPE_STANDARD: {
+      switch (req->bRequest)
+      {
+      case USB_REQ_GET_DESCRIPTOR:
+        if( (req->wValue >> 8) == CDC_DESCRIPTOR_TYPE)
+        {
+          // For CDC this request should never arrive probably
+  #ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+          pbuf = priv->descriptor;
+  #else
+          // pbuf = cls->cfg;
+          pbuf = (uint8_t*)USBD_MCDC_CfgDesc + 9;
+  #endif
+          len = MIN(USBD_MCDC_DESC_SIZE , req->wLength);
+        }
+
+        USBD_CtlSendData (pdev,
+                          pbuf,
+                          len);
+        break;
+
+      case USB_REQ_GET_INTERFACE :
+        USBD_CtlSendData (pdev,
+                          (uint8_t *)&priv->alt_set,
+                          1);
+        break;
+
+      case USB_REQ_SET_INTERFACE :
+        if ((uint8_t)(req->wValue) < USBD_ITF_MAX_NUM)
+        {
+          priv->alt_set = (uint8_t)(req->wValue);
+        }
+        else
+        {
+          /* Call the error management function (command will be nacked */
+          USBD_CtlError (pdev, req);
+        }
+        break;
+      default:
+        USBD_CtlError(pdev, req);
+        return USBD_OK;
+      }
+    break;
+    }
+
+  default:
+    USBD_CtlError (pdev, req);
+    return USBD_FAIL;
+  }
+  return USBD_OK;
+}
+
+static uint8_t USBD_MCDC_EP0_RxReady(void* pdev/*, USBD_Composite_Class_Data* cls*/)
+{
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+
+  if (priv->cmd != NO_CMD)
+  {
+    // USBD_MCDC_Change_Open_State(priv, 1);
+    /* Process the data */
+    USBD_MCDC_Request_Handler(pdev, /*cls,*/ priv->cmd, priv->cmd_buffer, priv->cmd_len);
+
+    /* Reset the command variable to default value */
+    priv->cmd = NO_CMD;
+  }
+
+  return USBD_OK;
+}
+
+static inline uint32_t USBD_Last_Tx_Packet_size(void *pdev, uint8_t epnum)
+{
+  return ((USB_OTG_CORE_HANDLE*)pdev)->dev.in_ep[epnum].xfer_len;
+}
+
+static inline uint32_t USBD_Last_Rx_Packet_size(void *pdev, uint8_t epnum)
+{
+  return ((USB_OTG_CORE_HANDLE*)pdev)->dev.out_ep[epnum].xfer_count;
+}
+
+static uint8_t USBD_MCDC_DataIn(void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t epnum)
+{
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+  uint32_t USB_Tx_length;
+
+  if ((epnum | 0x80) != (priv->ep_in_data) && (epnum | 0x80) != (priv->ep_in_int)) {
+    return USBD_FAIL;
+  }
+
+  USBD_MCDC_Change_Open_State(pdev, priv, 1);
+
+  if (!priv->tx_state)
+    return USBD_OK;
+
+  priv->tx_failed_counter = 0;
+  priv->tx_buffer_tail = ring_wrap(priv->tx_buffer_size, priv->tx_buffer_tail + priv->tx_buffer_last);
+  priv->tx_buffer_last = 0;
+
+  USB_Tx_length = ring_data_contig(priv->tx_buffer_size, priv->tx_buffer_head, priv->tx_buffer_tail);
+
+  if (USB_Tx_length) {
+    USB_Tx_length = MIN(USB_Tx_length, CDC_DATA_IN_PACKET_SIZE);
+  } else if (USBD_Last_Tx_Packet_size(pdev, epnum) != CDC_DATA_IN_PACKET_SIZE) {
+    priv->tx_state = 0;
+    return USBD_OK;
+  }
+
+  priv->tx_buffer_last = USB_Tx_length;
+
+  /* Prepare the available data buffer to be sent on IN endpoint */
+  DCD_EP_Tx (pdev,
+             priv->ep_in_data,
+             (uint8_t*)&priv->tx_buffer[priv->tx_buffer_tail],
+             USB_Tx_length);
+
+  return USBD_OK;
+}
+
+int USBD_MCDC_Start_Rx(void *pdev, USBD_MCDC_Instance_Data* priv)
+{
+
+  /* USB_Rx_Buffer_length is used here to keep track of
+   * available _contiguous_ buffer space in USB_Rx_Buffer.
+   */
+  uint32_t USB_Rx_length;
+  if (priv->rx_buffer_head >= priv->rx_buffer_tail)
+    priv->rx_buffer_length = priv->rx_buffer_size;
+
+  USB_Rx_length = ring_space_contig(priv->rx_buffer_length, priv->rx_buffer_head, priv->rx_buffer_tail);
+
+  if (USB_Rx_length < CDC_DATA_OUT_PACKET_SIZE) {
+    USB_Rx_length = ring_space_wrapped(priv->rx_buffer_length, priv->rx_buffer_head, priv->rx_buffer_tail);
+    if (USB_Rx_length < CDC_DATA_OUT_PACKET_SIZE) {
+      if (priv->rx_state) {
+        priv->rx_state = 0;
+        DCD_SetEPStatus(pdev, priv->ep_out_data, USB_OTG_EP_RX_NAK);
+      }
+      return 0;
+    }
+    priv->rx_buffer_length = priv->rx_buffer_head;
+    priv->rx_buffer_head = 0;
+    if (priv->rx_buffer_tail == priv->rx_buffer_length)
+      priv->rx_buffer_tail = 0;
+  }
+  if (!priv->rx_state) {
+    priv->rx_state = 1;
+    DCD_SetEPStatus(pdev, priv->ep_out_data, USB_OTG_EP_RX_VALID);
+  }
+
+  DCD_EP_PrepareRx(pdev,
+                   priv->ep_out_data,
+                   priv->rx_buffer + priv->rx_buffer_head,
+                   CDC_DATA_OUT_PACKET_SIZE);
+  return 1;
+}
+
+static uint8_t  USBD_MCDC_DataOut(void* pdev/*, USBD_Composite_Class_Data* cls*/, uint8_t epnum)
+{
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+  if (epnum != (priv->ep_out_data)) {
+    return USBD_FAIL;
+  }
+
+  uint32_t USB_Rx_Count = USBD_Last_Rx_Packet_size(pdev, epnum);
+  priv->rx_buffer_head = ring_wrap(priv->rx_buffer_length, priv->rx_buffer_head + USB_Rx_Count);
+
+  // Serial port is definitely open
+  USBD_MCDC_Change_Open_State(pdev, priv, 1);
+
+  USBD_MCDC_Start_Rx(pdev, priv);
+
+  return USBD_OK;
+}
+
+void USBD_MCDC_Schedule_Out(void *pdev, USBD_MCDC_Instance_Data* priv)
+{
+  if (!priv->rx_state)
+    USBD_MCDC_Start_Rx(pdev, priv);
+}
+
+static void USBD_MCDC_Schedule_In(void *pdev, USBD_MCDC_Instance_Data* priv)
+{
+  uint32_t USB_Tx_length;
+
+  if (priv->tx_state) {
+    if (priv->serial_open) {
+      priv->tx_failed_counter++;
+      if (priv->tx_failed_counter >= 1000) {
+        USBD_MCDC_Change_Open_State(pdev, priv, 0);
+      }
+    }
+
+    if (!priv->serial_open) {
+        // Completely flush TX buffer
+        DCD_EP_Flush(pdev, priv->ep_in_data);
+        // Send ZLP
+        DCD_EP_Tx(pdev, priv->ep_in_data, NULL, 0);
+        priv->tx_buffer_head = 0;
+        priv->tx_buffer_tail = 0;
+        priv->tx_buffer_last = 0;
+        USB_Tx_length = 0;
+
+        priv->tx_state = 0;
+    }
+    return;
+  }
+
+  priv->tx_buffer_tail = ring_wrap(priv->tx_buffer_size, priv->tx_buffer_tail + priv->tx_buffer_last);
+  priv->tx_buffer_last = 0;
+
+  USB_Tx_length = ring_data_contig(priv->tx_buffer_size, priv->tx_buffer_head, priv->tx_buffer_tail);
+
+  if (!USB_Tx_length)
+    return;
+
+  priv->tx_state = 1;
+  priv->tx_failed_counter = 0;
+
+  USB_Tx_length = MIN(USB_Tx_length, CDC_DATA_IN_PACKET_SIZE);
+  priv->tx_buffer_last = USB_Tx_length;
+
+  DCD_EP_Tx (pdev,
+             priv->ep_in_data,
+             (uint8_t*)&priv->tx_buffer[priv->tx_buffer_tail],
+             USB_Tx_length);
+}
+
+static uint8_t USBD_MCDC_SOF(void* pdev/*, USBD_Composite_Class_Data* cls*/)
+{
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+
+  if (priv->configured) {
+    USBD_MCDC_Schedule_In(pdev, priv);
+    USBD_MCDC_Schedule_Out(pdev, priv);
+  }
+
+  return USBD_OK;
+}
+
+static uint8_t* USBD_MCDC_GetCfgDesc(uint8_t speed/*, USBD_Composite_Class_Data* cls, uint8_t* buf*/, uint16_t *length)
+{
+  *length = sizeof(USBD_MCDC_CfgDesc);
+  return (uint8_t*)USBD_MCDC_CfgDesc;
+}
+
+static uint16_t USBD_MCDC_Request_Handler(void* pdev/*, USBD_Composite_Class_Data* cls*/, uint32_t cmd, uint8_t* buf, uint32_t len) {
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+  switch (cmd)
+  {
+  case SEND_ENCAPSULATED_COMMAND:
+      /* Not needed for this driver */
+      break;
+
+  case GET_ENCAPSULATED_RESPONSE:
+      /* Not needed for this driver */
+      break;
+
+  case SET_COMM_FEATURE:
+      /* Not needed for this driver */
+      break;
+
+  case GET_COMM_FEATURE:
+      /* Not needed for this driver */
+      break;
+
+  case CLEAR_COMM_FEATURE:
+      /* Not needed for this driver */
+      break;
+
+  case SET_LINE_CODING:
+      priv->linecoding.bitrate = (uint32_t)(buf[0] | (buf[1] << 8) | (buf[2] << 16) | (buf[3] << 24));
+      priv->linecoding.format = buf[4];
+      priv->linecoding.paritytype = buf[5];
+      priv->linecoding.datatype = buf[6];
+      // LOG_DEBUG(TRACE, "[%s] SET_LINE_CODING %d", priv->name, priv->linecoding.bitrate);
+      break;
+
+  case GET_LINE_CODING:
+      buf[0] = (uint8_t)(priv->linecoding.bitrate);
+      buf[1] = (uint8_t)(priv->linecoding.bitrate >> 8);
+      buf[2] = (uint8_t)(priv->linecoding.bitrate >> 16);
+      buf[3] = (uint8_t)(priv->linecoding.bitrate >> 24);
+      buf[4] = priv->linecoding.format;
+      buf[5] = priv->linecoding.paritytype;
+      buf[6] = priv->linecoding.datatype;
+      break;
+
+  case SET_CONTROL_LINE_STATE:
+      priv->ctrl_line = buf[0];
+      if (priv->ctrl_line & CDC_DTR) {
+        USBD_MCDC_Change_Open_State(pdev, priv, 1);
+      } else if ((priv->ctrl_line & CDC_DTR) == 0x00) {
+        USBD_MCDC_Change_Open_State(pdev, priv, 0);
+      }
+      // LOG_DEBUG(TRACE, "[%s] SET_CONTROL_LINE_STATE DTR=%d RTS=%d", priv->name, priv->ctrl_line & CDC_DTR ? 1 : 0, priv->ctrl_line & CDC_RTS ? 1 : 0);
+      break;
+
+  case SEND_BREAK:
+      /* Not needed for this driver */
+      break;
+
+  default:
+      break;
+  }
+
+  if (priv->req_handler) {
+    priv->req_handler(/*cls, */cmd, buf, len);
+  }
+
+  return USBD_OK;
+}
+
+uint8_t* USBD_MCDC_GetUsrStrDescriptor(uint8_t speed/*, USBD_Composite_Class_Data* cls*/, uint8_t index, uint16_t* length) {
+  // USBD_MCDC_Instance_Data* priv = (USBD_MCDC_Instance_Data*)cls->priv;
+  USBD_MCDC_Instance_Data* priv = &USBD_MCDC;
+
+  if (index == (USBD_MCDC_USRSTR_BASE/* + cls->firstInterface*/)) {
+    USBD_GetString((uint8_t*)priv->name, USBD_StrDesc, length);
+    return USBD_StrDesc;
+  }
+
+  *length = 0;
+  return NULL;
+}

--- a/services/inc/ringbuf_helper.h
+++ b/services/inc/ringbuf_helper.h
@@ -1,0 +1,60 @@
+#ifndef RINGBUF_HELPER_H_
+#define RINGBUF_HELPER_H_
+
+#include <stdint.h>
+
+/* Wrap up buffer index */
+static inline uint32_t ring_wrap(uint32_t size, uint32_t idx)
+{
+  return idx >= size ? idx - size : idx;
+}
+
+/* Returns the number of bytes available in buffer */
+static inline uint32_t ring_data_avail(uint32_t size, uint32_t head, uint32_t tail)
+{
+  if (head >= tail)
+    return head - tail;
+  else
+    return size + head - tail;
+}
+
+/* Returns the amount of free space available in buffer */
+static inline uint32_t ring_space_avail(uint32_t size, uint32_t head, uint32_t tail)
+{
+  if (size == 0)
+    return 0;
+  return size - ring_data_avail(size, head, tail) - 1;
+}
+
+/* Returns the number of contiguous data bytes available in buffer */
+static inline uint32_t ring_data_contig(uint32_t size, uint32_t head, uint32_t tail)
+{
+  if (head >= tail)
+    return head - tail;
+  else
+    return size - tail;
+}
+
+/* Returns the amount of contiguous space available in buffer */
+static inline uint32_t ring_space_contig(uint32_t size, uint32_t head, uint32_t tail)
+{
+  if (size == 0)
+    return 0;
+  if (head >= tail)
+    return (tail ? size : size - 1) - head;
+  else
+    return tail - head - 1;
+}
+
+/* Returns the amount of free space available after wrapping up the head */
+static inline uint32_t ring_space_wrapped(uint32_t size, uint32_t head, uint32_t tail)
+{
+  if (size == 0)
+    return 0;
+  if (head < tail || !tail)
+    return 0;
+  else
+    return tail - 1;
+}
+
+#endif // RINGBUF_HELPER_H_

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -28,6 +28,7 @@
 #include "system_update.h"
 #include "spark_macros.h"
 #include "string.h"
+#include "core_hal.h"
 #include "system_tick_hal.h"
 #include "watchdog_hal.h"
 #include "wlan_hal.h"
@@ -406,8 +407,8 @@ void system_delay_ms(unsigned long ms, bool force_no_background_loop=false)
 {
 	// if not threading, or we are the application thread, then implement delay
 	// as a background message pump
-    if (!system_thread_get_state(NULL) ||
-        APPLICATION_THREAD_CURRENT()) {
+    if ((!system_thread_get_state(NULL) || APPLICATION_THREAD_CURRENT()) && !HAL_IsISR())
+    {
     		system_delay_pump(ms, force_no_background_loop);
     }
     else

--- a/user/tests/wiring/usbserial/application.cpp
+++ b/user/tests/wiring/usbserial/application.cpp
@@ -1,0 +1,6 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+UNIT_TEST_APP();
+
+SYSTEM_MODE(SEMI_AUTOMATIC);

--- a/user/tests/wiring/usbserial/usbserial.cpp
+++ b/user/tests/wiring/usbserial/usbserial.cpp
@@ -1,0 +1,231 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "usb_settings.h"
+#include "ringbuf_helper.h"
+
+int randomString(char *buf, int len) {
+    for (int i = 0; i < len; i++) {
+        uint8_t d = random(0, 15);
+        char c = d + 48;
+        if (57 < c)
+            c += 7;
+        buf[i] = c;
+    }
+
+    return len;
+}
+
+void consume(Stream& serial)
+{
+    while (serial.available() > 0) {
+        (void)serial.read();
+    }
+}
+
+test(0_USBSERIAL_RingBufferHelperIsSane) {
+    uint32_t size = 129;
+    uint32_t head = 0;
+    uint32_t tail = 0;
+
+    head = 0;
+    tail = 0;
+    assertEqual(0, ring_data_avail(size, head, tail));
+    assertEqual(128, ring_space_avail(size, head, tail));
+    assertEqual(0, ring_data_contig(size, head, tail));
+    assertEqual(128, ring_space_contig(size, head, tail));
+    assertEqual(0, ring_space_wrapped(size, head, tail));
+
+    head = 63;
+    tail = 0;
+    assertEqual(63, ring_data_avail(size, head, tail));
+    assertEqual(65, ring_space_avail(size, head, tail));
+    assertEqual(63, ring_data_contig(size, head, tail));
+    assertEqual(65, ring_space_contig(size, head, tail));
+    assertEqual(0, ring_space_wrapped(size, head, tail));
+
+    head = 63;
+    tail = 32;
+    assertEqual(31, ring_data_avail(size, head, tail));
+    assertEqual(97, ring_space_avail(size, head, tail));
+    assertEqual(31, ring_data_contig(size, head, tail));
+    assertEqual(66, ring_space_contig(size, head, tail));
+    assertEqual(31, ring_space_wrapped(size, head, tail));
+
+    head = 63;
+    tail = 63;
+    assertEqual(0, ring_data_avail(size, head, tail));
+    assertEqual(128, ring_space_avail(size, head, tail));
+    assertEqual(0, ring_data_contig(size, head, tail));
+    assertEqual(66, ring_space_contig(size, head, tail));
+    assertEqual(62, ring_space_wrapped(size, head, tail));
+
+    head = 128;
+    tail = 63;
+    assertEqual(65, ring_data_avail(size, head, tail));
+    assertEqual(63, ring_space_avail(size, head, tail));
+    assertEqual(65, ring_data_contig(size, head, tail));
+    assertEqual(1, ring_space_contig(size, head, tail));
+    assertEqual(62, ring_space_wrapped(size, head, tail));
+
+    head = 128;
+    tail = 128;
+    assertEqual(0, ring_data_avail(size, head, tail));
+    assertEqual(128, ring_space_avail(size, head, tail));
+    assertEqual(0, ring_data_contig(size, head, tail));
+    assertEqual(1, ring_space_contig(size, head, tail));
+    assertEqual(127, ring_space_wrapped(size, head, tail));
+
+    head = 0;
+    tail = 63;
+    assertEqual(66, ring_data_avail(size, head, tail));
+    assertEqual(62, ring_space_avail(size, head, tail));
+    assertEqual(66, ring_data_contig(size, head, tail));
+    assertEqual(62, ring_space_contig(size, head, tail));
+    assertEqual(0, ring_space_wrapped(size, head, tail));
+
+    head = 32;
+    tail = 63;
+    assertEqual(98, ring_data_avail(size, head, tail));
+    assertEqual(30, ring_space_avail(size, head, tail));
+    assertEqual(66, ring_data_contig(size, head, tail));
+    assertEqual(30, ring_space_contig(size, head, tail));
+    assertEqual(0, ring_space_wrapped(size, head, tail));
+
+    head = 0;
+    tail = 128;
+    assertEqual(1, ring_data_avail(size, head, tail));
+    assertEqual(127, ring_space_avail(size, head, tail));
+    assertEqual(1, ring_data_contig(size, head, tail));
+    assertEqual(127, ring_space_contig(size, head, tail));
+    assertEqual(0, ring_space_wrapped(size, head, tail));
+
+    head = 128;
+    tail = 0;
+    assertEqual(128, ring_data_avail(size, head, tail));
+    assertEqual(0, ring_space_avail(size, head, tail));
+    assertEqual(128, ring_data_contig(size, head, tail));
+    assertEqual(0, ring_space_contig(size, head, tail));
+    assertEqual(0, ring_space_wrapped(size, head, tail));
+}
+
+test(1_USBSERIAL_ReadWrite) {
+    //The following code will test all the important USB Serial routines
+    char test[] = "hello";
+    char message[10];
+    // when
+    consume(Serial);
+    Serial.print("Type the following message and press Enter: ");
+    Serial.println(test);
+    serialReadLine(&Serial, message, 9, 10000);//10 sec timeout
+    Serial.println("");
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
+}
+
+test(2_USBSERIAL_isConnectedWorksCorrectly) {
+    Serial.println("Please close the USB Serial port and open it again within 60 seconds");
+
+    uint32_t mil = millis();
+    // Wait for 60 seconds maximum for the host to close the USB Serial port
+    while(Serial.isConnected()) {
+        assertTrue((millis() - mil) < 60000);
+    }
+    // Wait for 60 seconds maximum for the host to open the USB Serial port again
+    while(!Serial.isConnected()) {
+        assertTrue((millis() - mil) < 60000);
+    }
+
+    delay(10);
+    Serial.println("Glad too see you back!");
+
+    char test[] = "hello";
+    char message[10];
+    // when
+    consume(Serial);
+    Serial.print("Type the following message and press Enter: ");
+    Serial.println(test);
+    serialReadLine(&Serial, message, 9, 10000);//10 sec timeout
+    Serial.println("");
+    // then
+    assertTrue(strncmp(test, message, 5)==0);
+}
+
+test(3_USBSERIAL_RxBufferFillsCompletely) {
+    Serial.println("We will now test USB Serial RX buffer");
+    Serial.println("Please close the USB Serial port and open it again once the device reattaches");
+
+    uint32_t mil = millis();
+    // Wait for 60 seconds maximum for the host to close the USB Serial port
+    while(Serial.isConnected()) {
+        assertTrue((millis() - mil) < 60000);
+    }
+
+    Serial.end();
+    assertEqual(Serial.isEnabled(), false);
+    Serial.begin();
+    assertEqual(Serial.isEnabled(), true);
+
+    // Wait for 60 seconds maximum for the host to open the USB Serial port again
+    while(!Serial.isConnected()) {
+        assertTrue((millis() - mil) < 60000);
+    }
+
+    assertEqual(Serial.available(), 0);
+
+    delay(10);
+    Serial.println("Glad too see you back!");
+
+    for (int attmpt = 0; attmpt < 3; attmpt++) {
+        char randStr[USB_RX_BUFFER_SIZE + 2];
+        char rStr[USB_RX_BUFFER_SIZE + 2];
+        memset(randStr, 0, USB_RX_BUFFER_SIZE + 2);
+        memset(rStr, 0, USB_RX_BUFFER_SIZE + 2);
+        srand(millis());
+        randomString(randStr, USB_RX_BUFFER_SIZE - 1);
+
+        Serial.println("Please copy and paste the following string:");
+        Serial.println(randStr);
+
+        int32_t avail = 0;
+        mil = millis();
+        uint32_t milsame = 0;
+        while(Serial.available() != (USB_RX_BUFFER_SIZE - 1)) {
+            if (avail == Serial.available() && avail != 0) {
+                if (milsame == 0) {
+                    milsame = millis();
+                } else {
+                    if ((millis() - milsame) >= 5000) {
+                        // Depending on the host driver, we might have received (USB_RX_BUFFER_SIZE - 64)
+                        break;
+                    }
+                }
+            } else {
+                avail = Serial.available();
+                milsame = 0;
+            }
+            assertTrue((millis() - mil) < 120000);
+        }
+        avail = Serial.available();
+        Serial.printf("OK. Read back %d bytes\r\n", avail);
+
+        assertTrue((avail == (USB_RX_BUFFER_SIZE - 1)) ||
+                   (avail >= ((USB_RX_BUFFER_SIZE - 1) / 64 * 64)));
+        for (int i = 0; i < avail; i++) {
+            rStr[i] = Serial.read();
+        }
+
+        Serial.printf("Data: %s\r\n\r\n", rStr);
+
+        assertTrue(!strncmp(randStr, rStr, avail));
+
+        delay(500);
+        while(Serial.available()) {
+            (void)Serial.read();
+        }
+
+        if (!((avail == (USB_RX_BUFFER_SIZE - 1)) || (avail == ((USB_RX_BUFFER_SIZE - 1) / 64 * 64)))) {
+            // Continue only if we received data in 64-byte blocks
+            break;
+        }
+    }
+}

--- a/wiring/inc/spark_wiring_usbserial.h
+++ b/wiring/inc/spark_wiring_usbserial.h
@@ -31,6 +31,7 @@
 #include "usb_hal.h"
 #include "system_task.h"
 
+
 class USBSerial : public Stream
 {
 public:
@@ -38,8 +39,9 @@ public:
 	USBSerial();
 
     unsigned int baud() { return USB_USART_Baud_Rate(); }
-    operator bool() { return baud()!=0; }
+    operator bool() { return isEnabled(); }
     bool isConnected();
+    bool isEnabled() { return baud()!=0; }
 
 	void begin(long speed=9600);
 	void end();

--- a/wiring/inc/spark_wiring_usbserial.h
+++ b/wiring/inc/spark_wiring_usbserial.h
@@ -37,11 +37,11 @@ public:
 	// public methods
 	USBSerial();
 
-        unsigned int baud() { return USB_USART_Baud_Rate(); }
+    unsigned int baud() { return USB_USART_Baud_Rate(); }
+    operator bool() { return baud()!=0; }
+    bool isConnected();
 
-        operator bool() { return baud()!=0; }
-
-	void begin(long speed);
+	void begin(long speed=9600);
 	void end();
 	int peek();
 

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -31,7 +31,7 @@
 //
 USBSerial::USBSerial()
 {
-  _blocking = true;
+    _blocking = true;
 }
 
 //
@@ -46,6 +46,11 @@ void USBSerial::begin(long speed)
 void USBSerial::end()
 {
     USB_USART_Init(0);
+}
+
+bool USBSerial::isConnected()
+{
+    return USB_USART_Available_Data_For_Write() >= 0;
 }
 
 


### PR DESCRIPTION
- Almost 1-1 USB CDC driver implementation backport from `develop`, without composite support:
  - DTR/RTS support (open/closed detection: `Serial.isConnected()`)
  - Fixes the issue of USB Serial erroneously switching to closed state
  - Various other small fixes and improvements
- Cleaned up old USB HAL (`USB_USART_`) functions to behave like their new (`HAL_USB_`) counterparts in 0.6.x
- Added `wiring/usbserial` tests:
  - 0_USBSERIAL_RingBufferHelperIsSane
  - 1_USBSERIAL_ReadWrite
  - 2_USBSERIAL_isConnectedWorksCorrectly
  - 3_USBSERIAL_RxBufferFillsCompletely

This PR includes #1072

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation

DTR/RTS support (open/closed detection: Serial.isConnected()) will be _since 0.5.3_

- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

FEATURE

- DTR/RTS support (open/closed detection: `Serial.isConnected()`). [#1073](https://github.com/spark/firmware/pull/1073)

BUGFIX

- Fixes an issue of USB Serial erroneously switching to closed state. [#1073](https://github.com/spark/firmware/pull/1073)