### PR TITLE
Feature/usb hid multiple report fix

### DIFF
--- a/hal/inc/hal_dynalib_usb.h
+++ b/hal/inc/hal_dynalib_usb.h
@@ -88,10 +88,20 @@ DYNALIB_FN(BASE_IDX2 + 0, hal_usb, HAL_USB_Set_Vendor_Request_Callback, void(HAL
 	#define BASE_IDX4 (BASE_IDX3 + 4)
 #endif
 
-
+#ifdef USB_HID_ENABLE
+DYNALIB_FN(BASE_IDX4 + 0, hal_usb, HAL_USB_HID_Status, int32_t(uint8_t, void*))
+# define BASE_IDX5 (BASE_IDX4 + 1)
+#else
+# define BASE_IDX5 BASE_IDX4
+#endif
 
 DYNALIB_END(hal_usb)
 
 #undef BASE_IDX
+#undef BASE_IDX1
+#undef BASE_IDX2
+#undef BASE_IDX3
+#undef BASE_IDX4
+#undef BASE_IDX5
 
 #endif  /* HAL_DYNALIB_USB_H */

--- a/hal/inc/usb_hal.h
+++ b/hal/inc/usb_hal.h
@@ -186,6 +186,7 @@ int32_t HAL_USB_USART_LineCoding_BitRate_Handler(void (*handler)(uint32_t bitRat
 void HAL_USB_HID_Init(uint8_t reserved, void* reserved1);
 void HAL_USB_HID_Begin(uint8_t reserved, void* reserved1);
 void HAL_USB_HID_Send_Report(uint8_t reserved, void *pHIDReport, uint16_t reportSize, void* reserved1);
+int32_t HAL_USB_HID_Status(uint8_t reserved, void* reserved1);
 void HAL_USB_HID_End(uint8_t reserved);
 #endif
 

--- a/hal/src/stm32f2xx/usb_hal.c
+++ b/hal/src/stm32f2xx/usb_hal.c
@@ -532,6 +532,12 @@ void HAL_USB_HID_Send_Report(uint8_t reserved, void *pHIDReport, uint16_t report
 {
     USBD_MHID_SendReport(&USB_OTG_dev, NULL, pHIDReport, reportSize);
 }
+
+int32_t HAL_USB_HID_Status(uint8_t reserved, void* reserved1)
+{
+    return USBD_MHID_Transfer_Status(&USB_OTG_dev, NULL);
+}
+
 #endif
 
 

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_mhid.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_mhid.h
@@ -38,8 +38,11 @@ typedef struct USBD_MHID_Instance_Data {
   // Temporary aligned buffer
   __ALIGN_BEGIN uint8_t descriptor[USBD_MHID_DESC_SIZE] __ALIGN_END;
   #endif
+
+  volatile uint8_t intransfer;
 } USBD_MHID_Instance_Data;
 
 uint8_t USBD_MHID_SendReport (USB_OTG_CORE_HANDLE* pdev, USBD_MHID_Instance_Data* priv, uint8_t* report, uint16_t len);
+int32_t USBD_MHID_Transfer_Status(void* pdev, USBD_Composite_Class_Data* cls);
 
 #endif /* USBD_MHID_H_ */

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_mhid.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_mhid.c
@@ -179,6 +179,7 @@ static uint8_t USBD_MHID_Init(void* pdev, USBD_Composite_Class_Data* cls, uint8_
   //             HID_OUT_PACKET,
   //             USB_OTG_EP_INT);
 
+  priv->intransfer = 0;
   priv->configured = 1;
 
   return USBD_OK;
@@ -279,6 +280,7 @@ uint8_t USBD_MHID_SendReport (USB_OTG_CORE_HANDLE* pdev, USBD_MHID_Instance_Data
   
   if (pdev->dev.device_status == USB_OTG_CONFIGURED && priv->configured)
   {
+    priv->intransfer = 1;
     DCD_EP_Tx (pdev, priv->ep_in, report, len);
   }
   return USBD_OK;
@@ -312,6 +314,7 @@ static uint8_t USBD_MHID_DataIn(void* pdev, USBD_Composite_Class_Data* cls, uint
     return USBD_FAIL;
 
   DCD_EP_Flush(pdev, priv->ep_in);
+  priv->intransfer = 0;
   return USBD_OK;
 }
 
@@ -323,4 +326,10 @@ uint8_t* USBD_MHID_GetUsrStrDescriptor(uint8_t speed, USBD_Composite_Class_Data*
 
   *length = 0;
   return NULL;
+}
+
+int32_t USBD_MHID_Transfer_Status(void* pdev, USBD_Composite_Class_Data* cls)
+{
+  USBD_MHID_Instance_Data* priv = &USBD_MHID_Instance; /* (USBD_MHID_Instance_Data*)cls->priv; */
+  return priv->intransfer && (((USB_OTG_CORE_HANDLE*)pdev)->dev.device_status == USB_OTG_CONFIGURED && priv->configured);
 }

--- a/user/tests/wiring/usbhid/application.cpp
+++ b/user/tests/wiring/usbhid/application.cpp
@@ -1,0 +1,6 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+UNIT_TEST_APP();
+
+SYSTEM_MODE(SEMI_AUTOMATIC);

--- a/user/tests/wiring/usbhid/usbhid.cpp
+++ b/user/tests/wiring/usbhid/usbhid.cpp
@@ -1,0 +1,66 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+void startup();
+STARTUP(startup());
+
+void startup()
+{
+    Keyboard.begin();
+    Mouse.begin();
+}
+
+int randomString(char *buf, int len) {
+    for (int i = 0; i < len; i++) {
+        uint8_t d = random(0, 15);
+        char c = d + 48;
+        if (57 < c)
+            c += 7;
+        buf[i] = c;
+    }
+
+    return len;
+}
+
+void consume(Stream& serial)
+{
+    while (serial.available() > 0) {
+        (void)serial.read();
+    }
+}
+
+test(0_USBHID_MultipleConsecutiveReportsAreSuccessfullyDelivered) {
+    Serial.println("Please keep the terminal window in focus");
+    delay(5000);
+    srand(millis());
+
+    assertEqual(Serial.available(), 0);
+
+    char randStr[65];
+    char message[128];
+    memset(randStr, 0, sizeof(randStr));
+    memset(message, 0, sizeof(message));
+    randomString(randStr, sizeof(randStr) - 1);
+    Serial.println(randStr);
+
+    Keyboard.println(randStr);
+
+    serialReadLine(&Serial, message, sizeof(message) - 1, 10000); //10 sec timeout
+    assertTrue(strncmp(randStr, message, sizeof(randStr) - 1) == 0);
+    Serial.println();
+
+    randomString(randStr, sizeof(randStr) - 1);
+    Serial.println(randStr);
+    memset(message, 0, sizeof(message));
+    consume(Serial);
+
+    for (int i = 0; i < sizeof(randStr) - 1; i++) {
+        Keyboard.print(randStr[i]);
+        Mouse.move(5, 0, 0);
+    }
+    Keyboard.println();
+
+    serialReadLine(&Serial, message, sizeof(message) - 1, 10000); //10 sec timeout
+    assertTrue(strncmp(randStr, message, sizeof(randStr) - 1) == 0);
+    Serial.println();
+}

--- a/wiring/inc/spark_wiring_usbkeyboard.h
+++ b/wiring/inc/spark_wiring_usbkeyboard.h
@@ -93,6 +93,9 @@ public:
 	virtual size_t press(uint16_t k);
 	virtual size_t release(uint16_t k);
 	virtual void releaseAll(void);
+
+private:
+  void sendReport();
 };
 
 extern USBKeyboard Keyboard;

--- a/wiring/inc/spark_wiring_usbmouse.h
+++ b/wiring/inc/spark_wiring_usbmouse.h
@@ -61,6 +61,9 @@ public:
 	void press(uint8_t button = MOUSE_LEFT);		// press LEFT by default
 	void release(uint8_t button = MOUSE_LEFT);		// release LEFT by default
 	bool isPressed(uint8_t button = MOUSE_LEFT);	// check LEFT by default
+
+private:
+    void sendReport();
 };
 
 extern USBMouse Mouse;

--- a/wiring/src/spark_wiring_usbmouse.cpp
+++ b/wiring/src/spark_wiring_usbmouse.cpp
@@ -33,6 +33,7 @@
 //
 USBMouse::USBMouse(void)
 {
+    memset((void*)&mouseReport, 0, sizeof(mouseReport));
     mouseReport.reportId = 0x01;
     HAL_USB_HID_Init(0, NULL);
 }
@@ -61,14 +62,13 @@ void USBMouse::move(int8_t x, int8_t y, int8_t wheel)
 	mouseReport.x = x;
 	mouseReport.y = y;
 	mouseReport.wheel = wheel;
-	HAL_USB_HID_Send_Report(0, &mouseReport, sizeof(mouseReport), NULL);
+	sendReport();
 }
 
 void USBMouse::click(uint8_t button)
 {
 	mouseReport.buttons = button;
 	move(0,0,0);
-	delay(100);
 	mouseReport.buttons = 0;
 	move(0,0,0);
 }
@@ -91,6 +91,25 @@ bool USBMouse::isPressed(uint8_t button)
 	}
 
 	return false;
+}
+
+void USBMouse::sendReport()
+{
+    uint32_t m = millis();
+    while(HAL_USB_HID_Status(0, nullptr)) {
+        // Wait 1 bInterval (1ms)
+        delay(1);
+        if ((millis() - m) >= 50)
+            return;
+    }
+    HAL_USB_HID_Send_Report(0, &mouseReport, sizeof(mouseReport), NULL);
+    m = millis();
+    while(HAL_USB_HID_Status(0, nullptr)) {
+        // Wait 1 bInterval (1ms)
+        delay(1);
+        if ((millis() - m) >= 50)
+            return;
+    }
 }
 
 //Preinstantiate Object


### PR DESCRIPTION
Fixes issue #1090. Consecutive HID reports were overwriting the previous report before it was delivered to the host.

Adds:
- `HAL_USB_HID_Status()` function to check status of HID transfer;
- `wiring/usbhid` test

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation (n/a)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### BUGFIX

- Consecutive HID reports were overwriting previous the report before it was delivered to the host. Fixes [#1090](https://github.com/spark/firmware/issues/1090).