### PR TITLE
Disabling multiple USB configurations (normal/high power) as this breaks composite driver on Windows

### DIFF
--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_conf.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_conf.h
@@ -41,7 +41,15 @@
 #define MAX_USED_MEDIA                  2
 #endif
 
-#define USBD_CFG_MAX_NUM                2
+/*
+ * Disabling multiple configurations (100mA and 500mA) due to this Windows note:
+ * 
+ * USBCCGP will not load on a multi-config device by default
+ * because the hub driver doesn't create a "USB\COMPOSITE" PNP ID for a composite device
+ * if it has multiple configurations. However, you can write your own INF
+ * that matches a device-specific PNP ID to get USBCCGP to load as your device's function driver.
+ */
+#define USBD_CFG_MAX_NUM                1    // ^^^
 #define USBD_ITF_MAX_NUM                10
 #define USBD_DFU_INT_NUM                2
 #define USB_MAX_STR_DESC_SIZ            255

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_composite.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_composite.c
@@ -98,7 +98,8 @@ static const uint8_t USBD_Composite_CfgDescHeaderTemplate[USBD_COMPOSITE_CFGDESC
   0x01,                                          /* bConfigurationValue */
   USBD_IDX_CONFIG_STR,                           /* iConfiguration */
   0x80,                                          /* bmAttirbutes (Bus powered) */
-  0xFA                                           /* bMaxPower (500mA) */
+  // 0xFA                                           /* bMaxPower (500mA) */
+  0x32                                           /* bMaxPower (100mA) */
 };
 
 static const uint8_t USBD_Composite_VendorInterface[] = {


### PR DESCRIPTION
Fixes issue #1089

https://blogs.msdn.microsoft.com/usbcoreblog/2010/05/18/multi-config-usb-devices-and-windows/ :
> USBCCGP will not load on a multi-config device by default because the hub driver doesn't create a "USB\COMPOSITE" PNP ID for a composite device if it has multiple configurations. However, you can write your own INF that matches a device-specific PNP ID to get USBCCGP to load as your device's function driver.

### Driver help

- follow all steps here, including clearing the cache with the required tools.  Only after then connect your device https://github.com/avtolstoy/particle-usb-testing#windows

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### BUGFIX

Disabling multiple USB configurations (normal/high power) as this breaks composite driver on Windows. Fixes [#1089](https://github.com/spark/firmware/issues/1089) Serial and USBSerial1 not working at same time on Windows 8.1 Pro.