### PR TITLE
Feature/delay event processing

### DIFF
--- a/system/inc/system_dynalib.h
+++ b/system/inc/system_dynalib.h
@@ -59,6 +59,9 @@ DYNALIB_FN(16, system, Spark_Prepare_For_Firmware_Update, int(FileTransfer::Desc
 DYNALIB_FN(17, system, Spark_Save_Firmware_Chunk, int(FileTransfer::Descriptor&, const uint8_t*, void*))
 DYNALIB_FN(18, system, Spark_Finish_Firmware_Update, int(FileTransfer::Descriptor&, uint32_t, void*))
 
+DYNALIB_FN(19, system, application_thread_current, uint8_t(void*))
+DYNALIB_FN(20, system, system_thread_current, uint8_t(void*))
+
 DYNALIB_END(system)
 
 

--- a/system/inc/system_task.h
+++ b/system/inc/system_task.h
@@ -82,6 +82,8 @@ unsigned backoff_period(unsigned connection_attempts);
  */
 void* system_internal(int item, void* reserved);
 
+uint8_t application_thread_current(void* reserved);
+uint8_t system_thread_current(void* reserved);
 
 #ifdef __cplusplus
 }

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -443,7 +443,8 @@ void system_delay_ms(unsigned long ms, bool force_no_background_loop=false)
 {
 	// if not threading, or we are the application thread, then implement delay
 	// as a background message pump
-    if ((!system_thread_get_state(NULL) || APPLICATION_THREAD_CURRENT()) && !HAL_IsISR())
+
+    if ((!PLATFORM_THREADING || APPLICATION_THREAD_CURRENT()) && !HAL_IsISR())
     {
     		system_delay_pump(ms, force_no_background_loop);
     }
@@ -478,4 +479,14 @@ void cloud_disconnect(bool closeSocket)
     Spark_Error_Count = 0;  // this is also used for CFOD/WiFi reset, and blocks the LED when set.
 
 #endif
+}
+
+uint8_t application_thread_current(void* reserved)
+{
+    return APPLICATION_THREAD_CURRENT();
+}
+
+uint8_t system_thread_current(void* reserved)
+{
+    return SYSTEM_THREAD_CURRENT();
 }

--- a/user/tests/wiring/threading_no_threading_delay/application.cpp
+++ b/user/tests/wiring/threading_no_threading_delay/application.cpp
@@ -1,0 +1,4 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+UNIT_TEST_APP();

--- a/user/tests/wiring/threading_no_threading_delay/threading.cpp
+++ b/user/tests/wiring/threading_no_threading_delay/threading.cpp
@@ -1,0 +1,231 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "system_threading.h"
+
+static retained uint32_t magick = 0;
+static void startup();
+
+bool threading_state = false;
+
+STARTUP(startup());
+
+
+static bool will_process_events()
+{
+    if ((!PLATFORM_THREADING || application_thread_current(nullptr)) && !HAL_IsISR())
+        return true;
+    return false;
+}
+
+void startup()
+{
+    System.enableFeature(FEATURE_RETAINED_MEMORY);
+    if (magick == 0xdeadbeef) {
+        // Switch to SYSTEM_THREAD(ENABLED);
+        magick = 0;
+        system_thread_set_state(spark::feature::ENABLED, NULL);
+        threading_state = true;
+    } else {
+        // Switch to SYSTEM_THREAD(DISABLED);
+        magick = 0;
+        system_thread_set_state(spark::feature::DISABLED, NULL);
+        threading_state = false;
+    }
+}
+
+test(THREADING_00_no_threading_app_and_system_are_both_current_and_will_process_events_when_delay_is_called)
+{
+    if (threading_state) {
+        pass();
+        return;
+    }
+    assertTrue((bool)application_thread_current(nullptr));
+    assertTrue((bool)system_thread_current(nullptr));
+    assertTrue(will_process_events());
+}
+
+test(THREADING_01_no_threading_create_thread_and_check_it_is_not_application_or_system_current_and_will_not_process_events_when_delay_is_called)
+{
+    if (threading_state) {
+        pass();
+        return;
+    }
+    uint8_t app_current = 0xAA;
+    uint8_t system_current = 0xAA;
+    uint8_t will_process = 0xAA;
+    Thread* thread = new Thread("test", [&](void) {
+        app_current = application_thread_current(nullptr);
+        system_current = system_thread_current(nullptr);
+        will_process = will_process_events();
+    });
+    uint32_t m = millis();
+    while (app_current == 0xAA) {
+        assertLessOrEqual((millis() - m), 5000);
+    }
+    thread->join();
+    assertNotEqual(app_current, 0xAA);
+    assertNotEqual(system_current, 0xAA);
+    assertNotEqual(will_process, 0xAA);
+
+    assertFalse((bool)app_current);
+    assertFalse((bool)system_current);
+    assertFalse((bool)will_process);
+
+    delete thread;
+}
+
+test(THREADING_02_no_threading_create_timer_and_check_it_is_not_application_or_system_current_and_will_not_process_events_when_delay_is_called)
+{
+    if (threading_state) {
+        pass();
+        return;
+    }
+    uint8_t app_current = 0xAA;
+    uint8_t system_current = 0xAA;
+    uint8_t will_process = 0xAA;
+    Timer* timer = new Timer(10, [&]() {
+        app_current = application_thread_current(nullptr);
+        system_current = system_thread_current(nullptr);
+        will_process = will_process_events();
+    }, true);
+
+    timer->start();
+
+    uint32_t m = millis();
+    while (app_current == 0xAA) {
+        assertLessOrEqual((millis() - m), 5000);
+    }
+
+    assertNotEqual(app_current, 0xAA);
+    assertNotEqual(system_current, 0xAA);
+    assertNotEqual(will_process, 0xAA);
+
+    assertFalse((bool)app_current);
+    assertFalse((bool)system_current);
+    assertFalse((bool)will_process);
+
+    delete timer;
+}
+
+test(THREADING_03_no_threading_restart) {
+    if (threading_state) {
+        pass();
+        return;
+    }
+
+    magick = 0xdeadbeef;
+    Serial.println("The device will now reset, please rerun the tests once it boots");
+    int d = 5;
+    while (d >= 0) {
+        Serial.printf("%d... ", d);
+        delay(1000);
+        d--;
+    }
+    Serial.println();
+    Serial.println("BLASTOFF! Erm, uh, RESET!");
+    delay(1000);
+    System.reset();
+}
+
+test(THREADING_04_threading_app_is_current_system_is_not_will_not_process_events_when_delay_is_called)
+{
+    assertTrue((bool)application_thread_current(nullptr));
+    assertFalse((bool)system_thread_current(nullptr));
+    assertTrue(will_process_events());
+}
+
+test(THREADING_05_threading_create_thread_and_check_it_is_not_application_or_system_current_and_will_not_process_events_when_delay_is_called)
+{
+    if (!threading_state) {
+        fail();
+        return;
+    }
+    uint8_t app_current = 0xAA;
+    uint8_t system_current = 0xAA;
+    uint8_t will_process = 0xAA;
+    Thread* thread = new Thread("test", [&](void) {
+        app_current = application_thread_current(nullptr);
+        system_current = system_thread_current(nullptr);
+        will_process = will_process_events();
+    });
+
+    uint32_t m = millis();
+    while (app_current == 0xAA) {
+        assertLessOrEqual((millis() - m), 5000);
+    }
+
+    assertNotEqual(app_current, 0xAA);
+    assertNotEqual(system_current, 0xAA);
+    assertNotEqual(will_process, 0xAA);
+
+    assertFalse((bool)app_current);
+    assertFalse((bool)system_current);
+    assertFalse((bool)will_process);
+
+    delete thread;
+}
+
+test(THREADING_06_threading_create_timer_and_check_it_is_not_application_or_system_current_and_will_not_process_events_when_delay_is_called)
+{
+    if (!threading_state) {
+        fail();
+        return;
+    }
+    uint8_t app_current = 0xAA;
+    uint8_t system_current = 0xAA;
+    uint8_t will_process = 0xAA;
+    Timer* timer = new Timer(10, [&]() {
+        app_current = application_thread_current(nullptr);
+        system_current = system_thread_current(nullptr);
+        will_process = will_process_events();
+    }, true);
+
+    timer->start();
+
+    uint32_t m = millis();
+    while (app_current == 0xAA) {
+        assertLessOrEqual((millis() - m), 5000);
+    }
+
+    assertNotEqual(app_current, 0xAA);
+    assertNotEqual(system_current, 0xAA);
+    assertNotEqual(will_process, 0xAA);
+
+    assertFalse((bool)app_current);
+    assertFalse((bool)system_current);
+    assertFalse((bool)will_process);
+
+    delete timer;
+}
+
+test(THREADING_07_threading_execute_async_on_system_thread_check_it_is_current_and_will_not_process_events_when_delay_is_called)
+{
+    if (!threading_state) {
+        fail();
+        return;
+    }
+    uint8_t app_current = 0xAA;
+    uint8_t system_current = 0xAA;
+    uint8_t will_process = 0xAA;
+    
+    ActiveObjectBase* system = (ActiveObjectBase*)system_internal(1, nullptr); // Returns system thread instance
+    std::function<void(void)> f = [&](){
+        app_current = application_thread_current(nullptr);
+        system_current = system_thread_current(nullptr);
+        will_process = will_process_events();
+    };
+    system->invoke_async(f);
+
+    uint32_t m = millis();
+    while (app_current == 0xAA) {
+        assertLessOrEqual((millis() - m), 5000);
+    }
+
+    assertNotEqual(app_current, 0xAA);
+    assertNotEqual(system_current, 0xAA);
+    assertNotEqual(will_process, 0xAA);
+
+    assertFalse((bool)app_current);
+    assertTrue((bool)system_current);
+    assertFalse((bool)will_process);
+}


### PR DESCRIPTION
Fixes issue #1055

`system_delay_ms` should not use `!system_thread_get_state(NULL)` to determine whether to run event loop or not, as it is still possible to create a thread with `SYSTEM_THREAD(DISABLED)` and execute `delay()` in that thread, which will cause the event loop to be processed from that thread:
https://github.com/spark/firmware/compare/feature/delay-event-processing?expand=1#diff-de0a60700cd1e842d6a89faaba614c8cL446

This PR:
- Changes `system_delay_ms` condition to `if ((!PLATFORM_THREADING || APPLICATION_THREAD_CURRENT()) && !HAL_IsISR())`
  - `!system_thread_get_state(NULL)` -> `!PLATFORM_THREADING`
- Exposes `APPLICATION_THREAD_CURRENT()`/`SYSTEM_THREAD_CURRENT()` macros as  `application_thread_current`/`system_thread_current` dynalib functions
- Adds `wiring/threading_no_threading_delay` test

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### BUGFIX

- Do not run the event loop from delay() when threading is enabled. Fixes [#1055](https://github.com/spark/firmware/issues/1055)