### PR TITLE
Do not redefine BYTE_ORDER if including a header that already defines it

### DIFF
--- a/hal/src/photon/wiced/network/LwIP/WWD/FreeRTOS/cpu.h
+++ b/hal/src/photon/wiced/network/LwIP/WWD/FreeRTOS/cpu.h
@@ -40,7 +40,9 @@
 extern "C" {
 #endif
 
+#ifndef __MACHINE_ENDIAN_H__
 #define BYTE_ORDER LITTLE_ENDIAN
+#endif
 
 #ifdef __cplusplus
 } /*extern "C" */


### PR DESCRIPTION
Fixes #1085 by not re-declaring BYTE_ORDER if already included from a toolchain header.

---

Doneness:
- [x] Contributor has signed CLA
- [ ] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
