### PR TITLE
OTA/YModem update result

### DIFF
--- a/hal/inc/hal_dynalib_ota.h
+++ b/hal/inc/hal_dynalib_ota.h
@@ -48,7 +48,7 @@ DYNALIB_FN(4, hal_ota, HAL_OTA_Flashed_ResetStatus, void(void))
 
 DYNALIB_FN(5, hal_ota, HAL_FLASH_Begin, bool(uint32_t, uint32_t, void*))
 DYNALIB_FN(6, hal_ota, HAL_FLASH_Update, int(const uint8_t*, uint32_t, uint32_t, void*))
-DYNALIB_FN(7, hal_ota, HAL_FLASH_End, hal_update_complete_t(void*))
+DYNALIB_FN(7, hal_ota, HAL_FLASH_End, hal_update_complete_t(hal_module_t*))
 
 DYNALIB_END(hal_ota)
 

--- a/hal/inc/ota_flash_hal.h
+++ b/hal/inc/ota_flash_hal.h
@@ -49,6 +49,7 @@ typedef struct {
 } module_bounds_t;
 
 typedef enum {
+    MODULE_VALIDATION_PASSED           = 0,
     MODULE_VALIDATION_INTEGRITY        = 1<<1,
     MODULE_VALIDATION_DEPENDENCIES     = 1<<2,
     MODULE_VALIDATION_RANGE            = 1<<3,
@@ -131,7 +132,7 @@ typedef enum {
     HAL_UPDATE_APPLIED
 } hal_update_complete_t;
 
-hal_update_complete_t HAL_FLASH_End(void* reserved);
+hal_update_complete_t HAL_FLASH_End(hal_module_t* module);
 
 uint32_t HAL_FLASH_ModuleAddress(uint32_t address);
 uint32_t HAL_FLASH_ModuleLength(uint32_t address);

--- a/hal/src/core/ota_flash_hal.c
+++ b/hal/src/core/ota_flash_hal.c
@@ -64,7 +64,7 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t bufferSi
     return FLASH_Update(pBuffer, address, bufferSize);
 }
 
-hal_update_complete_t HAL_FLASH_End( void* reserved)
+hal_update_complete_t HAL_FLASH_End(hal_module_t* reserved)
 {
     FLASH_End();
     return HAL_UPDATE_APPLIED_PENDING_RESTART;

--- a/hal/src/gcc/ota_flash_hal.cpp
+++ b/hal/src/gcc/ota_flash_hal.cpp
@@ -46,7 +46,7 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t length, 
     return 0;
 }
 
- hal_update_complete_t HAL_FLASH_End(void* reserved)
+ hal_update_complete_t HAL_FLASH_End(hal_module_t* mod)
 {
 	 fclose(output_file);
 	 output_file = NULL;

--- a/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
+++ b/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
@@ -217,7 +217,7 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t length, 
     return FLASH_Update(pBuffer, address, length);
 }
 
-hal_update_complete_t HAL_FLASH_End(void* reserved)
+hal_update_complete_t HAL_FLASH_End(hal_module_t* mod)
 {
     hal_module_t module;
     hal_update_complete_t result = HAL_UPDATE_ERROR;
@@ -251,6 +251,10 @@ hal_update_complete_t HAL_FLASH_End(void* reserved)
     else
     {
     		WARN("OTA module not applied");
+    }
+    if (mod)
+    {
+        memcpy(mod, &module, sizeof(hal_module_t));
     }
     return result;
 }

--- a/hal/src/template/ota_flash_hal.cpp
+++ b/hal/src/template/ota_flash_hal.cpp
@@ -58,7 +58,7 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t length, 
     return 0;
 }
 
-hal_update_complete_t HAL_FLASH_End(void* reserved)
+hal_update_complete_t HAL_FLASH_End(hal_module_t* mod)
 {
     return HAL_UPDATE_ERROR;
 }

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -5,6 +5,7 @@
 #include "file_transfer.h"
 #include "static_assert.h"
 #include "appender.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,6 +48,12 @@ void system_lineCodingBitRateHandler(uint32_t bitrate);
 bool system_module_info(appender_fn appender, void* append_data, void* reserved=NULL);
 bool append_system_version_info(Appender* appender);
 
+bool ota_update_info(appender_fn append, void* append_data, void* mod, bool full, void* reserved);
+
+typedef enum {
+    MODULE_INFO_JSON_INCLUDE_PLATFORM_ID = 0x0001
+} module_info_json_flags_t;
+
 /**
  *
  * @param file
@@ -63,7 +70,7 @@ int Spark_Prepare_For_Firmware_Update(FileTransfer::Descriptor& file, uint32_t f
  * @param reserved NULL
  * @return 0 on success.
  */
-int Spark_Finish_Firmware_Update(FileTransfer::Descriptor& file, uint32_t flags, void* reserved);
+int Spark_Finish_Firmware_Update(FileTransfer::Descriptor& file, uint32_t flags, void* module);
 
 /**
  * Provides a chunk of the file data.

--- a/system/inc/system_ymodem.h
+++ b/system/inc/system_ymodem.h
@@ -81,6 +81,18 @@ public:
 
     int32_t receive_file(FileTransfer::Descriptor& tx, file_desc_t& file_info);
 
+    /**
+     * @brief  Send a byte
+     * @param  c: Character
+     * @retval 0: Byte sent
+     */
+    uint32_t send_byte(uint8_t c)
+    {
+        stream.write(c);
+        return 0;
+    }
+
+
 private:
     uint8_t packet_data[YModem::PACKET_1K_SIZE + YModem::PACKET_OVERHEAD];
     int32_t session_done, file_done, packets_received, errors, session_begin;
@@ -93,17 +105,6 @@ private:
      *         -1: Timeout
      */
     int32_t receive_byte(uint8_t& c, uint32_t timeout);
-
-    /**
-     * @brief  Send a byte
-     * @param  c: Character
-     * @retval 0: Byte sent
-     */
-    uint32_t send_byte(uint8_t c)
-    {
-        stream.write(c);
-        return 0;
-    }
 
     /* Constants used by Serial Command Line Mode */
     //#define CMD_STRING_SIZE         128

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -55,6 +55,7 @@ int userVarType(const char *varKey);
 const void *getUserVar(const char *varKey);
 int userFuncSchedule(const char *funcKey, const char *paramString, SparkDescriptor::FunctionResultCallback callback, void* reserved);
 
+static int finish_ota_firmware_update(FileTransfer::Descriptor& file, uint32_t flags, void* module);
 static void formatResetReasonEventData(int reason, uint32_t data, char *buf, size_t size);
 
 static sock_handle_t sparkSocket = socket_handle_invalid();
@@ -605,7 +606,8 @@ void Spark_Protocol_Init(void)
         		callbacks.transport_context = nullptr;
         }
 		callbacks.prepare_for_firmware_update = Spark_Prepare_For_Firmware_Update;
-        callbacks.finish_firmware_update = Spark_Finish_Firmware_Update;
+        //callbacks.finish_firmware_update = Spark_Finish_Firmware_Update;
+        callbacks.finish_firmware_update = finish_ota_firmware_update;
         callbacks.calculate_crc = HAL_Core_Compute_CRC32;
         callbacks.save_firmware_chunk = Spark_Save_Firmware_Chunk;
         callbacks.signal = Spark_Signal;
@@ -1120,6 +1122,42 @@ inline uint8_t spark_cloud_socket_closed()
         closed = true;
     }
     return closed;
+}
+
+int formatOtaUpdateStatusEventData(uint32_t flags, int result, hal_module_t* module, uint8_t *buf, size_t size)
+{
+    int res = 1;
+    memset(buf, 0, size);
+
+    BufferAppender appender(buf, size);
+    appender.append("{");
+    appender.append("\"r\":");
+    appender.append(result ? "\"error\"" : "\"ok\"");
+
+    if (flags & 1) {
+        appender.append(",");
+        res = ota_update_info(append_instance, &appender, module, false, NULL);
+    }
+
+    appender.append("}");
+
+    return res;
+}
+
+int finish_ota_firmware_update(FileTransfer::Descriptor& file, uint32_t flags, void*)
+{
+    hal_module_t module;
+    uint8_t buf[512];
+
+    int result = Spark_Finish_Firmware_Update(file, flags, &module);
+
+    formatOtaUpdateStatusEventData(flags, result, &module, buf, sizeof(buf));
+
+    Particle.publish("spark/device/ota_result", (const char*)buf, 60, PRIVATE);
+    HAL_Delay_Milliseconds(1000);
+    Spark_Process_Events();
+
+    return result;
 }
 
 static const char* resetReasonString(System_Reset_Reason reason)

--- a/system/src/system_ymodem.cpp
+++ b/system/src/system_ymodem.cpp
@@ -184,7 +184,11 @@ int32_t YModem::handle_packet(uint8_t* packet_data, int32_t packet_length,
 
         /* End of transmission */
     case 0:
-        send_byte(ACK);
+        /* Do not send ACK immediately after receiving EOT
+         * Validate the received binary and in case of an error respond with a CANCEL
+         */
+        // send_byte(ACK);
+        session_done = 1;
         file_done = 1;
         return 1;
     }
@@ -296,41 +300,62 @@ int32_t YModem::receive_file(FileTransfer::Descriptor& tx, YModem::file_desc_t& 
  */
 bool Ymodem_Serial_Flash_Update(Stream *serialObj, FileTransfer::Descriptor& file, void* reserved)
 {
+    bool result = false;
     YModem::file_desc_t desc;
     YModem* ymodem = new YModem(*serialObj);
     int32_t size = ymodem->receive_file(file, desc);
-    delete ymodem;
     if (size > 0)
     {
-        serialObj->println("\r\nDownloaded file successfully!");
-        serialObj->print("Name: ");
-        Serial_PrintCharArray(serialObj, desc.file_name);
-        serialObj->println("");
-        serialObj->print("Size: ");
-        serialObj->print(size);
-        serialObj->println(" bytes");
-        serialObj->flush();
-        HAL_Delay_Milliseconds(1000);
-        Spark_Finish_Firmware_Update(file, size>0 ? 1 : 0, NULL);
-        return true;
+        hal_module_t module;
+        int update_result = Spark_Finish_Firmware_Update(file, size>0 ? 1 : 0, &module);
+        module_validation_flags_t validation_result = (module_validation_flags_t)(module.validity_checked ^ module.validity_result);
+
+        if (!update_result && (validation_result == MODULE_VALIDATION_PASSED))
+        {
+            // Respond to EOT with ACK
+            ymodem->send_byte(YModem::ACK);
+
+            serialObj->println("\r\nDownloaded file successfully!");
+            serialObj->print("Name: ");
+            Serial_PrintCharArray(serialObj, desc.file_name);
+            serialObj->println("");
+            serialObj->print("Size: ");
+            serialObj->print(size);
+            serialObj->println(" bytes");
+            serialObj->flush();
+            HAL_Delay_Milliseconds(1000);
+            result = true;
+        } else {
+            // Respond to EOT with CANCEL
+            ymodem->send_byte(YModem::CA);
+            ymodem->send_byte(YModem::CA);
+            serialObj->printf("Validation failed: 0x%x\r\n", (uint32_t)validation_result);
+        }
+    } else {
+        ymodem->send_byte(YModem::CA);
+        ymodem->send_byte(YModem::CA);
     }
-    else if (size == -1)
+    
+    if (size == -1)
     {
         serialObj->println("The file size is higher than the allowed space memory!");
     }
     else if (size == -2)
     {
-        serialObj->println("Verification failed!");
+        serialObj->println("Failed to save chunk!");
     }
     else if (size == -3)
     {
         serialObj->println("Aborted by user.");
     }
-    else
+    else if (size <= 0)
     {
         serialObj->println("Failed to receive the file!");
     }
-    return false;
+
+    delete ymodem;
+
+    return result;
 }
 
 #endif  /* __LIB_YMODEM_H */

--- a/system/src/system_ymodem.cpp
+++ b/system/src/system_ymodem.cpp
@@ -184,11 +184,7 @@ int32_t YModem::handle_packet(uint8_t* packet_data, int32_t packet_length,
 
         /* End of transmission */
     case 0:
-        /* Do not send ACK immediately after receiving EOT
-         * Validate the received binary and in case of an error respond with a CANCEL
-         */
-        // send_byte(ACK);
-        session_done = 1;
+        send_byte(ACK);
         file_done = 1;
         return 1;
     }
@@ -218,7 +214,10 @@ int32_t YModem::handle_packet(uint8_t* packet_data, int32_t packet_length,
             } /* Filename packet is empty, end session */
             else
             {
-                send_byte(ACK);
+                /* Do not send ACK immediately
+                 * Validate the received binary and in case of an error respond with a CANCEL
+                 */
+                // send_byte(ACK);
                 file_done = 1;
                 session_done = 1;
             }


### PR DESCRIPTION
Implements #1032

When updating the device via YModem:
- After receiving `EOT` from Host, device doesn't immediately respond with `ACK`. Instead binary validation is performed.
- If successful, device notifies the Host with `ACK` and prints received file name and size.
- If validation fails, the device notifies the Host with two `CA` (`CA`, `CA`) as to indicate the error and prints hexademical error code, which is a bitmask of failed checks (https://github.com/spark/firmware/blob/c916faafaea75f802a521d32ca4353aba812dfe2/hal/inc/ota_flash_hal.h#L52)

When updating OTA:
- After successfully receiving the binary, the device performs validation and before rebooting publishes an event `spark/device/ota_result`, which contains the following JSON object:

``` javascript
{"r": "ok", "u": {JSON ota module info, same format as particle serial inspect}}
```
- In case of an error, the same object is published. JSON ota module info might not be present

``` javascript
{"r": "error", "u": {JSON ota module info, same format as particle serial inspect, might not be present}}
```
- A full system module info object + ota module info don't fit into 255 byte publish message limit, so only ota module info is included.

---

Doneness:
- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Enhancements

- When flashing (OTA/YModem) an invalid firmware binary (that the device ignores) it will post an event describing why the binary was not applied. [[Implements #1032]](https://github.com/spark/firmware/issues/1032)