### PR TITLE
Fix for listening mode delay

### DIFF
--- a/system/src/system_network.cpp
+++ b/system/src/system_network.cpp
@@ -145,11 +145,12 @@ void network_off(network_handle_t network, uint32_t flags, uint32_t param, void*
 void network_listen(network_handle_t network, uint32_t flags, void*)
 {
     const bool stop = flags & NETWORK_LISTEN_EXIT;
+    // Set/clear listening mode flag
+    nif(network).listen(stop);
     if (!stop) {
-        // Cancel current connection attempt before entering listening mode
+        // Cancel current connection attempt
         nif(network).connect_cancel(true);
     }
-    SYSTEM_THREAD_CONTEXT_ASYNC_CALL(nif(network).listen(stop));
 }
 
 bool network_listening(network_handle_t network, uint32_t, void*)

--- a/system/src/system_network.cpp
+++ b/system/src/system_network.cpp
@@ -131,6 +131,7 @@ bool network_has_credentials(network_handle_t network, uint32_t param, void* res
 
 void network_off(network_handle_t network, uint32_t flags, uint32_t param, void* reserved)
 {
+    nif(network).connect_cancel(true);
     // flags & 1 means also disconnect the cloud (so it doesn't autmatically connect when network resumed.)
     SYSTEM_THREAD_CONTEXT_ASYNC_CALL(nif(network).off(flags & 1));
 }
@@ -143,7 +144,12 @@ void network_off(network_handle_t network, uint32_t flags, uint32_t param, void*
  */
 void network_listen(network_handle_t network, uint32_t flags, void*)
 {
-    SYSTEM_THREAD_CONTEXT_ASYNC_CALL(nif(network).listen(flags & NETWORK_LISTEN_EXIT));
+    const bool stop = flags & NETWORK_LISTEN_EXIT;
+    if (!stop) {
+        // Cancel current connection attempt before entering listening mode
+        nif(network).connect_cancel(true);
+    }
+    SYSTEM_THREAD_CONTEXT_ASYNC_CALL(nif(network).listen(stop));
 }
 
 bool network_listening(network_handle_t network, uint32_t, void*)

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -266,10 +266,10 @@ public:
         if (stop) {
             WLAN_LISTEN_ON_FAILED_CONNECT = 0;  // ensure a failed wifi connection attempt doesn't bring the device back to listening mode
             WLAN_SMART_CONFIG_START = 0; // Cancel pending transition to listening mode
-        } else {
+            WLAN_SMART_CONFIG_ACTIVE = 0; // Break current listening loop
+        } else if (!WLAN_SMART_CONFIG_ACTIVE) {
             WLAN_SMART_CONFIG_START = 1;
         }
-        WLAN_SMART_CONFIG_ACTIVE = 0; // Break current listening loop
     }
 
     void listen_command() override

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -279,8 +279,9 @@ public:
 
     void connect(bool listen_enabled=true) override
     {
-        INFO("ready():%s,connecting():%s,listening():%s",(ready())?"true":"false",(connecting())?"true":"false",(listening())?"true":"false");
-        if (!ready() && !connecting() && !listening())
+        const bool listening = WLAN_SMART_CONFIG_START;
+        INFO("ready():%s,connecting():%s,listening():%s",(ready())?"true":"false",(connecting())?"true":"false",(listening)?"true":"false");
+        if (!ready() && !connecting() && !listening)
         {
             bool was_sleeping = SPARK_WLAN_SLEEP;
 

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -279,6 +279,7 @@ public:
 
     void connect(bool listen_enabled=true) override
     {
+        // Do not try to connect if listening mode is active or pending
         const bool listening = WLAN_SMART_CONFIG_START;
         INFO("ready():%s,connecting():%s,listening():%s",(ready())?"true":"false",(connecting())?"true":"false",(listening)?"true":"false");
         if (!ready() && !connecting() && !listening)

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -265,6 +265,7 @@ public:
     {
         if (stop) {
             WLAN_LISTEN_ON_FAILED_CONNECT = 0;  // ensure a failed wifi connection attempt doesn't bring the device back to listening mode
+            WLAN_SMART_CONFIG_START = 0; // Cancel pending transition to listening mode
         } else {
             WLAN_SMART_CONFIG_START = 1;
         }

--- a/user/tests/app/listening_mode_delay_issue_1013/listening_mode_delay.cpp
+++ b/user/tests/app/listening_mode_delay_issue_1013/listening_mode_delay.cpp
@@ -1,0 +1,113 @@
+#include "application.h"
+
+SYSTEM_MODE(MANUAL)
+SYSTEM_THREAD(ENABLED)
+
+LOG_SOURCE_CATEGORY("test")
+
+namespace {
+
+// Logging may hide race condition issues that are checked in this test, so it's commented out
+//
+// Serial1LogHandler logHandler(57600, LOG_LEVEL_WARN, {
+//     { "test", LOG_LEVEL_INFO }
+// });
+
+const int TIMEOUT = 2000; // Timeout for entering/leaving listening mode
+const int REPEAT_COUNT = 10;
+
+bool listeningStarted = false;
+bool listeningStopped = false;
+
+bool testStarted = false;
+bool testFinished = false;
+int testCount = 0;
+
+void onListeningChanged(system_event_t event, int data, void*) {
+    switch (event) {
+    case wifi_listen_begin:
+        listeningStarted = true;
+        LOG(TRACE, "Listening mode started");
+        break;
+    case wifi_listen_end:
+        listeningStopped = true;
+        LOG(TRACE, "Listening mode stopped");
+        break;
+    default:
+        break;
+    }
+}
+
+} // namespace
+
+void setup() {
+    // Set bogus WiFi credentials to cause repeated connection attempts
+    WiFi.on();
+    WiFi.clearCredentials();
+    WiFi.setCredentials("param-pam-pam");
+    WiFi.connect();
+
+    System.on(wifi_listen_begin | wifi_listen_end, onListeningChanged);
+}
+
+void loop() {
+    if (testFinished) {
+        return;
+    }
+
+    if (!testStarted) {
+        // Give the system thread some time to start a connection
+        delay(3000);
+        testStarted = true;
+        LOG(INFO, "Test started");
+    }
+
+    LOG(TRACE, "%d / %d", testCount + 1, REPEAT_COUNT);
+
+    bool failed = false;
+
+    // Enter listening mode
+    delay(50); // Gives the system thread some time to leave listening loop cleanly
+    LOG(TRACE, "Starting listening mode");
+    WiFi.listen();
+    uint32_t t = millis();
+    listeningStarted = false;
+    do {
+        Particle.process();
+        if (millis() - t > TIMEOUT) {
+            failed = true;
+            break;
+        }
+    } while (!listeningStarted);
+
+    if (!failed) {
+        // Exit listening mode
+        delay(50);
+        LOG(TRACE, "Stopping listening mode");
+        WiFi.listen(false);
+        t = millis();
+        listeningStopped = false;
+        do {
+            Particle.process();
+            if (millis() - t > TIMEOUT) {
+                failed = true;
+                break;
+            }
+        } while (!listeningStopped);
+    }
+
+    if (!failed) {
+        ++testCount;
+        if (testCount == REPEAT_COUNT) {
+            testFinished = true;
+            RGB.control(true);
+            RGB.color(0x00ff00); // Green
+            LOG(INFO, "TEST SUCCEEDED");
+        }
+    } else {
+        testFinished = true;
+        RGB.control(true);
+        RGB.color(0xff0000); // Red
+        LOG(ERROR, "TEST FAILED");
+    }
+}


### PR DESCRIPTION
This PR fixes #1013 by canceling current connection attempt before entering the listening mode.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bugfix

- Cancel current connection attempt before entering the listening mode with WiFi.listen(true) and also WiFi.off(). Fixes [#1013](https://github.com/spark/firmware/issues/1013)