### PR TITLE
feature/electron/spi1-dma-bugfix

### DIFF
--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -77,7 +77,7 @@ IDX[x] = added IRQ handler
 26 [x] EXTI4_IRQHandler                  // EXTI Line4
 27 [ ] DMA1_Stream0_IRQHandler           // DMA1 Stream 0
 28 [ ] DMA1_Stream1_IRQHandler           // DMA1 Stream 1
-29 [ ] DMA1_Stream2_IRQHandler           // DMA1 Stream 2
+29 [x] DMA1_Stream2_IRQHandler           // DMA1 Stream 2
 30 [ ] DMA1_Stream3_IRQHandler           // DMA1 Stream 3
 31 [ ] DMA1_Stream4_IRQHandler           // DMA1 Stream 4
 32 [ ] DMA1_Stream5_IRQHandler           // DMA1 Stream 5
@@ -162,6 +162,7 @@ const unsigned EXTI1_IRQHandler_Idx                 = 23;
 const unsigned EXTI2_IRQHandler_Idx                 = 24;
 const unsigned EXTI3_IRQHandler_Idx                 = 25;
 const unsigned EXTI4_IRQHandler_Idx                 = 26;
+const unsigned DMA1_Stream2_IRQHandler_Idx          = 29;
 const unsigned ADC_IRQHandler_Idx                   = 34;
 const unsigned CAN1_TX_IRQHandler_Idx               = 35;
 const unsigned CAN1_RX0_IRQHandler_Idx              = 36;
@@ -291,6 +292,8 @@ void HAL_Core_Setup_override_interrupts(void)
     isrs[I2C3_ER_IRQHandler_Idx]            = (uint32_t)I2C3_ER_irq;
     isrs[DMA1_Stream7_IRQHandler_Idx]       = (uint32_t)DMA1_Stream7_irq;
     isrs[DMA2_Stream5_IRQHandler_Idx]       = (uint32_t)DMA2_Stream5_irq;
+    isrs[DMA1_Stream2_IRQHandler_Idx]       = (uint32_t)DMA1_Stream2_irq;
+
     isrs[RTC_Alarm_IRQHandler_Idx]          = (uint32_t)RTC_Alarm_irq;
     SCB->VTOR = (unsigned long)isrs;
 }
@@ -600,7 +603,7 @@ void FLASH_IRQHandler(void)         {__ASM("bkpt 0");}
 void RCC_IRQHandler(void)           {__ASM("bkpt 0");}
 void DMA1_Stream0_IRQHandler(void)  {__ASM("bkpt 0");}
 void DMA1_Stream1_IRQHandler(void)  {__ASM("bkpt 0");}
-void DMA1_Stream2_IRQHandler(void)  {__ASM("bkpt 0");}
+//void DMA1_Stream2_IRQHandler(void)  {__ASM("bkpt 0");}
 void DMA1_Stream3_IRQHandler(void)  {__ASM("bkpt 0");}
 void DMA1_Stream4_IRQHandler(void)  {__ASM("bkpt 0");}
 void DMA1_Stream5_IRQHandler(void)  {__ASM("bkpt 0");}

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -544,7 +544,12 @@ bool HAL_SPI_Is_Enabled_Old()
 void DMA1_Stream7_irq(void)
 {
     //HAL_SPI_INTERFACE2 and HAL_SPI_INTERFACE3 shares same DMA peripheral and stream
-    HAL_SPI_TX_DMA_Stream_InterruptHandler(HAL_SPI_INTERFACE2);
+#if TOTAL_SPI==3
+    if (spiState[HAL_SPI_INTERFACE3].SPI_DMA_Configured)
+        HAL_SPI_TX_DMA_Stream_InterruptHandler(HAL_SPI_INTERFACE3);
+    else
+#endif
+        HAL_SPI_TX_DMA_Stream_InterruptHandler(HAL_SPI_INTERFACE2);
 }
 
 /**
@@ -565,7 +570,12 @@ void DMA2_Stream5_irq(void)
 void DMA1_Stream2_irq(void)
 {
     //HAL_SPI_INTERFACE2 and HAL_SPI_INTERFACE3 shares same DMA peripheral and stream
-    HAL_SPI_RX_DMA_Stream_InterruptHandler(HAL_SPI_INTERFACE2);
+#if TOTAL_SPI==3
+    if (spiState[HAL_SPI_INTERFACE3].SPI_DMA_Configured)
+        HAL_SPI_RX_DMA_Stream_InterruptHandler(HAL_SPI_INTERFACE3);
+    else
+#endif
+        HAL_SPI_RX_DMA_Stream_InterruptHandler(HAL_SPI_INTERFACE2);
 }
 
 /**

--- a/user/tests/wiring/no_fixture/spi.cpp
+++ b/user/tests/wiring/no_fixture/spi.cpp
@@ -2,6 +2,13 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
+static volatile uint8_t DMA_Completed_Flag = 0;
+
+static void SPI_DMA_Completed_Callback()
+{
+    DMA_Completed_Flag = 1;
+}
+
 void assertClockDivider(unsigned reference, unsigned desired, uint8_t expected_divider, unsigned expected_clock)
 {
     unsigned clock;
@@ -22,3 +29,127 @@ test(SPI_01_computeClockSpeed)
     assertClockDivider(60*MHZ, 300*KHZ, SPI_CLOCK_DIV256, 234375*HZ);
     assertClockDivider(60*MHZ, 1*KHZ, SPI_CLOCK_DIV256, 234375*HZ);
 }
+
+test(SPI_02_SPI_DMA_Transfers_Work_Correctly)
+{
+    SPI.begin();
+    uint8_t tempBuf[256];
+    uint8_t tempBuf1[256];
+    uint32_t m;
+
+    DMA_Completed_Flag = 0;
+    SPI.transfer(tempBuf, 0, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+
+    memset(tempBuf, 0xAA, sizeof(tempBuf));
+    DMA_Completed_Flag = 0;
+    SPI.transfer(0, tempBuf, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+    for (const auto& v : tempBuf) {
+        assertNotEqual(v, 0xAA);
+    }
+
+    memset(tempBuf, 0xAA, sizeof(tempBuf));
+    DMA_Completed_Flag = 0;
+    SPI.transfer(tempBuf1, tempBuf, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+
+    for (const auto& v : tempBuf) {
+        assertNotEqual(v, 0xAA);
+    }
+
+    SPI.end();
+}
+
+#if Wiring_SPI1
+test(SPI_03_SPI1_DMA_Transfers_Work_Correctly)
+{
+    SPI1.begin();
+    uint8_t tempBuf[256];
+    uint8_t tempBuf1[256];
+    uint32_t m;
+
+    DMA_Completed_Flag = 0;
+    SPI1.transfer(tempBuf, 0, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+
+    memset(tempBuf, 0xAA, sizeof(tempBuf));
+    DMA_Completed_Flag = 0;
+    SPI1.transfer(0, tempBuf, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+    for (const auto& v : tempBuf) {
+        assertNotEqual(v, 0xAA);
+    }
+
+    memset(tempBuf, 0xAA, sizeof(tempBuf));
+    DMA_Completed_Flag = 0;
+    SPI1.transfer(tempBuf1, tempBuf, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+
+    for (const auto& v : tempBuf) {
+        assertNotEqual(v, 0xAA);
+    }
+
+    SPI1.end();
+}
+#endif
+
+#if Wiring_SPI2
+test(SPI_04_SPI2_DMA_Transfers_Work_Correctly)
+{
+    SPI2.begin();
+    uint8_t tempBuf[256];
+    uint8_t tempBuf1[256];
+    uint32_t m;
+
+    DMA_Completed_Flag = 0;
+    SPI2.transfer(tempBuf, 0, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+
+    memset(tempBuf, 0xAA, sizeof(tempBuf));
+    DMA_Completed_Flag = 0;
+    SPI2.transfer(0, tempBuf, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+    for (const auto& v : tempBuf) {
+        assertNotEqual(v, 0xAA);
+    }
+
+    memset(tempBuf, 0xAA, sizeof(tempBuf));
+    DMA_Completed_Flag = 0;
+    SPI2.transfer(tempBuf1, tempBuf, sizeof(tempBuf), SPI_DMA_Completed_Callback);
+    m = millis();
+    while(!DMA_Completed_Flag) {
+        assertLessOrEqual((millis() - m), 2000);
+    }
+
+    for (const auto& v : tempBuf) {
+        assertNotEqual(v, 0xAA);
+    }
+
+    SPI2.end();
+}
+#endif

--- a/user/tests/wiring/spi_master_slave/spi_master/build.mk
+++ b/user/tests/wiring/spi_master_slave/spi_master/build.mk
@@ -1,0 +1,28 @@
+INCLUDE_DIRS += $(SOURCE_PATH)/$(USRSRC)  # add user sources to include path
+# add C and CPP files - if USRSRC is not empty, then add a slash
+CPPSRC += $(call target_files,$(USRSRC_SLASH),*.cpp)
+CSRC += $(call target_files,$(USRSRC_SLASH),*.c)
+
+APPSOURCES=$(call target_files,$(USRSRC_SLASH),*.cpp)
+APPSOURCES+=$(call target_files,$(USRSRC_SLASH),*.c)
+ifeq ($(strip $(APPSOURCES)),)
+$(error "No sources found in $(SOURCE_PATH)/$(USRSRC)")
+endif
+
+ifeq ("${USE_SPI}",)
+USE_SPI=SPI
+USE_CS=A2
+else ifeq ("${USE_SPI}","SPI1")
+USE_SPI=SPI1
+USE_CS=D5
+else ifeq ("${USE_SPI}","SPI2")
+USE_SPI=SPI2
+USE_CS=C0
+else
+USE_SPI=SPI
+USE_CS=A2
+endif
+
+CFLAGS += -DUSE_SPI=${USE_SPI} -DUSE_CS=${USE_CS}
+CXXFLAGS += -DUSE_SPI=${USE_SPI} -DUSE_CS=${USE_CS}
+

--- a/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
@@ -10,20 +10,68 @@
 
 #define SPI_DELAY 5
 
+#ifndef USE_SPI
+#error Define USE_SPI
+#endif
+
+#ifndef USE_CS
+#error Define USE_CS
+#endif
+
+/*
+ * Wiring diagrams
+ *
+ * SPI/SPI                        SPI1/SPI                       SPI2/SPI
+ * Master: SPI (USE_SPI=SPI)      Master: SPI1 (USE_SPI=SPI1)    Master: SPI2 (USE_SPI=SPI2)
+ * Slave:  SPI (USE_SPI=SPI)      Slave:  SPI  (USE_SPI=SPI)     Slave:  SPI  (USE_SPI=SPI)
+ *
+ * Master              Slave      Master              Slave      Master              Slave
+ * MOSI A5 <---------> A5 MOSI    MOSI D2 <---------> A5 MOSI    MOSI C1 <---------> A5 MOSI
+ * MISO A4 <---------> A4 MISO    MISO D3 <---------> A4 MISO    MISO C2 <---------> A4 MISO
+ * SCK  A3 <---------> A3 SCK     SCK  D4 <---------> A3 SCK     SCK  C3 <---------> A3 SCK
+ * CS   A2 <---------> A2 CS      CS   D5 <---------> A2 CS      CS   C0 <---------> A2 CS
+ *
+ *********************************************************************************************
+ *
+ * SPI/SPI1                       SPI1/SPI1                      SPI2/SPI1
+ * Master: SPI  (USE_SPI=SPI)     Master: SPI1 (USE_SPI=SPI1)    Master: SPI2 (USE_SPI=SPI2)
+ * Slave:  SPI1 (USE_SPI=SPI1)    Slave:  SPI1 (USE_SPI=SPI1)    Slave:  SPI1 (USE_SPI=SPI1)
+ *
+ * Master              Slave      Master              Slave      Master              Slave
+ * MOSI A5 <---------> D2 MOSI    MOSI D2 <---------> D2 MOSI    MOSI C1 <---------> D2 MOSI
+ * MISO A4 <---------> D3 MISO    MISO D3 <---------> D3 MISO    MISO C2 <---------> D3 MISO
+ * SCK  A3 <---------> D4 SCK     SCK  D4 <---------> D4 SCK     SCK  C3 <---------> D4 SCK
+ * CS   A2 <---------> D5 CS      CS   D5 <---------> D5 CS      CS   C0 <---------> D5 CS
+ *
+ *********************************************************************************************
+ *
+ * SPI/SPI2                       SPI1/SPI2                      SPI2/SPI2
+ * Master: SPI  (USE_SPI=SPI)     Master: SPI1 (USE_SPI=SPI1)    Master: SPI2 (USE_SPI=SPI2)
+ * Slave:  SPI2 (USE_SPI=SPI2     Slave:  SPI2 (USE_SPI=SPI2)    Slave:  SPI2 (USE_SPI=SPI2)
+ *
+ * Master              Slave      Master              Slave      Master              Slave
+ * MOSI A5 <---------> C1 MOSI    MOSI D2 <---------> C1 MOSI    MOSI C1 <---------> C1 MOSI
+ * MISO A4 <---------> C2 MISO    MISO D3 <---------> C2 MISO    MISO C2 <---------> C2 MISO
+ * SCK  A3 <---------> C3 SCK     SCK  D4 <---------> C3 SCK     SCK  C3 <---------> C3 SCK
+ * CS   A2 <---------> C0 CS      CS   D5 <---------> C0 CS      CS   C0 <---------> C0 CS
+ *
+ *********************************************************************************************
+ */
+
 static uint8_t SPI_Master_Tx_Buffer[TRANSFER_LENGTH_2];
 static uint8_t SPI_Master_Rx_Buffer[TRANSFER_LENGTH_2];
 static volatile uint8_t DMA_Completed_Flag = 0;
 
 static void SPI_Master_Configure()
 {
-    if (!SPI.isEnabled()) {
+    if (!USE_SPI.isEnabled()) {
         // Run SPI bus at 1 MHz, so that this test works reliably even if the
         // devices are connected with jumper wires
-        SPI.setClockSpeed(1, MHZ);
-        SPI.begin(A2);
+        USE_SPI.setClockSpeed(1, MHZ);
+        USE_SPI.begin(USE_CS);
 
         // Clock dummy byte just in case
-        (void)SPI.transfer(0xff);
+        (void)USE_SPI.transfer(0xff);
     }
 }
 
@@ -35,7 +83,7 @@ static void SPI_DMA_Completed_Callback()
 static void SPI_Master_Transfer_No_DMA(uint8_t* txbuf, uint8_t* rxbuf, int length) {
     for(int count = 0; count < length; count++)
     {
-        uint8_t tmp = SPI.transfer(txbuf ? txbuf[count] : 0xff);
+        uint8_t tmp = USE_SPI.transfer(txbuf ? txbuf[count] : 0xff);
         if (rxbuf)
             rxbuf[count] = tmp;
     }
@@ -44,12 +92,12 @@ static void SPI_Master_Transfer_No_DMA(uint8_t* txbuf, uint8_t* rxbuf, int lengt
 static void SPI_Master_Transfer_DMA(uint8_t* txbuf, uint8_t* rxbuf, int length, HAL_SPI_DMA_UserCallback cb) {
     if (cb) {
         DMA_Completed_Flag = 0;
-        SPI.transfer(txbuf, rxbuf, length, cb);
+        USE_SPI.transfer(txbuf, rxbuf, length, cb);
         while(DMA_Completed_Flag == 0);
-        assertEqual(length, SPI.available());
+        assertEqual(length, USE_SPI.available());
     } else {
-        SPI.transfer(txbuf, rxbuf, length, NULL);
-        assertEqual(length, SPI.available());
+        USE_SPI.transfer(txbuf, rxbuf, length, NULL);
+        assertEqual(length, USE_SPI.available());
     }
 }
 
@@ -65,7 +113,7 @@ bool SPI_Master_Slave_Change_Mode(uint8_t mode, uint8_t bitOrder, std::function<
     memset(SPI_Master_Rx_Buffer, 0, sizeof(SPI_Master_Rx_Buffer));
 
     // Select
-    digitalWrite(A2, LOW);
+    digitalWrite(USE_CS, LOW);
     delay(SPI_DELAY);
 
     memcpy(SPI_Master_Tx_Buffer, MASTER_TEST_MESSAGE, sizeof(MASTER_TEST_MESSAGE));
@@ -75,14 +123,14 @@ bool SPI_Master_Slave_Change_Mode(uint8_t mode, uint8_t bitOrder, std::function<
 
     transferFunc(SPI_Master_Tx_Buffer, SPI_Master_Rx_Buffer, TRANSFER_LENGTH_1);
 
-    digitalWrite(A2, HIGH);
+    digitalWrite(USE_CS, HIGH);
     delay(SPI_DELAY * 10);
 
     bool ret = (strncmp((const char *)SPI_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_1, sizeof(SLAVE_TEST_MESSAGE_1)) == 0);
 
     // Apply new settings here
-    SPI.setDataMode(mode);
-    SPI.setBitOrder(bitOrder);
+    USE_SPI.setDataMode(mode);
+    USE_SPI.setBitOrder(bitOrder);
     SPI_Master_Configure();
 
     return ret;
@@ -103,14 +151,14 @@ void SPI_Master_Slave_Master_Test_Routine(std::function<void(uint8_t*, uint8_t*,
         memset(SPI_Master_Rx_Buffer, 0, sizeof(SPI_Master_Rx_Buffer));
 
         // Select
-        digitalWrite(A2, LOW);
+        digitalWrite(USE_CS, LOW);
         delay(SPI_DELAY);
 
         memcpy(SPI_Master_Tx_Buffer, MASTER_TEST_MESSAGE, sizeof(MASTER_TEST_MESSAGE));
         memcpy(SPI_Master_Tx_Buffer + sizeof(MASTER_TEST_MESSAGE), (void*)&requestedLength, sizeof(uint32_t));
 
         transferFunc(SPI_Master_Tx_Buffer, SPI_Master_Rx_Buffer, TRANSFER_LENGTH_1);
-        digitalWrite(A2, HIGH);
+        digitalWrite(USE_CS, HIGH);
         // Serial.print("< ");
         // Serial.println((const char *)SPI_Master_Rx_Buffer);
         assertTrue(strncmp((const char *)SPI_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_1, sizeof(SLAVE_TEST_MESSAGE_1)) == 0);
@@ -119,7 +167,7 @@ void SPI_Master_Slave_Master_Test_Routine(std::function<void(uint8_t*, uint8_t*,
         if (requestedLength == 0)
             break;
 
-        digitalWrite(A2, LOW);
+        digitalWrite(USE_CS, LOW);
         delay(SPI_DELAY);
 
         // Received a good first reply from Slave
@@ -127,7 +175,7 @@ void SPI_Master_Slave_Master_Test_Routine(std::function<void(uint8_t*, uint8_t*,
         memset(SPI_Master_Rx_Buffer, 0, sizeof(SPI_Master_Rx_Buffer));
         transferFunc(NULL, SPI_Master_Rx_Buffer, requestedLength);
         // Deselect
-        digitalWrite(A2, HIGH);
+        digitalWrite(USE_CS, HIGH);
         delay(SPI_DELAY);
         // Serial.print("< ");
         // Serial.println((const char *)SPI_Master_Rx_Buffer);

--- a/user/tests/wiring/spi_master_slave/spi_slave/build.mk
+++ b/user/tests/wiring/spi_master_slave/spi_slave/build.mk
@@ -1,0 +1,28 @@
+INCLUDE_DIRS += $(SOURCE_PATH)/$(USRSRC)  # add user sources to include path
+# add C and CPP files - if USRSRC is not empty, then add a slash
+CPPSRC += $(call target_files,$(USRSRC_SLASH),*.cpp)
+CSRC += $(call target_files,$(USRSRC_SLASH),*.c)
+
+APPSOURCES=$(call target_files,$(USRSRC_SLASH),*.cpp)
+APPSOURCES+=$(call target_files,$(USRSRC_SLASH),*.c)
+ifeq ($(strip $(APPSOURCES)),)
+$(error "No sources found in $(SOURCE_PATH)/$(USRSRC)")
+endif
+
+ifeq ("${USE_SPI}",)
+USE_SPI=SPI
+USE_CS=A2
+else ifeq ("${USE_SPI}","SPI1")
+USE_SPI=SPI1
+USE_CS=D5
+else ifeq ("${USE_SPI}","SPI2")
+USE_SPI=SPI2
+USE_CS=C0
+else
+USE_SPI=SPI
+USE_CS=A2
+endif
+
+CFLAGS += -DUSE_SPI=${USE_SPI} -DUSE_CS=${USE_CS}
+CXXFLAGS += -DUSE_SPI=${USE_SPI} -DUSE_CS=${USE_CS}
+

--- a/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
@@ -7,6 +7,54 @@
 #define TRANSFER_LENGTH_1 (sizeof(MASTER_TEST_MESSAGE) + sizeof(uint32_t) + sizeof(uint32_t))
 #define TRANSFER_LENGTH_2 sizeof(SLAVE_TEST_MESSAGE_2)
 
+#ifndef USE_SPI
+#error Define USE_SPI
+#endif
+
+#ifndef USE_CS
+#error Define USE_CS
+#endif
+
+/*
+ * Wiring diagrams
+ *
+ * SPI/SPI                        SPI1/SPI                       SPI2/SPI
+ * Master: SPI (USE_SPI=SPI)      Master: SPI1 (USE_SPI=SPI1)    Master: SPI2 (USE_SPI=SPI2)
+ * Slave:  SPI (USE_SPI=SPI)      Slave:  SPI  (USE_SPI=SPI)     Slave:  SPI  (USE_SPI=SPI)
+ *
+ * Master              Slave      Master              Slave      Master              Slave
+ * MOSI A5 <---------> A5 MOSI    MOSI D2 <---------> A5 MOSI    MOSI C1 <---------> A5 MOSI
+ * MISO A4 <---------> A4 MISO    MISO D3 <---------> A4 MISO    MISO C2 <---------> A4 MISO
+ * SCK  A3 <---------> A3 SCK     SCK  D4 <---------> A3 SCK     SCK  C3 <---------> A3 SCK
+ * CS   A2 <---------> A2 CS      CS   D5 <---------> A2 CS      CS   C0 <---------> A2 CS
+ *
+ *********************************************************************************************
+ *
+ * SPI/SPI1                       SPI1/SPI1                      SPI2/SPI1
+ * Master: SPI  (USE_SPI=SPI)     Master: SPI1 (USE_SPI=SPI1)    Master: SPI2 (USE_SPI=SPI2)
+ * Slave:  SPI1 (USE_SPI=SPI1)    Slave:  SPI1 (USE_SPI=SPI1)    Slave:  SPI1 (USE_SPI=SPI1)
+ *
+ * Master              Slave      Master              Slave      Master              Slave
+ * MOSI A5 <---------> D2 MOSI    MOSI D2 <---------> D2 MOSI    MOSI C1 <---------> D2 MOSI
+ * MISO A4 <---------> D3 MISO    MISO D3 <---------> D3 MISO    MISO C2 <---------> D3 MISO
+ * SCK  A3 <---------> D4 SCK     SCK  D4 <---------> D4 SCK     SCK  C3 <---------> D4 SCK
+ * CS   A2 <---------> D5 CS      CS   D5 <---------> D5 CS      CS   C0 <---------> D5 CS
+ *
+ *********************************************************************************************
+ *
+ * SPI/SPI2                       SPI1/SPI2                      SPI2/SPI2
+ * Master: SPI  (USE_SPI=SPI)     Master: SPI1 (USE_SPI=SPI1)    Master: SPI2 (USE_SPI=SPI2)
+ * Slave:  SPI2 (USE_SPI=SPI2     Slave:  SPI2 (USE_SPI=SPI2)    Slave:  SPI2 (USE_SPI=SPI2)
+ *
+ * Master              Slave      Master              Slave      Master              Slave
+ * MOSI A5 <---------> C1 MOSI    MOSI D2 <---------> C1 MOSI    MOSI C1 <---------> C1 MOSI
+ * MISO A4 <---------> C2 MISO    MISO D3 <---------> C2 MISO    MISO C2 <---------> C2 MISO
+ * SCK  A3 <---------> C3 SCK     SCK  D4 <---------> C3 SCK     SCK  C3 <---------> C3 SCK
+ * CS   A2 <---------> C0 CS      CS   D5 <---------> C0 CS      CS   C0 <---------> C0 CS
+ *
+ *********************************************************************************************
+ */
+
 static uint8_t SPI_Slave_Tx_Buffer[TRANSFER_LENGTH_2];
 static uint8_t SPI_Slave_Rx_Buffer[TRANSFER_LENGTH_2];
 static volatile uint8_t DMA_Completed_Flag = 0;
@@ -28,9 +76,9 @@ static inline void SPI_Transfer_DMA(uint8_t *tx, uint8_t *rx, int length, HAL_SP
     while (true)
     {
         DMA_Completed_Flag = cb ? 0 : 1;
-        SPI.transfer(tx, rx, length, cb);
+        USE_SPI.transfer(tx, rx, length, cb);
         while(DMA_Completed_Flag == 0);
-        if (SPI.available() == 0)
+        if (USE_SPI.available() == 0)
         {
             /* 0 length transfer means that we got deselected by master and nothing got clocked in. Try again? */
             continue;
@@ -40,15 +88,15 @@ static inline void SPI_Transfer_DMA(uint8_t *tx, uint8_t *rx, int length, HAL_SP
 }
 
 static void SPI_Init(uint8_t mode, uint8_t bitOrder) {
-    if (SPI.isEnabled()) {
-        SPI.end();
+    if (USE_SPI.isEnabled()) {
+        USE_SPI.end();
     }
 
-    SPI.onSelect(SPI_On_Select);
-    SPI.setBitOrder(bitOrder);
-    SPI.setDataMode(mode);
+    USE_SPI.onSelect(SPI_On_Select);
+    USE_SPI.setBitOrder(bitOrder);
+    USE_SPI.setDataMode(mode);
 
-    SPI.begin(SPI_MODE_SLAVE, A2);
+    USE_SPI.begin(SPI_MODE_SLAVE, USE_CS);
 }
 
 test(SPI_Master_Slave_Slave_Transfer)
@@ -78,7 +126,7 @@ test(SPI_Master_Slave_Slave_Transfer)
         /* Receive up to TRANSFER_LENGTH_2 bytes */
         SPI_Transfer_DMA(SPI_Slave_Tx_Buffer, SPI_Slave_Rx_Buffer, TRANSFER_LENGTH_2, count % 2 == 0 ? &SPI_DMA_Completed_Callback : NULL);
         /* Check how many bytes we have received */
-        assertEqual(SPI.available(), TRANSFER_LENGTH_1);
+        assertEqual(USE_SPI.available(), TRANSFER_LENGTH_1);
 
         // Serial.print("< ");
         // Serial.println((const char *)SPI_Slave_Rx_Buffer);
@@ -118,7 +166,7 @@ test(SPI_Master_Slave_Slave_Transfer)
 
         SPI_Transfer_DMA(SPI_Slave_Tx_Buffer, SPI_Slave_Rx_Buffer, requestedLength, count % 2 == 0 ? &SPI_DMA_Completed_Callback : NULL);
         /* Check that we have transferred requestedLength bytes as requested */
-        assertEqual(SPI.available(), requestedLength);
+        assertEqual(USE_SPI.available(), requestedLength);
 
         /* Just a sanity check that we received only 0xff */
         for (int i = 0; i < requestedLength; i++)


### PR DESCRIPTION
`DMA1_Stream2_IRQn` used by SPI1 and SPI2 on Electron should be handled by `DMA1_Stream2_irq()`

Fixes issue #1080 

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### BUGFIX

- [Electron] `DMA1_Stream2_IRQn` used by SPI1 and SPI2 on Electron should be handled by `DMA1_Stream2_irq()`. Fixes [#1080](https://github.com/spark/firmware/issues/1080)