### PR TITLE
Feature/automated buildpacks 0.5.x

### DIFF
--- a/.buildpackrc
+++ b/.buildpackrc
@@ -1,0 +1,21 @@
+# This file is used by https://github.com/spark/firmware-buildpack-builder to
+# build Docker images containing all toolchains and sources nessesary for
+# compilation.
+#
+# Additionally release/prerelease information is used to automatically create
+# build targets in Particle Cloud when pushing a tag.
+
+# GCC buildpack variation to use ( see: https://hub.docker.com/r/particle/buildpack-hal/tags/ )
+export BUILDPACK_VARIATION=gcc-arm-none-eabi-4_9-2015q3
+
+# Platforms for which this firmware is considered stable
+export RELEASE_PLATFORMS=( )
+# Platforms for which this firmware is considered experimental
+export PRERELEASE_PLATFORMS=( core photon p1 electron )
+# Note: a single platform should be only in release or prerelease list. If
+# added to both it will be considered a prerelease
+
+# Platform IDs which require modules to be prebuild
+export MODULAR_PLATFORMS=( photon p1 electron )
+# Example GCC ARM version override for FOO platform
+export BUILDPACK_VARIATION_PLATFORM_FOO=gcc-arm-none-eabi-5_3-2016q1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ services:
 install:
   - 'if [ ! -z "$DOCKER_HUB_EMAIL" ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD; fi'
   - wget https://github.com/spark/firmware-buildpack-builder/archive/master.tar.gz -O - | tar -xz -C ../ --strip-components 1
-  - ../bin/build-image
+  - ../scripts/build-image
 
 script:
-  - ../bin/run-tests
+  - ../scripts/run-tests-in-container
   # - 'if [ "${UNIT_TEST}" = "y" ]; then ./ci/unit_tests.sh; else cd $DIR && make -s clean all DEBUG_BUILD=$DEBUG_BUILD PLATFORM=$PLATFORM COMPILE_LTO=$COMPILE_LTO TEST=$TEST SPARK_CLOUD=$SPARK_CLOUD APP=$APP; fi'
   # TODO - ./ci/integration_tests.sh
   # TODO  - ./ci/test_memory_available_with_real_core.sh
 
 #after_success: ./ci/update-gh-pages.sh
-after_success: ../bin/push-image
+after_success: ../scripts/push-image
 
 env:
   # matrix:

--- a/build/platform-id.mk
+++ b/build/platform-id.mk
@@ -52,6 +52,10 @@ ifeq ("$(PLATFORM)","P1")
 PLATFORM_ID = 8
 endif
 
+ifeq ("$(PLATFORM)","p1")
+PLATFORM_ID = 8
+endif
+
 ifeq ("$(PLATFORM)","ethernet")
 PLATFORM_ID = 9
 endif


### PR DESCRIPTION
From original PR https://github.com/spark/firmware/pull/1068

This PR updates how firmware buildpacks are build. It introduces `.buildpackrc` file which specifies for which platforms buildpacks should be prebuild, and for which platforms this firmware is considered stable/prerelease. It also allows to specify which GCC version should be used for specific platform.

With this merged in, it's encouraged to update `RELEASE_PLATFORMS` and `PRERELEASE_PLATFORMS` before releasing new version to reflect how build targets should be created. 

Also added lowercase `p1` platform alias.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled

N/A
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)