### PR TITLE
Fix for brew install gcc-arm-none-eabi

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,6 +1,6 @@
 ## 1. Download and Install Dependencies
 
-Building the firmware locally requires these dependencies ot be installed:
+Building the firmware locally requires these dependencies to be installed:
 
 1. [GCC for ARM Cortex processors](#1-gcc-for-arm-cortex-processors)
 2. [Make](#2-make)
@@ -22,7 +22,7 @@ message if the version is older than this.
 **OS X** users can install the toolchain with [Homebrew](http://brew.sh/):
 - `brew tap PX4/homebrew-px4`
 - `brew update`
-- `brew install gcc-arm-none-eabi-49`
+- `brew install gcc-arm-none-eabi`
 - `arm-none-eabi-gcc --version` (should now say v4.9.x)
 
 If you are upgrading an existing installation you will have to unlink and link your symblinks:


### PR DESCRIPTION
I tried to follow the Mac install instructions and encountered an error:

```
brew install gcc-arm-none-eabi-49
Error: No available formula with the name "gcc-arm-none-eabi-49" 
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
Error: No formulae found in taps.
```

I guessed that `-49` was not part of the formula name and tried:

```
brew install gcc-arm-none-eabi
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
No changes to formulae.
==> Installing gcc-arm-none-eabi from px4/px4
==> Downloading https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2
==> Downloading from https://launchpadlibrarian.net/218827447/gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2
######################################################################## 100.0%
==> Copying binaries...
==> cp -rv arm-none-eabi bin lib share /usr/local/Cellar/gcc-arm-none-eabi/20150925/
🍺  /usr/local/Cellar/gcc-arm-none-eabi/20150925: 4,944 files, 324.9M, built in 1 minute 5 seconds
```

It appears the installation was successful:

```
arm-none-eabi-gcc --version
arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 4.9.3 20150529 (release) [ARM/embedded-4_9-branch revision 227977]
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

---

Doneness:
- [x] Contributor has signed CLA
- [ ] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
