### PR TITLE
Feature/usb hid enhancements

### DIFF
--- a/hal/inc/hal_dynalib_usb.h
+++ b/hal/inc/hal_dynalib_usb.h
@@ -90,7 +90,8 @@ DYNALIB_FN(BASE_IDX2 + 0, hal_usb, HAL_USB_Set_Vendor_Request_Callback, void(HAL
 
 #ifdef USB_HID_ENABLE
 DYNALIB_FN(BASE_IDX4 + 0, hal_usb, HAL_USB_HID_Status, int32_t(uint8_t, void*))
-# define BASE_IDX5 (BASE_IDX4 + 1)
+DYNALIB_FN(BASE_IDX4 + 1, hal_usb, HAL_USB_HID_Set_State, uint8_t(uint8_t, uint8_t, void*))
+# define BASE_IDX5 (BASE_IDX4 + 2)
 #else
 # define BASE_IDX5 BASE_IDX4
 #endif

--- a/hal/inc/usb_hal.h
+++ b/hal/inc/usb_hal.h
@@ -188,6 +188,7 @@ void HAL_USB_HID_Begin(uint8_t reserved, void* reserved1);
 void HAL_USB_HID_Send_Report(uint8_t reserved, void *pHIDReport, uint16_t reportSize, void* reserved1);
 int32_t HAL_USB_HID_Status(uint8_t reserved, void* reserved1);
 void HAL_USB_HID_End(uint8_t reserved);
+uint8_t HAL_USB_HID_Set_State(uint8_t id, uint8_t state, void* reserved);
 #endif
 
 

--- a/hal/src/stm32f2xx/usb_hal.c
+++ b/hal/src/stm32f2xx/usb_hal.c
@@ -521,6 +521,18 @@ void HAL_USB_HID_End(uint8_t reserved)
     }
 }
 
+uint8_t HAL_USB_HID_Set_State(uint8_t id, uint8_t state, void* reserved)
+{
+    uint8_t ret = 0;
+    if (usbHid.registered) {
+        HAL_USB_Detach();
+        ret = USBD_MHID_SetDigitizerState(&USB_OTG_dev, NULL, id, state);
+        HAL_USB_Attach();
+    }
+
+    return ret;
+}
+
 /*******************************************************************************
  * Function Name : USB_HID_Send_Report.
  * Description   : Send HID Report Info to Host.

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_mhid.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/usbd_mhid.h
@@ -6,7 +6,9 @@
 
 #define USBD_MHID_CONFIG_DESC_SIZE      32
 #define USBD_MHID_DESC_SIZE              9
-#define USBD_MHID_REPORT_DESC_SIZE      99
+#define USBD_MHID_REPORT_DESC_SIZE     178
+
+#define USBD_MHID_DIGITIZER_REPORT_DESC_SIZE 65
 
 #define HID_DESCRIPTOR_TYPE           0x21
 #define HID_REPORT_DESC               0x22
@@ -44,5 +46,6 @@ typedef struct USBD_MHID_Instance_Data {
 
 uint8_t USBD_MHID_SendReport (USB_OTG_CORE_HANDLE* pdev, USBD_MHID_Instance_Data* priv, uint8_t* report, uint16_t len);
 int32_t USBD_MHID_Transfer_Status(void* pdev, USBD_Composite_Class_Data* cls);
+uint8_t USBD_MHID_SetDigitizerState(void* pdev, USBD_Composite_Class_Data* cls, uint8_t idx, uint8_t state);
 
 #endif /* USBD_MHID_H_ */

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_mhid.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_mhid.c
@@ -100,9 +100,9 @@ __ALIGN_BEGIN static const uint8_t USBD_MHID_DefaultReportDesc[USBD_MHID_REPORT_
   0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
   0x09, 0x02,                    // USAGE (Mouse)
   0xa1, 0x01,                    // COLLECTION (Application)
+  0x85, 0x01,                    //   REPORT_ID (1)
   0x09, 0x01,                    //   USAGE (Pointer)
   0xa1, 0x00,                    //   COLLECTION (Physical)
-  0x85, 0x01,                    //     REPORT_ID (1)
   0x05, 0x09,                    //     USAGE_PAGE (Button)
   0x19, 0x01,                    //     USAGE_MINIMUM (Button 1)
   0x29, 0x03,                    //     USAGE_MAXIMUM (Button 3)
@@ -117,14 +117,24 @@ __ALIGN_BEGIN static const uint8_t USBD_MHID_DefaultReportDesc[USBD_MHID_REPORT_
   0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
   0x09, 0x30,                    //     USAGE (X)
   0x09, 0x31,                    //     USAGE (Y)
+  // 0x36, 0x01, 0x80,              //     PHYSICAL_MINIMUM (-32767)
+  // 0x46, 0xff, 0x7f,              //     PHYSICAL_MAXIMUM (32767)
+  0x16, 0x01, 0x80,              //     LOGICAL_MINIMUM (-32767)
+  0x26, 0xff, 0x7f,              //     LOGICAL_MAXIMUM (32767)
+  // 0x15, 0x81,                    //     LOGICAL_MINIMUM (-127)
+  // 0x25, 0x7f,                    //     LOGICAL_MAXIMUM (127)
+  0x75, 0x10,                    //     REPORT_SIZE (16)
+  0x95, 0x02,                    //     REPORT_COUNT (2)
+  0x81, 0x06,                    //     INPUT (Data,Var,Rel)
   0x09, 0x38,                    //     USAGE (WHEEL)
   0x15, 0x81,                    //     LOGICAL_MINIMUM (-127)
   0x25, 0x7f,                    //     LOGICAL_MAXIMUM (127)
   0x75, 0x08,                    //     REPORT_SIZE (8)
-  0x95, 0x03,                    //     REPORT_COUNT (3)
+  0x95, 0x01,                    //     REPORT_COUNT (1)
   0x81, 0x06,                    //     INPUT (Data,Var,Rel)
   0xc0,                          //   END_COLLECTION
   0xc0,                          // END_COLLECTION
+  0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
   0x09, 0x06,                    // USAGE (Keyboard)
   0xa1, 0x01,                    // COLLECTION (Application)
   0x85, 0x02,                    //   REPORT_ID (2)
@@ -152,11 +162,43 @@ __ALIGN_BEGIN static const uint8_t USBD_MHID_DefaultReportDesc[USBD_MHID_REPORT_
   0x95, 0x06,                    //   REPORT_COUNT (6)
   0x75, 0x08,                    //   REPORT_SIZE (8)
   0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
-  0x25, 0x65,                    //   LOGICAL_MAXIMUM (101)
+  0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
   0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
   0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
-  0x29, 0x65,                    //   USAGE_MAXIMUM (Keyboard Application)
+  0x29, 0xdd,                    //   USAGE_MAXIMUM (Keypad Hexadecimal)
   0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
+  0xc0,                          // END_COLLECTION
+  0x05, 0x0d,                    // USAGE_PAGE (Digitizer)
+  0x09, 0x02,                    // USAGE (Pen)
+  0xa1, 0x01,                    // COLLECTION (Application)
+  0x85, 0x03,                    //   REPORT_ID (3)
+  0x09, 0x20,                    //   USAGE (Stylus)
+  0xa1, 0x00,                    //   COLLECTION (Physical)
+  0x09, 0x42,                    //     USAGE (Tip Switch)
+  0x09, 0x32,                    //     USAGE (In Rnage)
+  0x15, 0x00,                    //     LOGICAL_MINIMUM (0)
+  0x25, 0x01,                    //     LOGICAL_MAXIMUM (1)
+  0x75, 0x01,                    //     REPORT_SIZE (1)
+  0x95, 0x02,                    //     REPORT_COUNT (2)
+  0x81, 0x02,                    //     INPUT (Data,Var,Abs)
+  0x75, 0x01,                    //     REPORT_SIZE (1)
+  0x95, 0x06,                    //     REPORT_COUNT (6)
+  0x81, 0x01,                    //     INPUT (Cnst,Ary,Abs)
+  0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
+  0x09, 0x01,                    //     USAGE (Pointer)
+  0xa1, 0x00,                    //     COLLECTION (Physical)
+  0x09, 0x30,                    //       USAGE (X)
+  0x09, 0x31,                    //       USAGE (Y)
+  0x16, 0x00, 0x00,              //       LOGICAL_MINIMUM (0)
+  0x26, 0xff, 0x7f,              //       LOGICAL_MAXIMUM (32767)
+  0x36, 0x00, 0x00,              //       PHYSICAL_MINIMUM (0)
+  0x46, 0xff, 0x7f,              //       PHYSICAL_MAXIMUM (32767)
+  0x65, 0x00,                    //       UNIT (None)
+  0x75, 0x10,                    //       REPORT_SIZE (16)
+  0x95, 0x02,                    //       REPORT_COUNT (2)
+  0x81, 0x02,                    //       INPUT (Data,Var,Abs)
+  0xc0,                          //     END_COLLECTION
+  0xc0,                          //   END_COLLECTION
   0xc0                           // END_COLLECTION
 };
 
@@ -332,4 +374,16 @@ int32_t USBD_MHID_Transfer_Status(void* pdev, USBD_Composite_Class_Data* cls)
 {
   USBD_MHID_Instance_Data* priv = &USBD_MHID_Instance; /* (USBD_MHID_Instance_Data*)cls->priv; */
   return priv->intransfer && (((USB_OTG_CORE_HANDLE*)pdev)->dev.device_status == USB_OTG_CONFIGURED && priv->configured);
+}
+
+uint8_t USBD_MHID_SetDigitizerState(void* pdev, USBD_Composite_Class_Data* cls, uint8_t idx, uint8_t state)
+{
+  USBD_MHID_Instance_Data* priv = &USBD_MHID_Instance; /* (USBD_MHID_Instance_Data*)cls->priv; */
+  if (state) {
+    priv->report_descriptor_size = USBD_MHID_REPORT_DESC_SIZE;
+  } else {
+    priv->report_descriptor_size = USBD_MHID_REPORT_DESC_SIZE - USBD_MHID_DIGITIZER_REPORT_DESC_SIZE;
+  }
+
+  return 1;
 }

--- a/user/tests/wiring/usbhid2/application.cpp
+++ b/user/tests/wiring/usbhid2/application.cpp
@@ -1,0 +1,6 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+UNIT_TEST_APP();
+
+SYSTEM_MODE(SEMI_AUTOMATIC);

--- a/user/tests/wiring/usbhid2/usbhid.cpp
+++ b/user/tests/wiring/usbhid2/usbhid.cpp
@@ -1,0 +1,692 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include <cmath>
+
+void startup();
+STARTUP(startup());
+
+typedef struct {
+    char ev;
+    int x;
+    int y;
+    int v1;
+    int v2;
+    int v3;
+} HidEvent;
+
+void startup()
+{
+    Keyboard.begin();
+    Mouse.begin();
+}
+
+// asciimap is defined in spark_wiring_usbkeyboard.cpp
+extern const uint8_t usb_hid_asciimap[128];
+#define SHIFT_MOD 0x80
+
+static uint16_t s_aScreenWidth = 0;
+static uint16_t s_aScreenHeight = 0;
+
+static uint16_t s_rScreenWidth = 0;
+static uint16_t s_rScreenHeight = 0;
+
+static uint8_t s_relativeWorks = 0;
+
+int randomString(char *buf, int len) {
+    for (int i = 0; i < len; i++) {
+        uint8_t d = random(0, 15);
+        char c = d + 48;
+        if (57 < c)
+            c += 7;
+        buf[i] = c;
+    }
+
+    return len;
+}
+
+void consume(Stream& serial)
+{
+    while (serial.available() > 0) {
+        (void)serial.read();
+    }
+}
+
+int serialReadLineNoEcho(Stream *serialObj, uint8_t *dst, int max_len, system_tick_t timeout)
+{
+    uint16_t c = 0, i = 0;
+    system_tick_t last_millis = millis();
+
+    while (1)
+    {
+        if((timeout > 0) && ((millis()-last_millis) > timeout))
+        {
+            //Abort after a specified timeout
+            break;
+        }
+
+        if (0 < serialObj->available())
+        {
+            c = serialObj->read();
+
+            if (i == max_len || c == '\r' || c == '\n')
+            {
+                *dst = '\0';
+                break;
+            }
+
+            *dst++ = c;
+            ++i;
+        }
+    }
+
+    return (*dst == '\0');
+}
+
+bool readHidEvent(Stream& serial, HidEvent& ev, uint32_t timeout = 2000)
+{
+    char msg[255];
+    memset(msg, 'a', sizeof(msg));
+    msg[sizeof(msg) - 1] = '\0';
+    if (serialReadLineNoEcho(&serial, (uint8_t*)msg, sizeof(msg), timeout)) {
+        if (sscanf(msg, "%c %d %d %d %d %d", &ev.ev, &ev.x, &ev.y, &ev.v1, &ev.v2, &ev.v3) == 6) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+test(USBHID_01_Keyboard_Print_Random_Printable_Characters) {
+    delay(1000);
+    srand(millis());
+
+    char randStr[65];
+    HidEvent ev;
+    memset(randStr, 0, sizeof(randStr));
+    randomString(randStr, sizeof(randStr) - 1);
+    Serial.println(randStr);
+
+    consume(Serial);
+    for (int i = 0; i < sizeof(randStr) - 1; i++) {
+        Keyboard.print(randStr[i]);
+        for(;;) {
+            assertTrue(readHidEvent(Serial, ev));
+            assertEqual(ev.ev, 'k');
+            // Skip SHIFT
+            if (ev.v1 == KEY_LSHIFT)
+                continue;
+            assertEqual((char)ev.v3, randStr[i]);
+            break;
+        }
+    }
+}
+
+test(USBHID_02_Keyboard_Print_Full_Ascii_Map) {
+    HidEvent ev;
+    consume(Serial);
+    for (char i = 0; i < sizeof(usb_hid_asciimap); i++) {
+        // Skip KEY_RESERVED (0x00)
+        if (usb_hid_asciimap[(int)i] == 0x00)
+            continue;
+        Keyboard.print(i);
+        assertTrue(readHidEvent(Serial, ev));
+        assertEqual(ev.ev, 'k');
+        if (usb_hid_asciimap[(int)i] & SHIFT_MOD) {
+            // Skip SHIFT
+            assertTrue(readHidEvent(Serial, ev));
+            assertEqual(ev.ev, 'k');
+        }
+        if (ev.v2 & MOD_LSHIFT) { // SHIFT
+            ev.v1 |= SHIFT_MOD;
+        }
+        assertEqual(usb_hid_asciimap[(int)i], (uint8_t)ev.v1);
+        if (isprint(i)) {
+            assertEqual(i, (char)ev.v3);
+        }
+    }
+}
+
+test(USBHID_03_Keyboard_Up_To_Six_Buttons_Can_Pressed_Simultaneously) {
+    HidEvent ev;
+    consume(Serial);
+
+    assertTrue((bool)Keyboard.press(KEY_1));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_1);
+
+    assertTrue((bool)Keyboard.press(KEY_2));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_2);
+
+    assertTrue((bool)Keyboard.press(KEY_3));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_3);
+
+    assertTrue((bool)Keyboard.press(KEY_4));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_4);
+
+    assertTrue((bool)Keyboard.press(KEY_5));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_5);
+
+    assertTrue((bool)Keyboard.press(KEY_6));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_6);
+
+    assertFalse((bool)Keyboard.press(KEY_7));
+
+    assertTrue((bool)Keyboard.release(KEY_6));
+
+    assertTrue((bool)Keyboard.press(KEY_7));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_7);
+
+    assertFalse((bool)Keyboard.press(KEY_8));
+
+    Keyboard.releaseAll();
+}
+
+test(USBHID_04_Keyboard_Modifier_Keys_Are_Sent_As_Modifiers_And_Not_Key_Pressess) {
+    HidEvent ev;
+    consume(Serial);
+
+    Keyboard.releaseAll();
+
+    // Press 6 buttons
+    assertTrue((bool)Keyboard.press(KEY_1));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_1);
+
+    assertTrue((bool)Keyboard.press(KEY_2));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_2);
+
+    assertTrue((bool)Keyboard.press(KEY_3));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_3);
+
+    assertTrue((bool)Keyboard.press(KEY_4));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_4);
+
+    assertTrue((bool)Keyboard.press(KEY_5));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_5);
+
+    assertTrue((bool)Keyboard.press(KEY_6));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_6);
+
+    assertFalse((bool)Keyboard.press(KEY_7));
+
+    assertTrue((bool)Keyboard.release(KEY_6));
+
+    assertTrue((bool)Keyboard.press(KEY_7));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_7);
+
+    assertFalse((bool)Keyboard.press(KEY_8));
+
+    assertTrue((bool)Keyboard.click(KEY_LCTRL));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_LCTRL);
+
+    assertTrue((bool)Keyboard.click(KEY_LSHIFT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_LSHIFT);
+
+    assertTrue((bool)Keyboard.click(KEY_LALT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_LALT);
+
+    // assertTrue((bool)Keyboard.click(KEY_LGUI));
+    // assertTrue(readHidEvent(Serial, ev));
+    // assertEqual(ev.ev, 'k');
+    // assertEqual(ev.v1, (int)KEY_LGUI);
+
+    assertTrue((bool)Keyboard.click(KEY_RCTRL));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_RCTRL);
+
+    assertTrue((bool)Keyboard.click(KEY_RSHIFT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_RSHIFT);
+
+    assertTrue((bool)Keyboard.click(KEY_RALT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_RALT);
+
+    // assertTrue((bool)Keyboard.click(KEY_RGUI));
+    // assertTrue(readHidEvent(Serial, ev));
+    // assertEqual(ev.ev, 'k');
+    // assertEqual(ev.v1, (int)KEY_RGUI);
+
+    Keyboard.releaseAll();
+}
+
+test(USBHID_05_Keyboard_Modifiers_Work_Correctly) {
+    HidEvent ev;
+    consume(Serial);
+
+    Keyboard.releaseAll();
+
+    assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_LCTRL));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_LCTRL);
+
+    assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_LSHIFT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_LSHIFT);
+
+    assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_LALT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_LALT);
+
+    // assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_LGUI));
+    // assertTrue(readHidEvent(Serial, ev));
+    // assertEqual(ev.ev, 'k');
+    // assertEqual(ev.v1, (int)KEY_LGUI);
+
+    assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_RCTRL));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_RCTRL);
+
+    assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_RSHIFT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_RSHIFT);
+
+    assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_RALT));
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'k');
+    assertEqual(ev.v1, (int)KEY_RALT);
+
+    // assertTrue((bool)Keyboard.click(KEY_RESERVED, MOD_RGUI));
+    // assertTrue(readHidEvent(Serial, ev));
+    // assertEqual(ev.ev, 'k');
+    // assertEqual(ev.v1, (int)KEY_RGUI);
+
+    Keyboard.releaseAll();
+}
+
+test(USBHID_06_Keyboard_Multiple_Modifiers_Can_Be_Sent_Simultaneously) {
+    /*
+     * This test should fail on Windows
+     */
+    HidEvent ev;
+    consume(Serial);
+
+    Keyboard.releaseAll();
+
+    uint16_t modifiers = MOD_LCTRL | MOD_LSHIFT | MOD_LALT | /* MOD_LGUI */
+                         MOD_RCTRL | MOD_RSHIFT | MOD_RALT /* | MOD_RGUI */;
+    assertTrue((bool)Keyboard.click(KEY_RESERVED, modifiers));
+    while (modifiers) {
+        assertTrue(readHidEvent(Serial, ev));
+        assertEqual(ev.ev, 'k');
+        switch (ev.v1) {
+            case KEY_LCTRL:
+                modifiers &= ~(MOD_LCTRL);
+                break;
+            case KEY_LSHIFT:
+                modifiers &= ~(MOD_LSHIFT);
+                break;
+            case KEY_LALT:
+                modifiers &= ~(MOD_LALT);
+                break;
+            case KEY_LGUI:
+                modifiers &= ~(MOD_LGUI);
+                break;
+            case KEY_RCTRL:
+                modifiers &= ~(MOD_RCTRL);
+                break;
+            case KEY_RSHIFT:
+                modifiers &= ~(MOD_RSHIFT);
+                break;
+            case KEY_RALT:
+                modifiers &= ~(MOD_RALT);
+                break;
+            case KEY_RGUI:
+                modifiers &= ~(MOD_RGUI);
+                break;
+            default:
+                assertTrue(false);
+                break;
+        }
+    }
+
+    Keyboard.releaseAll();
+}
+
+test(USBHID_07_Keyboard_Most_Keycodes_Are_Correctly_Delivered) {
+    HidEvent ev;
+    consume(Serial);
+
+    Keyboard.releaseAll();
+    int errors = 0;
+    for (uint16_t k = KEY_A; k <= KEY_KPHEX; k++) {
+        // Avoid sending these keys
+        switch (k) {
+            case KEY_POWER:
+            case KEY_APPLICATION:
+            case KEY_PRINTSCREEN:
+            case KEY_F13:
+            case KEY_F14:
+            case KEY_F15:
+            case KEY_F16:
+            case KEY_F17:
+            case KEY_F18:
+            case KEY_F19:
+            case KEY_F20:
+            case KEY_F21:
+            case KEY_F22:
+            case KEY_F23:
+            case KEY_F24:
+                continue;
+                break;
+        }
+
+        assertTrue(Keyboard.click(k));
+        if (!readHidEvent(Serial, ev, 200)) {
+            errors++;
+        } else {
+            assertEqual(ev.ev, 'k');
+        }
+    }
+}
+
+test(USBHID_08_Mouse_Absolute_Movement_Figure_Out_Resolution) {
+    HidEvent ev;
+    consume(Serial);
+
+    Keyboard.releaseAll();
+
+    Mouse.moveTo(INT16_MAX, INT16_MAX);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x > 0 && ev.y > 0);
+    Serial.printf("Resolution: %d %d\r\n", ev.x, ev.y);
+    Mouse.screenSize(ev.x, ev.y);
+    s_aScreenWidth = ev.x;
+    s_aScreenHeight = ev.y;
+}
+
+test(USBHID_09_Mouse_Absolute_Movement_With_Screen_Size_Works_Correctly) {
+    HidEvent ev;
+    consume(Serial);
+
+    Mouse.moveTo(0, 0);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+
+    Mouse.moveTo(s_aScreenWidth, 0);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == s_aScreenWidth && ev.y == 0);
+
+    Mouse.moveTo(0, s_aScreenHeight);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == s_aScreenHeight);
+
+    Mouse.moveTo(s_aScreenWidth, s_aScreenHeight);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == s_aScreenWidth && ev.y == s_aScreenHeight);
+
+    Mouse.moveTo(0, 0);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+}
+
+test(USBHID_10_Mouse_Relative_Movement_Figure_Out_Resolution) {
+    /*
+     * This test should fail on Linux
+     */
+    HidEvent ev;
+    consume(Serial);
+
+    Mouse.moveTo(100, 100);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+
+    Mouse.move(-INT16_MAX, -INT16_MAX);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+    s_relativeWorks = 1;
+
+    Mouse.move(INT16_MAX, INT16_MAX);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x >= s_aScreenWidth && ev.y >= s_aScreenHeight);
+    s_rScreenWidth = ev.x;
+    s_rScreenHeight = ev.y;
+
+    Mouse.move(-INT16_MAX, -INT16_MAX);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+}
+
+test(USBHID_11_Mouse_Relative_Mixed_With_Absolute_Works_Correctly) {
+    /*
+     * This test should fail on OSX and Linux
+     */
+
+    if (!s_relativeWorks) {
+        fail();
+        return;
+    }
+    HidEvent ev;
+    consume(Serial);
+
+    Mouse.moveTo(s_aScreenWidth, s_aScreenHeight);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == s_aScreenWidth && ev.y == s_aScreenHeight);
+
+    Mouse.move(-INT16_MAX, -INT16_MAX);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+
+    Mouse.move(INT16_MAX, INT16_MAX);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == s_rScreenWidth && ev.y == s_rScreenHeight);
+
+    Mouse.moveTo(0, 0);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+
+    Mouse.move(0, 100);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y != 0);
+
+    Mouse.moveTo(0, 0);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+
+    Mouse.move(100, 0);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x != 0 && ev.y == 0);
+
+    Mouse.moveTo(0, 0);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue(ev.x == 0 && ev.y == 0);
+}
+
+test(USBHID_12_Mouse_Relative_Figure_Out_Maximum) {
+    /*
+     * This test should fail on Linux
+     */
+    if (!s_relativeWorks) {
+        fail();
+        return;
+    }
+    HidEvent ev;
+    consume(Serial);
+    //
+    int relMax = 0;
+    int relMaxC = 0;
+    int relMaxPx = 0;
+    for (int p = 0; p <= 32767;) {
+        Mouse.moveTo(relMaxC % s_aScreenWidth, 0);
+        readHidEvent(Serial, ev, 1000);
+
+        memset(&ev, 0, sizeof(ev));
+        Mouse.move(0, p);
+        if (!readHidEvent(Serial, ev, 100)) {
+            if (p > 100)
+                break;
+        } else {
+            assertEqual(ev.ev, 'm');
+        }
+        relMaxC++;
+        int l = floor(std::log10((float)p));
+        switch(l) {
+            case 3:
+                p += 10;
+                break;
+            case 4:
+                p += 100;
+                break;
+            case 5:
+                p += 1000;
+                break;
+            default:
+                p++;
+                break;
+        }
+
+        relMax = p;
+        if (ev.y > 0) {
+            relMaxPx = ev.y;
+            if (relMaxPx >= s_aScreenHeight)
+                break;
+        }
+    }
+
+    Serial.printf("Maximum relative movement: %d (%d px)\r\n", relMax, relMaxPx);
+
+    relMax = 0;
+    relMaxC = 0;
+    relMaxPx = 0;
+    for (int p = 0; p >= -32767;) {
+        Mouse.moveTo(relMaxC % s_aScreenWidth, s_aScreenHeight);
+        readHidEvent(Serial, ev, 1000);
+
+        memset(&ev, 0, sizeof(ev));
+        Mouse.move(0, p);
+        if (!readHidEvent(Serial, ev, 100)) {
+            if (p < -100)
+                break;
+        } else {
+            assertEqual(ev.ev, 'm');
+        }
+        relMaxC++;
+        int l = floor(std::log10(std::fabs((float)p)));
+        switch(l) {
+            case 3:
+                p -= 10;
+                break;
+            case 4:
+                p -= 100;
+                break;
+            case 5:
+                p -= 1000;
+                break;
+            default:
+                p--;
+                break;
+        }
+
+        relMax = p;
+        if (ev.y < s_aScreenHeight)
+            relMaxPx = ev.y;
+        if (ev.y == 0 && p < -100)
+            break;
+    }
+}
+
+test(USBHID_13_Mouse_Clicks_Work_Correctly) {
+    HidEvent ev;
+    consume(Serial);
+
+    Mouse.moveTo(s_aScreenWidth / 2, s_aScreenHeight / 2);
+    assertTrue(readHidEvent(Serial, ev));
+    assertEqual(ev.ev, 'm');
+    assertTrue((ev.x == (s_aScreenWidth / 2)) && (ev.y == (s_aScreenHeight / 2)));
+
+    Mouse.click(MOUSE_LEFT);
+    assertTrue(readHidEvent(Serial, ev, 1000));
+    assertEqual(ev.ev, 'c');
+    assertTrue((ev.x == (s_aScreenWidth / 2)) && (ev.y == (s_aScreenHeight / 2)));
+    assertEqual(ev.v1, 1);
+
+    Mouse.click(MOUSE_MIDDLE);
+    assertTrue(readHidEvent(Serial, ev, 1000));
+    assertEqual(ev.ev, 'c');
+    assertTrue((ev.x == (s_aScreenWidth / 2)) && (ev.y == (s_aScreenHeight / 2)));
+    assertEqual(ev.v1, 2);
+
+    Mouse.click(MOUSE_RIGHT);
+    assertTrue(readHidEvent(Serial, ev, 1000));
+    assertEqual(ev.ev, 'c');
+    assertTrue((ev.x == (s_aScreenWidth / 2)) && (ev.y == (s_aScreenHeight / 2)));
+    assertEqual(ev.v1, 3);
+}
+
+test(USBHID_14_Mouse_Wheel_Works_Correctly) {
+    HidEvent ev;
+    consume(Serial);
+
+    for (int p = -127; p <= 127; p++) {
+        if (p == 0)
+            continue;
+
+        memset(&ev, 0, sizeof(ev));
+        Mouse.scroll((int8_t)p);
+        while(readHidEvent(Serial, ev, 200)) {
+            assertEqual(ev.ev, 'w');
+            if (p < 0) {
+                assertTrue(ev.v1 < 0);
+            } else {
+                assertTrue(ev.v1 > 0);
+            }
+        }
+    }
+}

--- a/user/tests/wiring/usbhid2/usbhid.py
+++ b/user/tests/wiring/usbhid2/usbhid.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+
+# Linux requirements: python3, pyserial, tkinter
+# tkinter should usually be already installed
+# $ pip3 install tkinter
+# $ pip3 install pyserial
+#
+# OSX requirements: python3, pygame, pyserial
+# $ brew install python3 hg sdl sdl_image sdl_mixer sdl_ttf portmidi
+# $ pip3 install hg+https://bitbucket.org/pygame/pygame
+# $ pip3 install pyserial
+#
+# Windows requirements: python3, pygame, pyserial
+# $ C:\python35\Scripts\pip3.exe install pyserial
+# Download pygame whl from http://www.lfd.uci.edu/~gohlke/pythonlibs/#pygame
+# $ C:\python35\Scripts\pip3.exe install pygame-1.9.2b1-cp35-cp35m-win32.whl
+
+import sys
+import pprint
+import platform
+import serial
+import re
+import json
+
+if platform.system() == 'Darwin' or platform.system() == 'Windows':
+    import pygame
+else:
+    if sys.version_info[0] == 2:
+        from Tkinter import *
+    else:
+        from tkinter import *
+
+usb_keymap = {
+    # taken from https://chromium.googlesource.com/chromium/chromium/+/master/ui/base/keycodes/usb_keycode_map.h
+    # USB      XKB     Win     Mac
+    0x0000: (0x0000, 0x0000, 0xffff),  # Reserved
+    0x0001: (0x0000, 0x0000, 0xffff),  # ErrorRollOver
+    0x0002: (0x0000, 0x0000, 0xffff),  # POSTFail
+    0x0003: (0x0000, 0x0000, 0xffff),  # ErrorUndefined
+    0x0004: (0x0026, 0x001e, 0x0000),  # aA
+    0x0005: (0x0038, 0x0030, 0x000b),  # bB
+    0x0006: (0x0036, 0x002e, 0x0008),  # cC
+    0x0007: (0x0028, 0x0020, 0x0002),  # dD
+    0x0008: (0x001a, 0x0012, 0x000e),  # eE
+    0x0009: (0x0029, 0x0021, 0x0003),  # fF
+    0x000a: (0x002a, 0x0022, 0x0005),  # gG
+    0x000b: (0x002b, 0x0023, 0x0004),  # hH
+    0x000c: (0x001f, 0x0017, 0x0022),  # iI
+    0x000d: (0x002c, 0x0024, 0x0026),  # jJ
+    0x000e: (0x002d, 0x0025, 0x0028),  # kK
+    0x000f: (0x002e, 0x0026, 0x0025),  # lL
+    0x0010: (0x003a, 0x0032, 0x002e),  # mM
+    0x0011: (0x0039, 0x0031, 0x002d),  # nN
+    0x0012: (0x0020, 0x0018, 0x001f),  # oO
+    0x0013: (0x0021, 0x0019, 0x0023),  # pP
+    0x0014: (0x0018, 0x0010, 0x000c),  # qQ
+    0x0015: (0x001b, 0x0013, 0x000f),  # rR
+    0x0016: (0x0027, 0x001f, 0x0001),  # sS
+    0x0017: (0x001c, 0x0014, 0x0011),  # tT
+    0x0018: (0x001e, 0x0016, 0x0020),  # uU
+    0x0019: (0x0037, 0x002f, 0x0009),  # vV
+    0x001a: (0x0019, 0x0011, 0x000d),  # wW
+    0x001b: (0x0035, 0x002d, 0x0007),  # xX
+    0x001c: (0x001d, 0x0015, 0x0010),  # yY
+    0x001d: (0x0034, 0x002c, 0x0006),  # zZ
+    0x001e: (0x000a, 0x0002, 0x0012),  # 1!
+    0x001f: (0x000b, 0x0003, 0x0013),  # 2@
+    0x0020: (0x000c, 0x0004, 0x0014),  # 3#
+    0x0021: (0x000d, 0x0005, 0x0015),  # 4$
+    0x0022: (0x000e, 0x0006, 0x0017),  # 5%
+    0x0023: (0x000f, 0x0007, 0x0016),  # 6^
+    0x0024: (0x0010, 0x0008, 0x001a),  # 7&
+    0x0025: (0x0011, 0x0009, 0x001c),  # 8*
+    0x0026: (0x0012, 0x000a, 0x0019),  # 9(
+    0x0027: (0x0013, 0x000b, 0x001d),  # 0)
+    0x0028: (0x0024, 0x001c, 0x0024),  # Return
+    0x0029: (0x0009, 0x0001, 0x0035),  # Escape
+    0x002a: (0x0016, 0x000e, 0x0033),  # Backspace
+    0x002b: (0x0017, 0x000f, 0x0030),  # Tab
+    0x002c: (0x0041, 0x0039, 0x0031),  # Spacebar
+    0x002d: (0x0014, 0x000c, 0x001b),  # -_
+    0x002e: (0x0015, 0x000d, 0x0018),  # =+
+    0x002f: (0x0022, 0x001a, 0x0021),  # [{
+    0x0030: (0x0023, 0x001b, 0x001e),  # }]
+    0x0031: (0x0033, 0x002b, 0x002a),  # \| (US keyboard only)
+    # USB#070032 is not present on US keyboard.
+    # The keycap varies on international keyboards:
+    #   Dan: '*  Dutch: <>  Ger: #'  UK: #~
+    # For XKB, it uses the same scancode as the US \| key.
+    # TODO(garykac): Verify Mac intl keyboard.
+    # 0x0032: (0x0033, 0x002b, 0x002a),  # #~ (Non-US)
+    0x0033: (0x002f, 0x0027, 0x0029),  # ;:
+    0x0034: (0x0030, 0x0028, 0x0027),  # '"
+    0x0035: (0x0031, 0x0029, 0x0032),  # `~
+    0x0036: (0x003b, 0x0033, 0x002b),  # ,<
+    0x0037: (0x003c, 0x0034, 0x002f),  # .>
+    0x0038: (0x003d, 0x0035, 0x002c),  # /?
+    # TODO(garykac): CapsLock requires special handling for each platform.
+    0x0039: (0x0042, 0x003a, 0x0039),  # CapsLock
+    0x003a: (0x0043, 0x003b, 0x007a),  # F1
+    0x003b: (0x0044, 0x003c, 0x0078),  # F2
+    0x003c: (0x0045, 0x003d, 0x0063),  # F3
+    0x003d: (0x0046, 0x003e, 0x0076),  # F4
+    0x003e: (0x0047, 0x003f, 0x0060),  # F5
+    0x003f: (0x0048, 0x0040, 0x0061),  # F6
+    0x0040: (0x0049, 0x0041, 0x0062),  # F7
+    0x0041: (0x004a, 0x0042, 0x0064),  # F8
+    0x0042: (0x004b, 0x0043, 0x0065),  # F9
+    0x0043: (0x004c, 0x0044, 0x006d),  # F10
+    0x0044: (0x005f, 0x0057, 0x0067),  # F11
+    0x0045: (0x0060, 0x0058, 0x006f),  # F12
+    0x0046: (0x006b, 0xe037, 0xffff),  # PrintScreen
+    0x0047: (0x004e, 0x0046, 0xffff),  # ScrollLock
+    0x0048: (0x007f, 0x0000, 0xffff),  # Pause
+    # Labeled "Help/Insert" on Mac.
+    0x0049: (0x0076, 0xe052, 0x0072),  # Insert
+    0x004a: (0x006e, 0xe047, 0x0073),  # Home
+    0x004b: (0x0070, 0xe049, 0x0074),  # PageUp
+    0x004c: (0x0077, 0x0053, 0x0075),  # Delete (Forward Delete)
+    0x004d: (0x0073, 0xe04f, 0x0077),  # End
+    0x004e: (0x0075, 0xe051, 0x0079),  # PageDown
+    0x004f: (0x0072, 0xe04d, 0x007c),  # RightArrow
+    0x0050: (0x0071, 0xe04b, 0x007b),  # LeftArrow
+    0x0051: (0x0074, 0xe050, 0x007d),  # DownArrow
+    0x0052: (0x006f, 0xe048, 0x007e),  # UpArrow
+    0x0053: (0x004d, 0x0045, 0x0047),  # Keypad_NumLock Clear
+    0x0054: (0x006a, 0xe035, 0x004b),  # Keypad_/
+    0x0055: (0x003f, 0x0037, 0x0043),  # Keypad_*
+    0x0056: (0x0052, 0x004a, 0x004e),  # Keypad_-
+    0x0057: (0x0056, 0x004e, 0x0045),  # Keypad_+
+    0x0058: (0x0068, 0xe01c, 0x004c),  # Keypad_Enter
+    0x0059: (0x0057, 0x004f, 0x0053),  # Keypad_1 End
+    0x005a: (0x0058, 0x0050, 0x0054),  # Keypad_2 DownArrow
+    0x005b: (0x0059, 0x0051, 0x0055),  # Keypad_3 PageDown
+    0x005c: (0x0053, 0x004b, 0x0056),  # Keypad_4 LeftArrow
+    0x005d: (0x0054, 0x004c, 0x0057),  # Keypad_5
+    0x005e: (0x0055, 0x004d, 0x0058),  # Keypad_6 RightArrow
+    0x005f: (0x004f, 0x0047, 0x0059),  # Keypad_7 Home
+    0x0060: (0x0050, 0x0048, 0x005b),  # Keypad_8 UpArrow
+    0x0061: (0x0051, 0x0049, 0x005c),  # Keypad_9 PageUp
+    0x0062: (0x005a, 0x0052, 0x0052),  # Keypad_0 Insert
+    0x0063: (0x005b, 0x0000, 0x0041),  # Keypad_. Delete
+    # USB#070064 is not present on US keyboard.
+    # This key is typically located near LeftShift key.
+    # The keycap varies on international keyboards:
+    #   Dan: <> Dutch: ][ Ger: <> UK: \|
+    # TODO(garykac) Determine correct XKB scancode.
+    0x0064: (0x0000, 0x0056, 0xffff),  # Non-US \|
+    0x0065: (0x0087, 0xe05d, 0xffff),  # AppMenu (next to RWin key)
+    0x0066: (0x007c, 0x0000, 0xffff),  # Power
+    0x0067: (0x007d, 0x0000, 0x0051),  # Keypad_=
+    0x0068: (0x0000, 0x0000, 0x0069),  # F13
+    0x0069: (0x0000, 0x0000, 0x006b),  # F14
+    0x006a: (0x0000, 0x005d, 0x0071),  # F15
+    0x006b: (0x0000, 0x0063, 0x006a),  # F16
+    0x006c: (0x0000, 0x0064, 0x0040),  # F17
+    0x006d: (0x0000, 0x0065, 0x004f),  # F18
+    0x006e: (0x0000, 0x0066, 0x0050),  # F19
+    0x006f: (0x0000, 0x0067, 0x005a),  # F20
+    0x0070: (0x0000, 0x0068, 0xffff),  # F21
+    0x0071: (0x0000, 0x0069, 0xffff),  # F22
+    0x0072: (0x0000, 0x006a, 0xffff),  # F23
+    0x0073: (0x0000, 0x006b, 0xffff),  # F24
+    0x0074: (0x0000, 0x0000, 0xffff),  # Execute
+    0x0075: (0x0092, 0xe03b, 0xffff),  # Help
+    0x0076: (0x0093, 0x0000, 0xffff),  # Menu
+    0x0077: (0x0000, 0x0000, 0xffff),  # Select
+    0x0078: (0x0000, 0x0000, 0xffff),  # Stop
+    0x0079: (0x0089, 0x0000, 0xffff),  # Again (Redo)
+    0x007a: (0x008b, 0xe008, 0xffff),  # Undo
+    0x007b: (0x0091, 0xe017, 0xffff),  # Cut
+    0x007c: (0x008d, 0xe018, 0xffff),  # Copy
+    0x007d: (0x008f, 0xe00a, 0xffff),  # Paste
+    0x007e: (0x0090, 0x0000, 0xffff),  # Find
+    0x007f: (0x0079, 0xe020, 0x004a),  # Mute
+    0x0080: (0x007b, 0xe030, 0x0048),  # VolumeUp
+    0x0081: (0x007a, 0xe02e, 0x0049),  # VolumeDown
+    0x0082: (0x0000, 0x0000, 0xffff),  # LockingCapsLock
+    0x0083: (0x0000, 0x0000, 0xffff),  # LockingNumLock
+    0x0084: (0x0000, 0x0000, 0xffff),  # LockingScrollLock
+    # USB#070085 is used as Brazilian Keypad_.
+    0x0085: (0x0000, 0x0000, 0x005f),  # Keypad_Comma
+    # USB#070086 is used on AS/400 keyboards. Standard Keypad_= is USB#070067.
+    #0x0086: (0x0000, 0x0000, 0xffff),  # Keypad_=
+    # USB#070087 is used for Brazilian /? and Japanese _ 'ro'.
+    0x0087: (0x0000, 0x0000, 0x005e),  # International1
+    # USB#070088 is used as Japanese Hiragana/Katakana key.
+    0x0088: (0x0065, 0x0000, 0x0068),  # International2
+    # USB#070089 is used as Japanese Yen key.
+    0x0089: (0x0000, 0x007d, 0x005d),  # International3
+    # USB#07008a is used as Japanese Henkan (Convert) key.
+    0x008a: (0x0064, 0x0000, 0xffff),  # International4
+    # USB#07008b is used as Japanese Muhenkan (No-convert) key.
+    0x008b: (0x0066, 0x0000, 0xffff),  # International5
+    0x008c: (0x0000, 0x0000, 0xffff),  # International6
+    0x008d: (0x0000, 0x0000, 0xffff),  # International7
+    0x008e: (0x0000, 0x0000, 0xffff),  # International8
+    0x008f: (0x0000, 0x0000, 0xffff),  # International9
+    # USB#070090 is used as Korean Hangul/English toggle key.
+    0x0090: (0x0082, 0x0000, 0xffff),  # LANG1
+    # USB#070091 is used as Korean Hanja conversion key.
+    0x0091: (0x0083, 0x0000, 0xffff),  # LANG2
+    # USB#070092 is used as Japanese Katakana key.
+    0x0092: (0x0062, 0x0000, 0xffff),  # LANG3
+    # USB#070093 is used as Japanese Hiragana key.
+    0x0093: (0x0063, 0x0000, 0xffff),  # LANG4
+    # USB#070094 is used as Japanese Zenkaku/Hankaku (Fullwidth/halfwidth) key.
+    0x0094: (0x0000, 0x0000, 0xffff),  # LANG5
+    0x0095: (0x0000, 0x0000, 0xffff),  # LANG6
+    0x0096: (0x0000, 0x0000, 0xffff),  # LANG7
+    0x0097: (0x0000, 0x0000, 0xffff),  # LANG8
+    0x0098: (0x0000, 0x0000, 0xffff),  # LANG9
+    0x0099: (0x0000, 0x0000, 0xffff),  # AlternateErase
+    0x009a: (0x0000, 0x0000, 0xffff),  # SysReq/Attention
+    0x009b: (0x0088, 0x0000, 0xffff),  # Cancel
+    0x009c: (0x0000, 0x0000, 0xffff),  # Clear
+    0x009d: (0x0000, 0x0000, 0xffff),  # Prior
+    0x009e: (0x0000, 0x0000, 0xffff),  # Return
+    0x009f: (0x0000, 0x0000, 0xffff),  # Separator
+    0x00a0: (0x0000, 0x0000, 0xffff),  # Out
+    0x00a1: (0x0000, 0x0000, 0xffff),  # Oper
+    0x00a2: (0x0000, 0x0000, 0xffff),  # Clear/Again
+    0x00a3: (0x0000, 0x0000, 0xffff),  # CrSel/Props
+    0x00a4: (0x0000, 0x0000, 0xffff),  # ExSel
+    #0x00b0: (0x0000, 0x0000, 0xffff),  # Keypad_00
+    #0x00b1: (0x0000, 0x0000, 0xffff),  # Keypad_000
+    #0x00b2: (0x0000, 0x0000, 0xffff),  # ThousandsSeparator
+    #0x00b3: (0x0000, 0x0000, 0xffff),  # DecimalSeparator
+    #0x00b4: (0x0000, 0x0000, 0xffff),  # CurrencyUnit
+    #0x00b5: (0x0000, 0x0000, 0xffff),  # CurrencySubunit
+    0x00b6: (0x00bb, 0x0000, 0xffff),  # Keypad_(
+    0x00b7: (0x00bc, 0x0000, 0xffff),  # Keypad_)
+    #0x00b8: (0x0000, 0x0000, 0xffff),  # Keypad_{
+    #0x00b9: (0x0000, 0x0000, 0xffff),  # Keypad_}
+    #0x00ba: (0x0000, 0x0000, 0xffff),  # Keypad_Tab
+    #0x00bb: (0x0000, 0x0000, 0xffff),  # Keypad_Backspace
+    #0x00bc: (0x0000, 0x0000, 0xffff),  # Keypad_A
+    #0x00bd: (0x0000, 0x0000, 0xffff),  # Keypad_B
+    #0x00be: (0x0000, 0x0000, 0xffff),  # Keypad_C
+    #0x00bf: (0x0000, 0x0000, 0xffff),  # Keypad_D
+    #0x00c0: (0x0000, 0x0000, 0xffff),  # Keypad_E
+    #0x00c1: (0x0000, 0x0000, 0xffff),  # Keypad_F
+    #0x00c2: (0x0000, 0x0000, 0xffff),  # Keypad_Xor
+    #0x00c3: (0x0000, 0x0000, 0xffff),  # Keypad_^
+    #0x00c4: (0x0000, 0x0000, 0xffff),  # Keypad_%
+    #0x00c5: (0x0000, 0x0000, 0xffff),  # Keypad_<
+    #0x00c6: (0x0000, 0x0000, 0xffff),  # Keypad_>
+    #0x00c7: (0x0000, 0x0000, 0xffff),  # Keypad_&
+    #0x00c8: (0x0000, 0x0000, 0xffff),  # Keypad_&&
+    #0x00c9: (0x0000, 0x0000, 0xffff),  # Keypad_|
+    #0x00ca: (0x0000, 0x0000, 0xffff),  # Keypad_||
+    #0x00cb: (0x0000, 0x0000, 0xffff),  # Keypad_:
+    #0x00cc: (0x0000, 0x0000, 0xffff),  # Keypad_#
+    #0x00cd: (0x0000, 0x0000, 0xffff),  # Keypad_Space
+    #0x00ce: (0x0000, 0x0000, 0xffff),  # Keypad_@
+    #0x00cf: (0x0000, 0x0000, 0xffff),  # Keypad_!
+    #0x00d0: (0x0000, 0x0000, 0xffff),  # Keypad_MemoryStore
+    #0x00d1: (0x0000, 0x0000, 0xffff),  # Keypad_MemoryRecall
+    #0x00d2: (0x0000, 0x0000, 0xffff),  # Keypad_MemoryClear
+    #0x00d3: (0x0000, 0x0000, 0xffff),  # Keypad_MemoryAdd
+    #0x00d4: (0x0000, 0x0000, 0xffff),  # Keypad_MemorySubtract
+    #0x00d5: (0x0000, 0x0000, 0xffff),  # Keypad_MemoryMultiply
+    #0x00d6: (0x0000, 0x0000, 0xffff),  # Keypad_MemoryDivide
+    0x00d7: (0x007e, 0x0000, 0xffff),  # Keypad_+/-
+    #0x00d8: (0x0000, 0x0000, 0xffff),  # Keypad_Clear
+    #0x00d9: (0x0000, 0x0000, 0xffff),  # Keypad_ClearEntry
+    #0x00da: (0x0000, 0x0000, 0xffff),  # Keypad_Binary
+    #0x00db: (0x0000, 0x0000, 0xffff),  # Keypad_Octal
+    0x00dc: (0x0081, 0x0000, 0xffff),  # Keypad_Decimal
+    #0x00dd: (0x0000, 0x0000, 0xffff),  # Keypad_Hexadecimal
+    # USB#0700de - #0700df are reserved.
+    0x00e0: (0x0025, 0x001d, 0x003b),  # LeftControl
+    0x00e1: (0x0032, 0x002a, 0x0038),  # LeftShift
+    0x00e2: (0x0040, 0x0038, 0x003a),  # LeftAlt/Option
+    0x00e3: (0x0085, 0x005b, 0x0037),  # LeftGUI/Super/Win/Cmd
+    0x00e4: (0x0069, 0xe01d, 0x003e),  # RightControl
+    0x00e5: (0x003e, 0x0036, 0x003c),  # RightShift
+    0x00e6: (0x006c, 0xe038, 0x003d),  # RightAlt/Option
+    0x00e7: (0x0086, 0x005c, 0x0036),  # RightGUI/Super/Win/Cmd
+}
+
+usb_keymap_platform = {
+    'Linux': dict([(v[0], k) for (k, v) in usb_keymap.items()]),
+    'Windows': dict([(v[1], k) for (k, v) in usb_keymap.items()]),
+    'Darwin': dict([(v[2], k) for (k, v) in usb_keymap.items()]),
+}
+
+def usb_hid_to_keycode(keycode):
+    i = 0
+    if platform.system() == 'Linux':
+        i = 0
+    elif platform.system() == 'Windows':
+        i = 1
+    else:
+        i = 2
+    try:
+        return usb_keymap[keycode][i]
+    except:
+        return 0
+
+def keycode_to_usb_hid(keycode):
+    try:
+        return usb_keymap_platform[platform.system()][keycode]
+    except:
+        return 0
+
+class SerialConnection:
+    def __init__(self, port):
+        self.s = None
+        if port is not None:
+            self.s = serial.Serial(port, timeout=0, writeTimeout=0.5)
+        self.state = False
+
+    def start(self):
+        if self.s is not None:
+            self.s.writelines(['t'.encode('utf-8')])
+
+    def report_event(self, ev):
+        #print('> {} {} {} {} {} {}'.format(*ev).encode('utf-8'))
+        if not self.state:
+            return
+        # type
+        # posx
+        # posy
+        # value1
+        # value2
+        # value3
+        try:
+            self.s.writelines(['{} {} {} {} {} {}\n'.format(*ev).encode('utf-8')])
+        except:
+            pass
+
+    def report_mouse_position(self, pos, res):
+        ev = ('m', pos[0], pos[1], res[0], res[1], 0)
+        self.report_event(ev)
+
+    def report_mouse_click(self, pos, button):
+        ev = ('c', pos[0], pos[1], button, 0, 0)
+        self.report_event(ev)
+
+    def report_mouse_wheel(self, value):
+        ev = ('w', 0, 0, value)
+        self.report_event(ev)
+
+    def report_key(self, code, mod, char):
+        if char == '':
+            char = 256
+        else:
+            char = ord(char)
+        ev = ('k', 0, 0, code, mod, char)
+        self.report_event(ev)
+
+    def handle(self):
+        l = b''
+        if self.s is not None:
+            l = self.s.readline()
+        if l == b'':
+            return None
+        l = l.strip()
+        print(l.decode('utf-8'))
+        if l == b'Running tests':
+            self.state = True
+        elif l.startswith(b'Test summary:'):
+            (p, f, s, t) = re.search(b'^Test summary: (\d+) passed, (\d+) failed, and (\d+) skipped, out of (\d+) test\(s\).$', l).groups()
+            self.state = False
+            status = True
+            text = l
+            if (int(p) + int(s)) == int(t):
+                status = True
+            else:
+                status = False
+            return (status, l)
+
+class MainWindowBase:
+    def __init__(self, ser):
+        self.s = ser
+        self.exit = 0
+
+    def handle(self):
+        pass
+
+    def finish(self, status, text):
+        pass
+
+    def draw_text(self, text):
+        pass
+
+if platform.system() == 'Darwin' or platform.system() == 'Windows':
+    class MainWindowPyGame(MainWindowBase):
+        modifier_map = {
+            pygame.KMOD_NONE:   0xe000,
+            pygame.KMOD_LSHIFT: 0xe002,
+            pygame.KMOD_RSHIFT: 0xe020,
+            pygame.KMOD_SHIFT:  0xe002,
+            pygame.KMOD_LCTRL:  0xe001,
+            pygame.KMOD_RCTRL:  0xe010,
+            pygame.KMOD_CTRL:   0xe001,
+            pygame.KMOD_LALT:   0xe004,
+            pygame.KMOD_RALT:   0xe040,
+            pygame.KMOD_ALT:    0xe004,
+            pygame.KMOD_LMETA:  0xe008,
+            pygame.KMOD_RMETA:  0xe080,
+            pygame.KMOD_META:   0xe008,
+            pygame.KMOD_NUM:    0x0000,
+            pygame.KMOD_CAPS:   0x0000,
+            pygame.KMOD_MODE:   0xe000
+        }
+
+        patch_scancodes = {
+            pygame.K_LCTRL:  usb_hid_to_keycode(0x00e0),
+            pygame.K_LSHIFT: usb_hid_to_keycode(0x00e1),
+            pygame.K_LALT:   usb_hid_to_keycode(0x00e2),
+            pygame.K_LMETA:  usb_hid_to_keycode(0x00e3),
+            pygame.K_RCTRL:  usb_hid_to_keycode(0x00e4),
+            pygame.K_RSHIFT: usb_hid_to_keycode(0x00e5),
+            pygame.K_RALT:   usb_hid_to_keycode(0x00e6),
+            pygame.K_RMETA:  usb_hid_to_keycode(0x00e7)
+        }
+
+        def modifier_normalize(self, val):
+            out = 0x0000
+            for (k, v) in self.modifier_map.items():
+                if val & k:
+                    out |= v
+            return out
+
+        def __init__(self, ser):
+            super().__init__(ser)
+            pygame.init()
+            self.s = ser
+            self.info = pygame.display.Info()
+            self.screen = pygame.display.set_mode((self.info.current_w, self.info.current_h), pygame.FULLSCREEN)
+            self.mouse = pygame.mouse.get_pos()
+            self.textpos = (5, 0)
+            self.screen.fill((255, 255, 255))
+
+            self.font = pygame.font.SysFont("monospace", 8)
+            self.font1 = pygame.font.SysFont("monospace", 24)
+            self.handle()
+
+            self.exit_info()
+
+        def handle(self):
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    sys.exit()
+                elif event.type == pygame.KEYDOWN:
+                    self.on_key(event)
+                elif event.type == pygame.MOUSEMOTION:
+                    self.on_mouse_motion(event)
+                elif event.type == pygame.MOUSEBUTTONDOWN:
+                    self.on_mouse_click(event)
+            pygame.display.flip()
+
+        def draw_text(self, text):
+            label = self.font.render(text, 1, (0x20, 0x20, 0x20))
+            self.screen.blit(label, self.textpos)
+            self.textpos = (self.textpos[0], self.textpos[1] + 10)
+            if (self.textpos[1] + 10) >= self.info.current_h:
+                self.textpos = (self.textpos[0] + 150, 0)
+
+        def on_key(self, event):
+            chhex = ord(event.unicode) if len(event.unicode) > 0 else 0
+            # Normalize modifiers
+            mod = self.modifier_normalize(event.mod)
+            if event.key in self.patch_scancodes:
+                event.scancode = self.patch_scancodes[event.key]
+            self.draw_text('Key {}/{:03x} {} ({:02x})'.format(keycode_to_usb_hid(event.scancode), mod & 0x0fff, json.dumps(event.unicode), chhex))
+            if keycode_to_usb_hid(event.scancode) == 0x0029:
+                self.exit += 1
+            else:
+                self.exit = 0
+
+            #pprint.pprint(event)
+            self.s.report_key(keycode_to_usb_hid(event.scancode), mod, event.unicode)
+
+        def on_mouse_motion(self, event):
+            pygame.draw.line(self.screen, (0,0,0), self.mouse, event.pos)
+            self.mouse = event.pos
+            #print('========================= Motion ========================')
+            #pprint.pprint(event)
+            self.s.report_mouse_position(self.mouse, (self.info.current_w, self.info.current_h))
+        def on_mouse_click(self, event):
+            # print('========================= Click ========================')
+            if event.button > 3:
+                self.on_mouse_wheel(event)
+                return
+            fill=None
+            if event.button == 1:
+                fill = 'red'
+            elif event.button == 2:
+                fill = 'green'
+            elif event.button == 3:
+                fill = 'blue'
+
+            pygame.draw.circle(self.screen, pygame.Color(fill),
+                               event.pos, 10)
+            # pprint.pprint(vars(event))
+            # self.ok()
+            self.s.report_mouse_click(event.pos, event.button)
+        def on_mouse_wheel(self, event):
+            #print('========================= Wheel ========================')
+            #pprint.pprint(vars(event))
+            val = 0
+            if event.button == 4:
+                val = -1
+            elif event.button == 5:
+                val = 1
+            if val != 0:
+                self.s.report_mouse_wheel(val)
+
+        def exit_info(self):
+            fill = 'blue'
+            label = self.font1.render('Press ESC 10 times to exit', 1, pygame.Color(fill))
+            pos = label.get_rect()
+            pos.centerx = self.screen.get_rect().centerx
+            pos.centery = 100
+            self.screen.blit(label, pos)
+
+        def finish(self, status, text):
+            fill = 'green' if status == True else 'red'
+            label = self.font1.render(text, 1, pygame.Color(fill))
+            pos = label.get_rect()
+            pos.centerx = self.screen.get_rect().centerx
+            pos.centery = self.screen.get_rect().centery
+            self.screen.blit(label, pos)
+    MainWindow = MainWindowPyGame
+else:
+    class MainWindowTkinter(MainWindowBase):
+        modifier_map = {
+            0x0001:  0xe002,
+            0x0004:  0xe001,
+            0x0008:  0xe004,
+            0x0080:  0xe040,
+            0x20000: 0xe004
+        }
+
+        def modifier_normalize(self, val):
+            out = 0x0000
+            for (k, v) in self.modifier_map.items():
+                if val & k:
+                    out |= v
+            return out
+
+        def __init__(self, ser):
+            super().__init__(ser)
+            self.tk = Tk()
+            self.tk.config(menu=None)
+            self.tk.overrideredirect(False)
+            try:
+                self.tk.attributes("-toolwindow", 1)
+            except:
+                pass
+            try:
+                self.tk.attributes('-zoomed', True)
+            except:
+                pass
+            self.tk.attributes('-fullscreen', True)
+            self.tk.wm_attributes('-topmost', True)
+            self.tk.lift()
+
+            self.canvas = Canvas(self.tk, bg='white', width=self.tk.winfo_screenwidth(), height=self.tk.winfo_screenheight())
+            self.canvas.pack()
+            self.tk.bind('<Motion>', self.on_mouse_motion)
+            self.tk.bind('<Key>', self.on_key)
+            self.tk.bind('<Button-1>', self.on_mouse_click)
+            self.tk.bind('<Button-2>', self.on_mouse_click)
+            self.tk.bind('<Button-3>', self.on_mouse_click)
+            if platform.system() == 'Linux':
+                self.tk.bind('<Button-4>', self.on_mouse_wheel)
+                self.tk.bind('<Button-5>', self.on_mouse_wheel)
+            else:
+                self.tk.bind('<MouseWheel>', self.on_mouse_wheel)
+
+            self.mouse = (self.tk.winfo_pointerx(), self.tk.winfo_pointery())
+            self.textpos = (5, 0)
+            self.exit = 0
+
+            self.exit_info()
+
+        def draw_text(self, text):
+            self.canvas.create_text(self.textpos[0], self.textpos[1], text=text, font=('Monospace', 8), anchor=NW, fill='gray')
+            self.textpos = (self.textpos[0], self.textpos[1] + 10)
+            if (self.textpos[1] + 10) >= self.tk.winfo_screenheight():
+                self.textpos = (self.textpos[0] + 150, 0)
+
+        def on_key(self, event):
+            #print('========================= Key ========================')
+            chhex = ord(event.char) if len(event.char) > 0 else 0
+            mod = self.modifier_normalize(event.state)
+            self.draw_text('Key {}/{:03x} {} ({:02x})'.format(keycode_to_usb_hid(event.keycode), mod & 0x0fff, json.dumps(event.char), chhex))
+            if keycode_to_usb_hid(event.keycode) == 0x0029:
+                self.exit += 1
+            else:
+                self.exit = 0
+
+            #pprint.pprint(vars(event))
+            self.s.report_key(keycode_to_usb_hid(event.keycode), mod, event.char)
+        def on_mouse_motion(self, event):
+            self.canvas.create_line(self.mouse[0], self.mouse[1], event.x, event.y)
+            self.mouse = (event.x, event.y)
+            #print('========================= Motion ========================')
+            #pprint.pprint(vars(event))
+            self.s.report_mouse_position(self.mouse, (self.tk.winfo_screenwidth(), self.tk.winfo_screenheight()))
+        def on_mouse_click(self, event):
+            # print('========================= Click ========================')
+            fill=None
+            if event.num == 1:
+                fill = 'red'
+            elif event.num == 2:
+                fill = 'green'
+            elif event.num == 3:
+                fill = 'blue'
+            self.canvas.create_oval(event.x - 10,
+                                    event.y - 10,
+                                    event.x + 10,
+                                    event.y + 10, fill=fill)
+            # pprint.pprint(vars(event))
+            # self.ok()
+            # self.fail()
+            self.s.report_mouse_click((event.x, event.y), event.num)
+        def on_mouse_wheel(self, event):
+            #print('========================= Wheel ========================')
+            #pprint.pprint(vars(event))
+            val = 0
+            if platform.system() == 'Linux':
+                if event.num == 4:
+                    val = -1
+                elif event.num == 5:
+                    val = 1
+            else:
+                val = event.delta
+
+            if val != 0:
+                self.s.report_mouse_wheel(val)
+
+        def exit_info(self):
+            fill = 'blue'
+            self.canvas.create_text(self.tk.winfo_screenwidth() / 2, 100, text='Press ESC 10 times to exit', font=('Monospace', 24), fill=fill)
+
+        def finish(self, status, text):
+            fill = 'green' if status == True else 'red'
+            self.canvas.create_text(self.tk.winfo_screenwidth() / 2, self.tk.winfo_screenheight() / 2, text=text, font=('Monospace', 24), fill=fill)
+
+        def handle(self):
+            self.tk.update_idletasks()
+            self.tk.update()
+
+    MainWindow = MainWindowTkinter
+
+def usage():
+    print('Usage: {} <tty>'.format(sys.argv[0]))
+    sys.exit(0)
+
+if __name__ == '__main__':
+    sport = None
+    if len(sys.argv) >= 2:
+        sport = sys.argv[1]
+    else:
+        usage()
+    s = SerialConnection(sport)
+    w = MainWindow(s)
+    s.start()
+    while True:
+        r = s.handle()
+        if r is not None:
+            w.finish(r[0], r[1])
+        # w.tk.update_idletasks()
+        # w.tk.update()
+        w.handle()
+        if w.exit >= 10:
+            break

--- a/wiring/inc/spark_wiring_usbkeyboard.h
+++ b/wiring/inc/spark_wiring_usbkeyboard.h
@@ -30,45 +30,7 @@
 
 #ifdef SPARK_USB_KEYBOARD
 #include "spark_wiring.h"
-
-#define KEY_LEFT_CTRL		0x80
-#define KEY_LEFT_SHIFT		0x81
-#define KEY_LEFT_ALT		0x82
-#define KEY_LEFT_GUI		0x83
-#define KEY_RIGHT_CTRL		0x84
-#define KEY_RIGHT_SHIFT		0x85
-#define KEY_RIGHT_ALT		0x86
-#define KEY_RIGHT_GUI		0x87
-
-#define KEY_UP_ARROW		0xDA
-#define KEY_DOWN_ARROW		0xD9
-#define KEY_LEFT_ARROW		0xD8
-#define KEY_RIGHT_ARROW		0xD7
-#define KEY_BACKSPACE		0xB2
-#define KEY_TAB				0xB3
-#define KEY_RETURN			0xB0
-#define KEY_ESC				0xB1
-#define KEY_INSERT			0xD1
-#define KEY_DELETE			0xD4
-#define KEY_PAGE_UP			0xD3
-#define KEY_PAGE_DOWN		0xD6
-#define KEY_HOME			0xD2
-#define KEY_END				0xD5
-#define KEY_CAPS_LOCK		0xC1
-#define KEY_F1				0xC2
-#define KEY_F2				0xC3
-#define KEY_F3				0xC4
-#define KEY_F4				0xC5
-#define KEY_F5				0xC6
-#define KEY_F6				0xC7
-#define KEY_F7				0xC8
-#define KEY_F8				0xC9
-#define KEY_F9				0xCA
-#define KEY_F10				0xCB
-#define KEY_F11				0xCC
-#define KEY_F12				0xCD
-
-#define KEY_RAW       0x88
+#include "spark_wiring_usbkeyboard_scancode.h"
 
 typedef struct
 {
@@ -88,10 +50,11 @@ public:
 
 	void begin(void);
 	void end(void);
-  virtual size_t write(uint8_t k);
-	virtual size_t writeRaw(uint16_t k);
-	virtual size_t press(uint16_t k);
-	virtual size_t release(uint16_t k);
+  virtual size_t write(uint8_t ch);
+	virtual size_t writeKey(uint16_t k, uint16_t modifiers = 0);
+  virtual size_t click(uint16_t k, uint16_t modifiers = 0);
+	virtual size_t press(uint16_t k, uint16_t modifiers = 0);
+	virtual size_t release(uint16_t k, uint16_t modifiers = 0);
 	virtual void releaseAll(void);
 
 private:

--- a/wiring/inc/spark_wiring_usbkeyboard_scancode.h
+++ b/wiring/inc/spark_wiring_usbkeyboard_scancode.h
@@ -1,0 +1,416 @@
+#ifndef __SPARK_WIRING_USBKEYBOARDSCANCODE_H
+#define __SPARK_WIRING_USBKEYBOARDSCANCODE_H
+
+// http://www.usb.org/developers/hidpage/Hut1_12v2.pdf
+typedef enum {
+  // input.h compatible key names
+  KEY_RESERVED           = 0x00,     // Reserved (no event indicated)
+  KEY_A                  = 0x04,     // Keyboard a and A
+  KEY_B                  = 0x05,     // Keyboard b and B
+  KEY_C                  = 0x06,     // Keyboard c and C
+  KEY_D                  = 0x07,     // Keyboard d and D
+  KEY_E                  = 0x08,     // Keyboard e and E
+  KEY_F                  = 0x09,     // Keyboard f and F
+  KEY_G                  = 0x0A,     // Keyboard g and G
+  KEY_H                  = 0x0B,     // Keyboard h and H
+  KEY_I                  = 0x0C,     // Keyboard i and I
+  KEY_J                  = 0x0D,     // Keyboard j and J
+  KEY_K                  = 0x0E,     // Keyboard k and K
+  KEY_L                  = 0x0F,     // Keyboard l and L
+  KEY_M                  = 0x10,     // Keyboard m and M
+  KEY_N                  = 0x11,     // Keyboard n and N
+  KEY_O                  = 0x12,     // Keyboard o and O
+  KEY_P                  = 0x13,     // Keyboard p and P
+  KEY_Q                  = 0x14,     // Keyboard q and Q
+  KEY_R                  = 0x15,     // Keyboard r and R
+  KEY_S                  = 0x16,     // Keyboard s and S
+  KEY_T                  = 0x17,     // Keyboard t and T
+  KEY_U                  = 0x18,     // Keyboard u and U
+  KEY_V                  = 0x19,     // Keyboard v and V
+  KEY_W                  = 0x1A,     // Keyboard w and W
+  KEY_X                  = 0x1B,     // Keyboard x and X
+  KEY_Y                  = 0x1C,     // Keyboard y and Y
+  KEY_Z                  = 0x1D,     // Keyboard z and Z
+  KEY_1                  = 0x1E,     // Keyboard 1 and !
+  KEY_2                  = 0x1F,     // Keyboard 2 and @
+  KEY_3                  = 0x20,     // Keyboard 3 and #
+  KEY_4                  = 0x21,     // Keyboard 4 and $
+  KEY_5                  = 0x22,     // Keyboard 5 and %
+  KEY_6                  = 0x23,     // Keyboard 6 and ^
+  KEY_7                  = 0x24,     // Keyboard 7 and &
+  KEY_8                  = 0x25,     // Keyboard 8 and *
+  KEY_9                  = 0x26,     // Keyboard 9 and (
+  KEY_0                  = 0x27,     // Keyboard 0 and )
+  KEY_ENTER              = 0x28,     // Keyboard Return (ENTER)
+  KEY_ESC                = 0x29,     // Keyboard ESCAPE
+  KEY_BACKSPACE          = 0x2A,     // Keyboard DELETE (Backspace)
+  KEY_TAB                = 0x2B,     // Keyboard Tab
+  KEY_SPACE              = 0x2C,     // Keyboard Spacebar
+  KEY_MINUS              = 0x2D,     // Keyboard - and (underscore)
+  KEY_EQUAL              = 0x2E,     // Keyboard = and +
+  KEY_LEFTBRACE          = 0x2F,     // Keyboard [ and {
+  KEY_RIGHTBRACE         = 0x30,     // Keyboard ] and }
+  KEY_BACKSLASH          = 0x31,     // Keyboard \ and |
+  KEY_HASH               = 0x32,     // Keyboard Non-US # and ~
+  KEY_SEMICOLON          = 0x33,     // Keyboard ; and :
+  KEY_APOSTROPHE         = 0x34,     // Keyboard ‘ and “
+  KEY_GRAVE              = 0x35,     // Keyboard Grave Accent and Tilde
+  KEY_COMMA              = 0x36,     // Keyboard , and <
+  KEY_DOT                = 0x37,     // Keyboard . and >
+  KEY_SLASH              = 0x38,     // Keyboard / and ?
+  KEY_CAPSLOCK           = 0x39,     // Keyboard Caps Lock
+  KEY_F1                 = 0x3A,     // Keyboard F1
+  KEY_F2                 = 0x3B,     // Keyboard F2
+  KEY_F3                 = 0x3C,     // Keyboard F3
+  KEY_F4                 = 0x3D,     // Keyboard F4
+  KEY_F5                 = 0x3E,     // Keyboard F5
+  KEY_F6                 = 0x3F,     // Keyboard F6
+  KEY_F7                 = 0x40,     // Keyboard F7
+  KEY_F8                 = 0x41,     // Keyboard F8
+  KEY_F9                 = 0x42,     // Keyboard F9
+  KEY_F10                = 0x43,     // Keyboard F10
+  KEY_F11                = 0x44,     // Keyboard F11
+  KEY_F12                = 0x45,     // Keyboard F12
+  KEY_PRINT              = 0x46,     // Keyboard PrintScreen
+  KEY_SCROLLLOCK         = 0x47,     // Keyboard Scroll Lock
+  KEY_PAUSE              = 0x48,     // Keyboard Pause
+  KEY_INSERT             = 0x49,     // Keyboard Insert
+  KEY_HOME               = 0x4A,     // Keyboard Home
+  KEY_PAGEUP             = 0x4B,     // Keyboard PageUp
+  KEY_DELETE             = 0x4C,     // Keyboard Delete Forward
+  KEY_END                = 0x4D,     // Keyboard End
+  KEY_PAGEDOWN           = 0x4E,     // Keyboard PageDown
+  KEY_RIGHT              = 0x4F,     // Keyboard RightArrow
+  KEY_LEFT               = 0x50,     // Keyboard LeftArrow
+  KEY_DOWN               = 0x51,     // Keyboard DownArrow
+  KEY_UP                 = 0x52,     // Keyboard UpArrow
+  KEY_NUMLOCK            = 0x53,     // Keypad Num Lock and Clear
+  KEY_KPSLASH            = 0x54,     // Keypad /
+  KEY_KPASTERISK         = 0x55,     // Keypad *
+  KEY_KPMINUS            = 0x56,     // Keypad -
+  KEY_KPPLUS             = 0x57,     // Keypad +
+  KEY_KPENTER            = 0x58,     // Keypad ENTER
+  KEY_KP1                = 0x59,     // Keypad 1 and End
+  KEY_KP2                = 0x5A,     // Keypad 2 and Down Arrow
+  KEY_KP3                = 0x5B,     // Keypad 3 and PageDn
+  KEY_KP4                = 0x5C,     // Keypad 4 and Left Arrow
+  KEY_KP5                = 0x5D,     // Keypad 5
+  KEY_KP6                = 0x5E,     // Keypad 6 and Right Arrow
+  KEY_KP7                = 0x5F,     // Keypad 7 and Home
+  KEY_KP8                = 0x60,     // Keypad 8 and Up Arrow
+  KEY_KP9                = 0x61,     // Keypad 9 and PageUp
+  KEY_KP0                = 0x62,     // Keypad 0 and Insert
+  KEY_KPDOT              = 0x63,     // Keypad . and Delete
+  KEY_102ND              = 0x64,     // Keyboard Non-US \ and |
+  KEY_COMPOSE            = 0x65,     // Keyboard Application
+                                     // LOGICAL_MAXIMUM
+  KEY_POWER              = 0x66,     // Keyboard Power
+  KEY_KPEQUAL            = 0x67,     // Keypad =
+  KEY_F13                = 0x68,     // Keyboard F13
+  KEY_F14                = 0x69,     // Keyboard F14
+  KEY_F15                = 0x6A,     // Keyboard F15
+  KEY_F16                = 0x6B,     // Keyboard F16
+  KEY_F17                = 0x6C,     // Keyboard F17
+  KEY_F18                = 0x6D,     // Keyboard F18
+  KEY_F19                = 0x6E,     // Keyboard F19
+  KEY_F20                = 0x6F,     // Keyboard F20
+  KEY_F21                = 0x70,     // Keyboard F21
+  KEY_F22                = 0x71,     // Keyboard F22
+  KEY_F23                = 0x72,     // Keyboard F23
+  KEY_F24                = 0x73,     // Keyboard F24
+  KEY_OPEN               = 0x74,     // Keyboard Execute
+  KEY_HELP               = 0x75,     // Keyboard Help
+  KEY_MENU               = 0x76,     // Keyboard Menu
+  KEY_SELECT             = 0x77,     // Keyboard Select
+  KEY_STOP               = 0x78,     // Keyboard Stop
+  KEY_AGAIN              = 0x79,     // Keyboard Again
+  KEY_UNDO               = 0x7A,     // Keyboard Undo
+  KEY_CUT                = 0x7B,     // Keyboard Cut
+  KEY_COPY               = 0x7C,     // Keyboard Copy
+  KEY_PASTE              = 0x7D,     // Keyboard Paste
+  KEY_FIND               = 0x7E,     // Keyboard Find
+  KEY_MUTE               = 0x7F,     // Keyboard Mute
+  KEY_VOLUMEUP           = 0x80,     // Keyboard Volume Up
+  KEY_VOLUMEDOWN         = 0x81,     // Keyboard Volume Down
+  KEY_LOCKCAPSLOCK       = 0x82,     // Keyboard Locking Caps Lock
+  KEY_LOCKNUMLOCK        = 0x83,     // Keyboard Locking Num Lock
+  KEY_LOCKSCROLLOCK      = 0x84,     // Keyboard Locking Scroll Lock
+  KEY_KPCOMMA            = 0x85,     // Keypad Comma
+  KEY_KPEQUALSIGN        = 0x86,     // Keypad Equal Sign
+  KEY_RO                 = 0x87,     // Keyboard International1
+  KEY_KATAKANAHIRAGANA   = 0x88,     // Keyboard International2
+  KEY_YEN                = 0x89,     // Keyboard International3
+  KEY_HENKAN             = 0x8A,     // Keyboard International4
+  KEY_MUHENKAN           = 0x8B,     // Keyboard International5
+  KEY_KPJPCOMMA          = 0x8C,     // Keyboard International6
+  KEY_INTL7              = 0x8D,     // Keyboard International7
+  KEY_INTL8              = 0x8E,     // Keyboard International8
+  KEY_INTL9              = 0x8F,     // Keyboard International9
+  KEY_HANGEUL            = 0x90,     // Keyboard LANG1
+  KEY_HANJA              = 0x91,     // Keyboard LANG2
+  KEY_KATAKANA           = 0x92,     // Keyboard LANG3
+  KEY_HIRAGANA           = 0x93,     // Keyboard LANG4
+  KEY_ZENKAKUHENKAKU     = 0x94,     // Keyboard LANG5
+  KEY_LANG6              = 0x95,     // Keyboard LANG6
+  KEY_LANG7              = 0x96,     // Keyboard LANG7
+  KEY_LANG8              = 0x97,     // Keyboard LANG8
+  KEY_LANG9              = 0x98,     // Keyboard LANG9
+  KEY_ALTERASE           = 0x99,     // Keyboard Alternate Erase
+  KEY_SYSRQ              = 0x9A,     // Keyboard SysReq/Attention
+  KEY_CANCEL             = 0x9B,     // Keyboard Cancel
+  KEY_CLEAR              = 0x9C,     // Keyboard Clear
+  KEY_PRIOR              = 0x9D,     // Keyboard Prior
+  KEY_ENTER2             = 0x9E,     // Keyboard Return
+  KEY_SEPARATOR          = 0x9F,     // Keyboard Separator
+  KEY_OUT                = 0xA0,     // Keyboard Out
+  KEY_OPER               = 0xA1,     // Keyboard Oper
+  KEY_CLRAGAIN           = 0xA2,     // Keyboard Clear/Again
+  KEY_CRSEL              = 0xA3,     // Keyboard CrSel/Props
+  KEY_EXSEL              = 0xA4,     // Keyboard ExSel
+                                     // Keys 0xA5 to 0xAF reserved
+  KEY_KP00               = 0xB0,     // Keypad 00
+  KEY_KP000              = 0xB1,     // Keypad 000
+  KEY_THOUSANDSEP        = 0xB2,     // Thousands Separator
+  KEY_DECIMALSEP         = 0xB3,     // Decimal Separator
+  KEY_CURRENCY           = 0xB4,     // Currency Unit
+  KEY_CURRENCYSUB        = 0xB5,     // Currency Sub-unit
+  KEY_KPLEFTPAREN        = 0xB6,     // Keypad (
+  KEY_KPRIGHTPAREN       = 0xB7,     // Keypad )
+  KEY_KPLEFTBRACE        = 0xB8,     // Keypad {
+  KEY_KPRIGHTBRACE       = 0xB9,     // Keypad }
+  KEY_KPTAB              = 0xBA,     // Keypad Tab
+  KEY_KPBACKSPACE        = 0xBB,     // Keypad Backspace
+  KEY_KPA                = 0xBC,     // Keypad A
+  KEY_KPB                = 0xBD,     // Keypad B
+  KEY_KPC                = 0xBE,     // Keypad C
+  KEY_KPD                = 0xBF,     // Keypad D
+  KEY_KPE                = 0xC0,     // Keypad E
+  KEY_KPF                = 0xC1,     // Keypad F
+  KEY_KPXOR              = 0xC2,     // Keypad XOR
+  KEY_KPPOWER            = 0xC3,     // Keypad ^
+  KEY_KPPERCENT          = 0xC4,     // Keypad %
+  KEY_KPLT               = 0xC5,     // Keypad <
+  KEY_KPGT               = 0xC6,     // Keypad >
+  KEY_KPAMP              = 0xC7,     // Keypad &
+  KEY_KPAMPAMP           = 0xC8,     // Keypad &&
+  KEY_KPBAR              = 0xC9,     // Keypad |
+  KEY_KPBARBAR           = 0xCA,     // Keypad ||
+  KEY_KPCOLON            = 0xCB,     // Keypad :
+  KEY_KPHASH             = 0xCC,     // Keypad #
+  KEY_KPSPACE            = 0xCD,     // Keypad Space
+  KEY_KPAT               = 0xCE,     // Keypad @
+  KEY_KPEXCLAM           = 0xCF,     // Keypad !
+  KEY_KPMEMSTORE         = 0xD0,     // Keypad Memory Store
+  KEY_KPMEMRECALL        = 0xD1,     // Keypad Memory Recall
+  KEY_KPMEMCLEAR         = 0xD2,     // Keypad Memory Clear
+  KEY_KPMEMADD           = 0xD3,     // Keypad Memory Add
+  KEY_KPMEMSUB           = 0xD4,     // Keypad Memory Subtract
+  KEY_KPMEMMULT          = 0xD5,     // Keypad Memory Multiply
+  KEY_KPMEMDIV           = 0xD6,     // Keypad Memory Divide
+  KEY_KPPLUSMINUS        = 0xD7,     // Keypad +/-
+  KEY_KPCLEAR            = 0xD8,     // Keypad Clear
+  KEY_KPCLEARENT         = 0xD9,     // Keypad Clear Entry
+  KEY_KPBINARY           = 0xDA,     // Keypad Binary
+  KEY_KPOCTAL            = 0xDB,     // Keypad Octal
+  KEY_KPDECIMAL          = 0xDC,     // Keypad Decimal
+  KEY_KPHEX              = 0xDD,     // Keypad Hexadecimal
+                                     // Keys 0xDE to 0xDF reserved
+                                     // These are sent as modifiers
+  KEY_LEFTCTRL           = 0xE0,     // Keyboard LeftControl
+  KEY_LEFTSHIFT          = 0xE1,     // Keyboard LeftShift
+  KEY_LEFTALT            = 0xE2,     // Keyboard LeftAlt
+  KEY_LEFTGUI            = 0xE3,     // Keyboard Left GUI
+  KEY_RIGHTCTRL          = 0xE4,     // Keyboard RightControl
+  KEY_RIGHTSHIFT         = 0xE5,     // Keyboard RightShift
+  KEY_RIGHTALT           = 0xE6,     // Keyboard RightAlt
+  KEY_RIGHTGUI           = 0xE7,     // Keyboard Right GUI
+                                     // End of modifiers
+
+  // Additional alternative names
+  KEY_INTL1              = 0x87,     // Keyboard International1
+  KEY_INTL2              = 0x88,     // Keyboard International2
+  KEY_INTL3              = 0x89,     // Keyboard International3
+  KEY_INTL4              = 0x8A,     // Keyboard International4
+  KEY_INTL5              = 0x8B,     // Keyboard International5
+  KEY_INTL6              = 0x8C,     // Keyboard International6
+  KEY_LANG1              = 0x90,     // Keyboard LANG1
+  KEY_LANG2              = 0x91,     // Keyboard LANG2
+  KEY_LANG3              = 0x92,     // Keyboard LANG3
+  KEY_LANG4              = 0x93,     // Keyboard LANG4
+  KEY_LANG5              = 0x94,     // Keyboard LANG5
+
+
+  // SDL2-like key names
+  KEY_UNKNOWN            = 0x00,     // Reserved (no event indicated)
+  KEY_ERROR_ROLLOVER     = 0x01,     // Keyboard ErrorRollOver
+  KEY_POSTFAIL           = 0x02,     // Keyboard POSTFail
+  KEY_ERROR_UNDEFINED    = 0x03,     // Keyboard ErrorUndefined
+
+  KEY_RETURN             = 0x28,     // Keyboard Return (ENTER)
+  KEY_ESCAPE             = 0x29,     // Keyboard ESCAPE
+
+  KEY_EQUALS             = 0x2E,     // Keyboard = and +
+  KEY_LEFTBRACKET        = 0x2F,     // Keyboard [ and {
+  KEY_RIGHTBRACKET       = 0x30,     // Keyboard ] and }
+
+  KEY_NONUSHASH          = 0x32,     // Keyboard Non-US # and ~
+
+  KEY_PERIOD             = 0x37,     // Keyboard . and >
+
+  KEY_PRINTSCREEN        = 0x46,     // Keyboard PrintScreen
+
+  KEY_NUMLOCKCLEAR       = 0x53,     // Keypad Num Lock and Clear
+  KEY_KP_DIVIDE          = 0x54,     // Keypad /
+  KEY_KP_MULTIPLY        = 0x55,     // Keypad *
+  KEY_KP_MINUS           = 0x56,     // Keypad -
+  KEY_KP_PLUS            = 0x57,     // Keypad +
+  KEY_KP_ENTER           = 0x58,     // Keypad ENTER
+  KEY_KP_1               = 0x59,     // Keypad 1 and End
+  KEY_KP_2               = 0x5A,     // Keypad 2 and Down Arrow
+  KEY_KP_3               = 0x5B,     // Keypad 3 and PageDn
+  KEY_KP_4               = 0x5C,     // Keypad 4 and Left Arrow
+  KEY_KP_5               = 0x5D,     // Keypad 5
+  KEY_KP_6               = 0x5E,     // Keypad 6 and Right Arrow
+  KEY_KP_7               = 0x5F,     // Keypad 7 and Home
+  KEY_KP_8               = 0x60,     // Keypad 8 and Up Arrow
+  KEY_KP_9               = 0x61,     // Keypad 9 and PageUp
+  KEY_KP_0               = 0x62,     // Keypad 0 and Insert
+  KEY_KP_PERIOD          = 0x63,     // Keypad . and Delete
+  KEY_NONUSBACKSLASH     = 0x64,     // Keyboard Non-US \ and |
+  KEY_APPLICATION        = 0x65,     // Keyboard Application
+                                     // LOGICAL_MAXIMUM
+
+  KEY_KP_EQUALS          = 0x67,     // Keypad =
+
+  KEY_EXECUTE            = 0x74,     // Keyboard Execute
+
+  KEY_LOCKINGCAPSLOCK    = 0x82,     // Keyboard Locking Caps Lock
+  KEY_LOCKINGNUMLOCK     = 0x83,     // Keyboard Locking Num Lock
+  KEY_LOCKINGSCROLLOCK   = 0x84,     // Keyboard Locking Scroll Lock
+  KEY_KP_COMMA           = 0x85,     // Keypad Comma
+  KEY_KP_EQUALSAS400     = 0x86,     // Keypad Equal Sign
+  KEY_INTERNATIONAL1     = 0x87,     // Keyboard International1
+  KEY_INTERNATIONAL2     = 0x88,     // Keyboard International2
+  KEY_INTERNATIONAL3     = 0x89,     // Keyboard International3
+  KEY_INTERNATIONAL4     = 0x8A,     // Keyboard International4
+  KEY_INTERNATIONAL5     = 0x8B,     // Keyboard International5
+  KEY_INTERNATIONAL6     = 0x8C,     // Keyboard International6
+  KEY_INTERNATIONAL7     = 0x8D,     // Keyboard International7
+  KEY_INTERNATIONAL8     = 0x8E,     // Keyboard International8
+  KEY_INTERNATIONAL9     = 0x8F,     // Keyboard International9
+
+  KEY_SYSREQ             = 0x9A,     // Keyboard SysReq/Attention
+
+  KEY_RETURN2            = 0x9E,     // Keyboard Return
+  
+  KEY_CLEARAGAIN         = 0xA2,     // Keyboard Clear/Again
+                                     // Keys 0xA5 to 0xAF reserved
+  KEY_KP_00              = 0xB0,     // Keypad 00
+  KEY_KP_000             = 0xB1,     // Keypad 000
+  KEY_THOUSANDSSEPARATOR = 0xB2,     // Thousands Separator
+  KEY_DECIMALSEPARATOR   = 0xB3,     // Decimal Separator
+  KEY_CURRENCYUNIT       = 0xB4,     // Currency Unit
+  KEY_CURRENCYSUBUNIT    = 0xB5,     // Currency Sub-unit
+  KEY_KP_LEFTPAREN       = 0xB6,     // Keypad (
+  KEY_KP_RIGHTPAREN      = 0xB7,     // Keypad )
+  KEY_KP_LEFTBRACE       = 0xB8,     // Keypad {
+  KEY_KP_RIGHTBRACE      = 0xB9,     // Keypad }
+  KEY_KP_TAB             = 0xBA,     // Keypad Tab
+  KEY_KP_BACKSPACE       = 0xBB,     // Keypad Backspace
+  KEY_KP_A               = 0xBC,     // Keypad A
+  KEY_KP_B               = 0xBD,     // Keypad B
+  KEY_KP_C               = 0xBE,     // Keypad C
+  KEY_KP_D               = 0xBF,     // Keypad D
+  KEY_KP_E               = 0xC0,     // Keypad E
+  KEY_KP_F               = 0xC1,     // Keypad F
+  KEY_KP_XOR             = 0xC2,     // Keypad XOR
+  KEY_KP_POWER           = 0xC3,     // Keypad ^
+  KEY_KP_PERCENT         = 0xC4,     // Keypad %
+  KEY_KP_LESS            = 0xC5,     // Keypad <
+  KEY_KP_GREATER         = 0xC6,     // Keypad >
+  KEY_KP_AMPERSAND       = 0xC7,     // Keypad &
+  KEY_KP_DBLAMPERSAND    = 0xC8,     // Keypad &&
+  KEY_KP_VERTICALBAR     = 0xC9,     // Keypad |
+  KEY_KP_DBLVERTICALBAR  = 0xCA,     // Keypad ||
+  KEY_KP_COLON           = 0xCB,     // Keypad :
+  KEY_KP_HASH            = 0xCC,     // Keypad #
+  KEY_KP_SPACE           = 0xCD,     // Keypad Space
+  KEY_KP_AT              = 0xCE,     // Keypad @
+  KEY_KP_EXCLAM          = 0xCF,     // Keypad !
+  KEY_KP_MEMSTORE        = 0xD0,     // Keypad Memory Store
+  KEY_KP_MEMRECALL       = 0xD1,     // Keypad Memory Recall
+  KEY_KP_MEMCLEAR        = 0xD2,     // Keypad Memory Clear
+  KEY_KP_MEMADD          = 0xD3,     // Keypad Memory Add
+  KEY_KP_MEMSUBTRACT     = 0xD4,     // Keypad Memory Subtract
+  KEY_KP_MEMMULTIPLY     = 0xD5,     // Keypad Memory Multiply
+  KEY_KP_MEMDIVIDE       = 0xD6,     // Keypad Memory Divide
+  KEY_KP_PLUSMINUS       = 0xD7,     // Keypad +/-
+  KEY_KP_CLEAR           = 0xD8,     // Keypad Clear
+  KEY_KP_CLEARENTRY      = 0xD9,     // Keypad Clear Entry
+  KEY_KP_BINARY          = 0xDA,     // Keypad Binary
+  KEY_KP_OCTAL           = 0xDB,     // Keypad Octal
+  KEY_KP_DECIMAL         = 0xDC,     // Keypad Decimal
+  KEY_KP_HEXADECIMAL     = 0xDD,     // Keypad Hexadecimal
+                                     // Keys 0xDE to 0xDF reserved
+                                     // These are sent as modifiers
+  KEY_LCTRL              = 0xE0,     // Keyboard LeftControl
+  KEY_LSHIFT             = 0xE1,     // Keyboard LeftShift
+  KEY_LALT               = 0xE2,     // Keyboard LeftAlt
+  KEY_LGUI               = 0xE3,     // Keyboard Left GUI
+  KEY_RCTRL              = 0xE4,     // Keyboard RightControl
+  KEY_RSHIFT             = 0xE5,     // Keyboard RightShift
+  KEY_RALT               = 0xE6,     // Keyboard RightAlt
+  KEY_RGUI               = 0xE7,     // Keyboard Right GUI
+                                     // End of modifiers
+
+  KEY_MODE               = 0x101,
+  KEY_AUDIONEXT          = 0x102,
+  KEY_AUDIOPREV          = 0x103,
+  KEY_AUDIOSTOP          = 0x104,
+  KEY_AUDIOPLAY          = 0x105,
+  KEY_AUDIOMUTE          = 0x106,
+  KEY_MEDIASELECT        = 0x107,
+  KEY_WWW                = 0x108,
+  KEY_MAIL               = 0x109,
+  KEY_CALCULATOR         = 0x10A,
+  KEY_COMPUTER           = 0x10B,
+  KEY_AC_SEARCH          = 0x10C,
+  KEY_AC_HOME            = 0x10D,
+  KEY_AC_BACK            = 0x10E,
+  KEY_AC_FORWARD         = 0x10F,
+  KEY_AC_STOP            = 0x110,
+  KEY_AC_REFRESH         = 0x111,
+  KEY_AC_BOOKMARKS       = 0x112,
+  KEY_BRIGHTNESSDOWN     = 0x113,
+  KEY_BRIGHTNESSUP       = 0x114,
+  KEY_DISPLAYSWITCH      = 0x115,
+  KEY_KBDILLUMTOGGLE     = 0x116,
+  KEY_KBDILLUMDOWN       = 0x117,
+  KEY_KBDILLUMUP         = 0x118,
+  KEY_EJECT              = 0x119,
+  KEY_SLEEP              = 0x11A,
+  KEY_APP1               = 0x11B,
+  KEY_APP2               = 0x11C
+} UsbKeyboardScanCode;
+
+typedef enum {
+  MOD_RESERVED           = 0xE000,
+  MOD_LEFTCTRL           = 0xE001,     // Keyboard LeftControl
+  MOD_LEFTSHIFT          = 0xE002,     // Keyboard LeftShift
+  MOD_LEFTALT            = 0xE004,     // Keyboard LeftAlt
+  MOD_LEFTGUI            = 0xE008,     // Keyboard Left GUI
+  MOD_RIGHTCTRL          = 0xE010,     // Keyboard RightControl
+  MOD_RIGHTSHIFT         = 0xE020,     // Keyboard RightShift
+  MOD_RIGHTALT           = 0xE040,     // Keyboard RightAlt
+  MOD_RIGHTGUI           = 0xE080,     // Keyboard Right GUI
+  MOD_LCTRL              = 0xE001,     // Keyboard LeftControl
+  MOD_LSHIFT             = 0xE002,     // Keyboard LeftShift
+  MOD_LALT               = 0xE004,     // Keyboard LeftAlt
+  MOD_LGUI               = 0xE008,     // Keyboard Left GUI
+  MOD_RCTRL              = 0xE010,     // Keyboard RightControl
+  MOD_RSHIFT             = 0xE020,     // Keyboard RightShift
+  MOD_RALT               = 0xE040,     // Keyboard RightAlt
+  MOD_RGUI               = 0xE080,     // Keyboard Right GUI
+} UsbKeyboardModifier;
+
+#endif // __SPARK_WIRING_USBKEYBOARDSCANCODE_H

--- a/wiring/inc/spark_wiring_usbmouse.h
+++ b/wiring/inc/spark_wiring_usbmouse.h
@@ -30,40 +30,72 @@
 
 #ifdef SPARK_USB_MOUSE
 #include "spark_wiring.h"
+#include <array>
 
-#define MOUSE_LEFT		0x01
-#define MOUSE_RIGHT		0x02
-#define MOUSE_MIDDLE	0x04
-#define MOUSE_ALL		(MOUSE_LEFT | MOUSE_RIGHT | MOUSE_MIDDLE)
-
-typedef struct
-{
-    uint8_t reportId; // 0x01
-	uint8_t buttons;
-	int8_t x;
-	int8_t y;
-	int8_t wheel;
-} MouseReport;
+#define MOUSE_LEFT      0x01
+#define MOUSE_RIGHT     0x02
+#define MOUSE_MIDDLE    0x04
+#define MOUSE_ALL       (MOUSE_LEFT | MOUSE_RIGHT | MOUSE_MIDDLE)
 
 class USBMouse
 {
+public:
+    typedef std::array<float, 4> ScreenMargin;
 private:
-	MouseReport mouseReport;
-	void buttons(uint8_t button);
+
+#pragma pack(push, 1)
+    typedef struct
+    {
+        uint8_t reportId; // 0x01
+        uint8_t buttons;
+        int16_t x;
+        int16_t y;
+        int8_t wheel;
+    } MouseReport;
+
+    typedef struct
+    {
+        uint8_t reportId; // 0x03
+        uint8_t sw;
+        int16_t x;
+        int16_t y;
+    } DigitizerReport;
+#pragma pack(pop)
+
+    MouseReport mouseReport;
+    DigitizerReport digitizerReport;
+    uint16_t screenWidth_;
+    uint16_t screenHeight_;
+    ScreenMargin margin_;
+    bool digitizerState_;
+
+    void buttons(uint8_t button);
+    void sendMouseReport();
+    void sendDigitizerReport();
 
 public:
-	USBMouse(void);
+    USBMouse(void);
 
-	void begin(void);
-	void end(void);
-	void move(int8_t x, int8_t y, int8_t wheel);
+    void begin(void);
+    void end(void);
+    void moveTo(int16_t x, int16_t y);
+
+    void enableMoveTo(bool state);
+
+    void screenSize(uint16_t width, uint16_t height,
+                    float marginLeft = 0.0f, float marginRight = 0.0f,
+                    float marginTop = 0.0f, float marginBottom = 0.0f);
+
+    void screenSize(uint16_t width, uint16_t height, const ScreenMargin& margin);
+
+    void move(int16_t x, int16_t y, int8_t wheel = 0);
+    void scroll(int8_t wheel) {
+        move(0, 0, wheel);
+    }
 	void click(uint8_t button = MOUSE_LEFT);
 	void press(uint8_t button = MOUSE_LEFT);		// press LEFT by default
 	void release(uint8_t button = MOUSE_LEFT);		// release LEFT by default
 	bool isPressed(uint8_t button = MOUSE_LEFT);	// check LEFT by default
-
-private:
-    void sendReport();
 };
 
 extern USBMouse Mouse;

--- a/wiring/src/spark_wiring_usbkeyboard.cpp
+++ b/wiring/src/spark_wiring_usbkeyboard.cpp
@@ -28,138 +28,138 @@
 #ifdef SPARK_USB_KEYBOARD
 #include "spark_wiring_usbkeyboard.h"
 
-#define SHIFT 0x80
+#define SHIFT_MOD 0x80
 
-const uint8_t asciimap[128] =
+extern const uint8_t usb_hid_asciimap[128] =
 {
-	0x00,             // NUL
-	0x00,             // SOH
-	0x00,             // STX
-	0x00,             // ETX
-	0x00,             // EOT
-	0x00,             // ENQ
-	0x00,             // ACK
-	0x00,             // BEL
-	0x2a,             // BS  Backspace
-	0x2b,             // TAB Tab
-	0x28,             // LF  Enter
-	0x00,             // VT
-	0x00,             // FF
-	0x00,             // CR
-	0x00,             // SO
-	0x00,             // SI
-	0x00,             // DEL
-	0x00,             // DC1
-	0x00,             // DC2
-	0x00,             // DC3
-	0x00,             // DC4
-	0x00,             // NAK
-	0x00,             // SYN
-	0x00,             // ETB
-	0x00,             // CAN
-	0x00,             // EM
-	0x00,             // SUB
-	0x00,             // ESC
-	0x00,             // FS
-	0x00,             // GS
-	0x00,             // RS
-	0x00,             // US
-	0x2c,		      //  ' '
-	0x1e|SHIFT,	      // !
-	0x34|SHIFT,	      // "
-	0x20|SHIFT,       // #
-	0x21|SHIFT,       // $
-	0x22|SHIFT,       // %
-	0x24|SHIFT,       // &
-	0x34,             // '
-	0x26|SHIFT,       // (
-	0x27|SHIFT,       // )
-	0x25|SHIFT,       // *
-	0x2e|SHIFT,       // +
-	0x36,             // ,
-	0x2d,             // -
-	0x37,             // .
-	0x38,             // /
-	0x27,             // 0
-	0x1e,             // 1
-	0x1f,             // 2
-	0x20,             // 3
-	0x21,             // 4
-	0x22,             // 5
-	0x23,             // 6
-	0x24,             // 7
-	0x25,             // 8
-	0x26,             // 9
-	0x33|SHIFT,       // :
-	0x33,             // ;
-	0x36|SHIFT,       // <
-	0x2e,             // =
-	0x37|SHIFT,       // >
-	0x38|SHIFT,       // ?
-	0x1f|SHIFT,       // @
-	0x04|SHIFT,       // A
-	0x05|SHIFT,       // B
-	0x06|SHIFT,       // C
-	0x07|SHIFT,       // D
-	0x08|SHIFT,       // E
-	0x09|SHIFT,       // F
-	0x0a|SHIFT,       // G
-	0x0b|SHIFT,       // H
-	0x0c|SHIFT,       // I
-	0x0d|SHIFT,       // J
-	0x0e|SHIFT,       // K
-	0x0f|SHIFT,       // L
-	0x10|SHIFT,       // M
-	0x11|SHIFT,       // N
-	0x12|SHIFT,       // O
-	0x13|SHIFT,       // P
-	0x14|SHIFT,       // Q
-	0x15|SHIFT,       // R
-	0x16|SHIFT,       // S
-	0x17|SHIFT,       // T
-	0x18|SHIFT,       // U
-	0x19|SHIFT,       // V
-	0x1a|SHIFT,       // W
-	0x1b|SHIFT,       // X
-	0x1c|SHIFT,       // Y
-	0x1d|SHIFT,       // Z
-	0x2f,             // [
-	0x31,             // bslash
-	0x30,             // ]
-	0x23|SHIFT,       // ^
-	0x2d|SHIFT,       // _
-	0x35,             // `
-	0x04,             // a
-	0x05,             // b
-	0x06,             // c
-	0x07,             // d
-	0x08,             // e
-	0x09,             // f
-	0x0a,             // g
-	0x0b,             // h
-	0x0c,             // i
-	0x0d,             // j
-	0x0e,             // k
-	0x0f,             // l
-	0x10,             // m
-	0x11,             // n
-	0x12,             // o
-	0x13,             // p
-	0x14,             // q
-	0x15,             // r
-	0x16,             // s
-	0x17,             // t
-	0x18,             // u
-	0x19,             // v
-	0x1a,             // w
-	0x1b,             // x
-	0x1c,             // y
-	0x1d,             // z
-	0x2f|SHIFT,       //
-	0x31|SHIFT,       // |
-	0x30|SHIFT,       // }
-	0x35|SHIFT,       // ~
-	0				  // DEL
+    KEY_RESERVED,               // 0x00 NUL
+    KEY_RESERVED,               // 0x01 SOH
+    KEY_RESERVED,               // 0x02 STX
+    KEY_RESERVED,               // 0x03 ETX
+    KEY_RESERVED,               // 0x04 EOT
+    KEY_RESERVED,               // 0x05 ENQ
+    KEY_RESERVED,               // 0x06 ACK
+    KEY_RESERVED,               // 0x07 BEL
+    KEY_BACKSPACE,              // 0x08 BS Backspace
+    KEY_TAB,                    // 0x09 TAB Tab
+    KEY_ENTER,                  // 0x0A LF Line Feed
+    KEY_RESERVED,               // 0x0B VT
+    KEY_RESERVED,               // 0x0C FF
+    KEY_RESERVED,               // 0x0D CR Carriage return
+    KEY_RESERVED,               // 0x0E SO
+    KEY_RESERVED,               // 0x0F SI
+    KEY_RESERVED,               // 0x10 DEL
+    KEY_RESERVED,               // 0x11 DC1
+    KEY_RESERVED,               // 0x12 DC2
+    KEY_RESERVED,               // 0x13 DC3
+    KEY_RESERVED,               // 0x14 DC4
+    KEY_RESERVED,               // 0x15 NAK
+    KEY_RESERVED,               // 0x16 SYN
+    KEY_RESERVED,               // 0x17 ETB
+    KEY_RESERVED,               // 0x18 CAN
+    KEY_RESERVED,               // 0x19 EM
+    KEY_RESERVED,               // 0x1A SUB
+    KEY_ESCAPE,                 // 0x1B ESC
+    KEY_RESERVED,               // 0x1C FS
+    KEY_RESERVED,               // 0x1D GS
+    KEY_RESERVED,               // 0x1E RS
+    KEY_RESERVED,               // 0x1F US
+    KEY_SPACE,                  // 0x20  ' '
+    SHIFT_MOD | KEY_1,          // 0x21 !
+    SHIFT_MOD | KEY_APOSTROPHE, // 0x22 "
+    SHIFT_MOD | KEY_3,          // 0x23 #
+    SHIFT_MOD | KEY_4,          // 0x24 $
+    SHIFT_MOD | KEY_5,          // 0x25 %
+    SHIFT_MOD | KEY_7,          // 0x26 &
+    KEY_APOSTROPHE,             // 0x27 '
+    SHIFT_MOD | KEY_9,          // 0x28 (
+    SHIFT_MOD | KEY_0,          // 0x29 )
+    SHIFT_MOD | KEY_8,          // 0x2A *
+    SHIFT_MOD | KEY_EQUAL,      // 0x2B +
+    KEY_COMMA,                  // 0x2C ,
+    KEY_MINUS,                  // 0x2D -
+    KEY_DOT,                    // 0x2E .
+    KEY_SLASH,                  // 0x2F /
+    KEY_0,                      // 0x30 0
+    KEY_1,                      // 0x31 1
+    KEY_2,                      // 0x32 2
+    KEY_3,                      // 0x33 3
+    KEY_4,                      // 0x34 4
+    KEY_5,                      // 0x35 5
+    KEY_6,                      // 0x36 6
+    KEY_7,                      // 0x37 7
+    KEY_8,                      // 0x38 8
+    KEY_9,                      // 0x39 9
+    SHIFT_MOD | KEY_SEMICOLON,  // 0x3A :
+    KEY_SEMICOLON,              // 0x3B ;
+    SHIFT_MOD | KEY_COMMA,      // 0x3C <
+    KEY_EQUAL,                  // 0x3D =
+    SHIFT_MOD | KEY_DOT,        // 0x3E >
+    SHIFT_MOD | KEY_SLASH,      // 0x3F ?
+    SHIFT_MOD | KEY_2,          // 0x40 @
+    SHIFT_MOD | KEY_A,          // 0x41 A
+    SHIFT_MOD | KEY_B,          // 0x42 B
+    SHIFT_MOD | KEY_C,          // 0x43 C
+    SHIFT_MOD | KEY_D,          // 0x44 D
+    SHIFT_MOD | KEY_E,          // 0x45 E
+    SHIFT_MOD | KEY_F,          // 0x46 F
+    SHIFT_MOD | KEY_G,          // 0x47 G
+    SHIFT_MOD | KEY_H,          // 0x48 H
+    SHIFT_MOD | KEY_I,          // 0x49 I
+    SHIFT_MOD | KEY_J,          // 0x4A J
+    SHIFT_MOD | KEY_K,          // 0x4B K
+    SHIFT_MOD | KEY_L,          // 0x4C L
+    SHIFT_MOD | KEY_M,          // 0x4D M
+    SHIFT_MOD | KEY_N,          // 0x4E N
+    SHIFT_MOD | KEY_O,          // 0x4F O
+    SHIFT_MOD | KEY_P,          // 0x50 P
+    SHIFT_MOD | KEY_Q,          // 0x51 Q
+    SHIFT_MOD | KEY_R,          // 0x52 R
+    SHIFT_MOD | KEY_S,          // 0x53 S
+    SHIFT_MOD | KEY_T,          // 0x54 T
+    SHIFT_MOD | KEY_U,          // 0x55 U
+    SHIFT_MOD | KEY_V,          // 0x56 V
+    SHIFT_MOD | KEY_W,          // 0x57 W
+    SHIFT_MOD | KEY_X,          // 0x58 X
+    SHIFT_MOD | KEY_Y,          // 0x59 Y
+    SHIFT_MOD | KEY_Z,          // 0x5A Z
+    KEY_LEFTBRACE,              // 0x5B [
+    KEY_BACKSLASH,              // 0x5C bslash
+    KEY_RIGHTBRACE,             // 0x5D ]
+    SHIFT_MOD | KEY_6,          // 0x5E ^
+    SHIFT_MOD | KEY_MINUS,      // 0x5F _
+    KEY_GRAVE,                  // 0x60 `
+    KEY_A,                      // 0x61 a
+    KEY_B,                      // 0x62 b
+    KEY_C,                      // 0x63 c
+    KEY_D,                      // 0x64 d
+    KEY_E,                      // 0x65 e
+    KEY_F,                      // 0x66 f
+    KEY_G,                      // 0x67 g
+    KEY_H,                      // 0x68 h
+    KEY_I,                      // 0x69 i
+    KEY_J,                      // 0x6A j
+    KEY_K,                      // 0x6B k
+    KEY_L,                      // 0x6C l
+    KEY_M,                      // 0x6D m
+    KEY_N,                      // 0x6E n
+    KEY_O,                      // 0x6F o
+    KEY_P,                      // 0x70 p
+    KEY_Q,                      // 0x71 q
+    KEY_R,                      // 0x72 r
+    KEY_S,                      // 0x73 s
+    KEY_T,                      // 0x74 t
+    KEY_U,                      // 0x75 u
+    KEY_V,                      // 0x76 v
+    KEY_W,                      // 0x77 w
+    KEY_X,                      // 0x78 x
+    KEY_Y,                      // 0x79 y
+    KEY_Z,                      // 0x7A z
+    SHIFT_MOD | KEY_LEFTBRACE,  // 0x7B {
+    SHIFT_MOD | KEY_BACKSLASH,  // 0x7C |
+    SHIFT_MOD | KEY_RIGHTBRACE, // 0x7D }
+    SHIFT_MOD | KEY_GRAVE,      // 0x7E ~
+    KEY_DELETE                  // 0x7F DEL
 };
 
 //
@@ -167,174 +167,191 @@ const uint8_t asciimap[128] =
 //
 USBKeyboard::USBKeyboard(void)
 {
-	memset((void*)&keyReport, 0, sizeof(keyReport));
-	keyReport.reportId = 0x02;
-	HAL_USB_HID_Init(0, NULL);
+    memset((void*)&keyReport, 0, sizeof(keyReport));
+    keyReport.reportId = 0x02;
+    HAL_USB_HID_Init(0, NULL);
 }
 
 void USBKeyboard::begin(void)
 {
-	HAL_USB_HID_Begin(0, NULL);
+    HAL_USB_HID_Begin(0, NULL);
 }
 
 void USBKeyboard::end(void)
 {
-	HAL_USB_HID_End(0);
+    HAL_USB_HID_End(0);
 }
 
 // press() adds the specified key (printing, non-printing, or modifier)
 // to the persistent key report and sends the report.  Because of the way
 // USB HID works, the host acts like the key remains pressed until we
 // call release(), releaseAll(), or otherwise clear the report and resend.
-size_t USBKeyboard::press(uint16_t key)
+size_t USBKeyboard::press(uint16_t key, uint16_t modifiers)
 {
-	uint8_t i;
-	if (key >= 136)
-	{
-		// it's a non-printing key (not a modifier)
-		key = key - 136;
-	}
-	else if (key >= 128)
-	{
-		// it's a modifier key
-		keyReport.modifiers |= (1 << (key - 128));
-		key = 0;
-	}
-	else
-	{
-		// it's a printing key
-		key = asciimap[key];
-		if (!key)
-		{
-			setWriteError();
-			return 0;
-		}
-		if (key & 0x80)
-		{
-			// it's a capital letter or other character reached with shift
-			keyReport.modifiers |= 0x02;	// the left shift modifier
-			key &= 0x7F;
-		}
-	}
+    bool doReport = false;
+    if (key >= KEY_LEFTCTRL && key <= KEY_RIGHTGUI)
+    {
+       // it's a modifier key
+       keyReport.modifiers |= (1 << (key - KEY_LEFTCTRL));
+       key = 0;
+       doReport = true;
+    }
 
-	// Add key to the keyReport only if it's not already present
-	// and if there is an empty slot.
-	if (keyReport.keys[0] != key && keyReport.keys[1] != key &&
-		keyReport.keys[2] != key && keyReport.keys[3] != key &&
-		keyReport.keys[4] != key && keyReport.keys[5] != key)
-	{
+    if (key > KEY_KPHEX)
+        return 0;
 
-		for (i=0; i<6; i++)
-		{
-			if (keyReport.keys[i] == 0x00)
-			{
-				keyReport.keys[i] = key;
-				break;
-			}
-		}
-		if (i == 6)
-		{
-			setWriteError();
-			return 0;
-		}
-	}
+    if (modifiers) {
+        if (modifiers > MOD_RESERVED && modifiers <= (MOD_RESERVED | 0xFF)) {
+            modifiers &= 0x00FF;
+            keyReport.modifiers |= modifiers;
+            doReport = true;
+        } else {
+            modifiers = 0;
+        }
+    }
 
-	sendReport();
-	return 1;
+    // Add key to the keyReport only if it's not already present
+    // and if there is an empty slot.
+    if (key && keyReport.keys[0] != key && keyReport.keys[1] != key &&
+        keyReport.keys[2] != key && keyReport.keys[3] != key &&
+        keyReport.keys[4] != key && keyReport.keys[5] != key)
+    {
+        uint8_t i;
+        for (i = 0; i < 6; i++)
+        {
+            if (keyReport.keys[i] == 0x00)
+            {
+                keyReport.keys[i] = key;
+                doReport = true;
+                break;
+            }
+        }
+        if (i == 6)
+        {
+            setWriteError();
+            return 0;
+        }
+    }
+
+    if (doReport) {
+        sendReport();
+        return 1;
+    }
+    return 0;
 }
 
 // release() takes the specified key out of the persistent key report and
 // sends the report.  This tells the OS the key is no longer pressed and that
 // it shouldn't be repeated any more.
-size_t USBKeyboard::release(uint16_t key)
+size_t USBKeyboard::release(uint16_t key, uint16_t modifiers)
 {
-	uint8_t i;
-	if (key >= 136)
-	{
-		// it's a non-printing key (not a modifier)
-		key = key - 136;
-	}
-	else if (key >= 128)
-	{
-		// it's a modifier key
-		keyReport.modifiers &= ~(1 << (key - 128));
-		key = 0;
-	}
-	else
-	{
-		// it's a printing key
-		key = asciimap[key];
-		if (!key)
-		{
-			return 0;
-		}
-		if (key & 0x80)
-		{
-			// it's a capital letter or other character reached with shift
-			keyReport.modifiers &= ~(0x02);	// the left shift modifier
-			key &= 0x7F;
-		}
-	}
+    bool doReport = false;
+    if (key >= KEY_LEFTCTRL && key <= KEY_RIGHTGUI)
+    {
+       // it's a modifier key
+       keyReport.modifiers &= ~(1 << (key - KEY_LEFTCTRL));
+       key = 0;
+       doReport = true;
+    }
 
-	// Test the key report to see if key is present.  Clear it if it exists.
-	// Check all positions in case the key is present more than once (which it shouldn't be)
-	for (i = 0 ; i < 6 ; i++)
-	{
-		if (0 != key && keyReport.keys[i] == key)
-		{
-			keyReport.keys[i] = 0x00;
-		}
-	}
+    if (key > KEY_KPHEX)
+        return 0;
 
-	sendReport();
-	return 1;
+    if (modifiers) {
+        if (modifiers > MOD_RESERVED && modifiers <= (MOD_RESERVED | 0xFF)) {
+            modifiers &= 0x00FF;
+            keyReport.modifiers &= ~(modifiers);
+            doReport = true;
+        } else {
+            modifiers = 0;
+        }
+    }
+
+    // Test the key report to see if key is present.  Clear it if it exists.
+    // Check all positions in case the key is present more than once (which it shouldn't be)
+    if (key) {
+        for (uint8_t i = 0; i < 6; i++)
+        {
+            if (0 != key && keyReport.keys[i] == key)
+            {
+                keyReport.keys[i] = 0x00;
+                doReport = true;
+            }
+        }
+    }
+
+    if (doReport) {
+        sendReport();
+        return 1;
+    }
+
+    return 0;
 }
 
 void USBKeyboard::releaseAll(void)
 {
-	keyReport.keys[0] = 0;
-	keyReport.keys[1] = 0;
-	keyReport.keys[2] = 0;
-	keyReport.keys[3] = 0;
-	keyReport.keys[4] = 0;
-	keyReport.keys[5] = 0;
-	keyReport.modifiers = 0;
-	sendReport();
+    keyReport.keys[0] = 0;
+    keyReport.keys[1] = 0;
+    keyReport.keys[2] = 0;
+    keyReport.keys[3] = 0;
+    keyReport.keys[4] = 0;
+    keyReport.keys[5] = 0;
+    keyReport.modifiers = 0;
+    sendReport();
 }
 
-size_t USBKeyboard::writeRaw(uint16_t key)
+size_t USBKeyboard::writeKey(uint16_t key, uint16_t modifiers)
 {
-	uint8_t p = press(136 + key);	// Keydown
-	uint8_t r = release(136 + key);	// Keyup
-	(void)r;
-	return (p);					// just return the result of press() since release() almost always returns 1
+    // Keydown
+    uint8_t p = press(key, modifiers);
+    // Keyup
+    uint8_t r = release(key, modifiers);
+    (void)r;
+    // just return the result of press() since release() almost always returns 1
+    return (p);
 }
 
-size_t USBKeyboard::write(uint8_t key)
+size_t USBKeyboard::click(uint16_t key, uint16_t modifiers)
 {
-	uint8_t p = press(key);		// Keydown
-	uint8_t r = release(key);	// Keyup
-	(void)r;
-	return (p);					// just return the result of press() since release() almost always returns 1
+    return writeKey(key, modifiers);
+}
+
+size_t USBKeyboard::write(uint8_t ch)
+{
+    uint16_t key = 0;
+    uint16_t modifiers = 0;
+
+    if (ch < sizeof(usb_hid_asciimap)) {
+        // Lookup key code from ascii -> keycode map
+        key = usb_hid_asciimap[ch];
+        if (key) {
+            modifiers = (key & SHIFT_MOD) ? MOD_LEFTSHIFT : 0;
+        }
+        key &= 0x7F;
+    }
+    
+    if (key)
+        return writeKey(key, modifiers);
+    return 0;
 }
 
 void USBKeyboard::sendReport()
 {
-	uint32_t m = millis();
-	while(HAL_USB_HID_Status(0, nullptr)) {
-		// Wait 1 bInterval (1ms)
-		delay(1);
-		if ((millis() - m) >= 50)
-			return;
-	}
-	HAL_USB_HID_Send_Report(0, &keyReport, sizeof(keyReport), NULL);
-	m = millis();
-	while(HAL_USB_HID_Status(0, nullptr)) {
-		// Wait 1 bInterval (1ms)
-		delay(1);
-		if ((millis() - m) >= 50)
-			return;
-	}
+    uint32_t m = millis();
+    while(HAL_USB_HID_Status(0, nullptr)) {
+       // Wait 1 bInterval (1ms)
+       delay(1);
+       if ((millis() - m) >= 50)
+         return;
+    }
+    HAL_USB_HID_Send_Report(0, &keyReport, sizeof(keyReport), NULL);
+    m = millis();
+    while(HAL_USB_HID_Status(0, nullptr)) {
+       // Wait 1 bInterval (1ms)
+       delay(1);
+       if ((millis() - m) >= 50)
+         return;
+    }
 }
 
 //Preinstantiate Object

--- a/wiring/src/spark_wiring_usbmouse.cpp
+++ b/wiring/src/spark_wiring_usbmouse.cpp
@@ -27,73 +27,108 @@
 
 #ifdef SPARK_USB_MOUSE
 #include "spark_wiring_usbmouse.h"
+#include <cmath>
 
 //
 // Constructor
 //
-USBMouse::USBMouse(void)
+USBMouse::USBMouse(void) :
+    screenWidth_(0),
+    screenHeight_(0),
+    margin_{0, 0, 0, 0},
+    digitizerState_{true}
 {
     memset((void*)&mouseReport, 0, sizeof(mouseReport));
     mouseReport.reportId = 0x01;
+    memset((void*)&digitizerReport, 0, sizeof(digitizerReport));
+    digitizerReport.reportId = 0x03;
+    digitizerReport.sw = 0x02;
     HAL_USB_HID_Init(0, NULL);
 }
 
 void USBMouse::buttons(uint8_t button)
 {
-	if (mouseReport.buttons != button)
-	{
-		mouseReport.buttons = button;
-		move(0,0,0);
-	}
+    if (mouseReport.buttons != button)
+    {
+       mouseReport.buttons = button;
+       move(0,0,0);
+    }
 }
 
 void USBMouse::begin(void)
 {
-	HAL_USB_HID_Begin(0, NULL);
+    HAL_USB_HID_Begin(0, NULL);
 }
 
 void USBMouse::end(void)
 {
-	HAL_USB_HID_End(0);
+    HAL_USB_HID_End(0);
 }
 
-void USBMouse::move(int8_t x, int8_t y, int8_t wheel)
+void USBMouse::move(int16_t x, int16_t y, int8_t wheel)
 {
-	mouseReport.x = x;
-	mouseReport.y = y;
-	mouseReport.wheel = wheel;
-	sendReport();
+    mouseReport.x = x;
+    mouseReport.y = y;
+    mouseReport.wheel = wheel;
+    sendMouseReport();
+}
+
+void USBMouse::moveTo(int16_t x, int16_t y)
+{
+    if (x >= 0 && y >= 0) {
+        float xl = 0.0f;
+        float xr = INT16_MAX;
+        float yt = 0;
+        float yb = INT16_MAX;
+        xl += (INT16_MAX / 100.0f) * margin_[0]; // margin left
+        xr -= (INT16_MAX / 100.0f) * margin_[1]; // margin right
+        yt += (INT16_MAX / 100.0f) * margin_[2]; // margin top
+        yb -= (INT16_MAX / 100.0f) * margin_[3]; // margin bottom
+        if (screenWidth_ > 0 && screenHeight_ > 0) {
+            if (x == screenWidth_)
+                x = INT16_MAX;
+            else
+                x = lroundf(xl + ((xr - xl) / (float)screenWidth_) * (float)x);
+            if (y == screenHeight_)
+                y = INT16_MAX;
+            else
+                y = lroundf(yt + ((yb - yt) / (float)screenHeight_) * (float)y);
+        }
+        digitizerReport.x = x;
+        digitizerReport.y = y;
+        sendDigitizerReport();
+    }
 }
 
 void USBMouse::click(uint8_t button)
 {
-	mouseReport.buttons = button;
-	move(0,0,0);
-	mouseReport.buttons = 0;
-	move(0,0,0);
+    mouseReport.buttons = button;
+    move(0,0,0);
+    mouseReport.buttons = 0;
+    move(0,0,0);
 }
 
 void USBMouse::press(uint8_t button)
 {
-	buttons(mouseReport.buttons | button);
+    buttons(mouseReport.buttons | button);
 }
 
 void USBMouse::release(uint8_t button)
 {
-	buttons(mouseReport.buttons & ~button);
+    buttons(mouseReport.buttons & ~button);
 }
 
 bool USBMouse::isPressed(uint8_t button)
 {
-	if ((mouseReport.buttons & button) > 0)
-	{
-		return true;
-	}
+    if ((mouseReport.buttons & button) > 0)
+    {
+       return true;
+    }
 
-	return false;
+    return false;
 }
 
-void USBMouse::sendReport()
+void USBMouse::sendMouseReport()
 {
     uint32_t m = millis();
     while(HAL_USB_HID_Status(0, nullptr)) {
@@ -110,6 +145,46 @@ void USBMouse::sendReport()
         if ((millis() - m) >= 50)
             return;
     }
+}
+
+void USBMouse::sendDigitizerReport()
+{
+    if (!digitizerState_)
+        return;
+    uint32_t m = millis();
+    while(HAL_USB_HID_Status(0, nullptr)) {
+        // Wait 1 bInterval (1ms)
+        delay(1);
+        if ((millis() - m) >= 50)
+            return;
+    }
+    HAL_USB_HID_Send_Report(0, &digitizerReport, sizeof(digitizerReport), NULL);
+    m = millis();
+    while(HAL_USB_HID_Status(0, nullptr)) {
+        // Wait 1 bInterval (1ms)
+        delay(1);
+        if ((millis() - m) >= 50)
+            return;
+    }
+}
+
+void USBMouse::screenSize(uint16_t width, uint16_t height, float marginLeft, float marginRight,
+                          float marginTop, float marginBottom)
+{
+    screenSize(width, height, {marginLeft, marginRight, marginTop, marginBottom});
+}
+
+void USBMouse::screenSize(uint16_t width, uint16_t height, const ScreenMargin& margin)
+{
+    screenWidth_ = width;
+    screenHeight_ = height;
+    margin_ = margin;
+}
+
+void USBMouse::enableMoveTo(bool state)
+{
+    digitizerState_ = state;
+    HAL_USB_HID_Set_State(0x03, (uint8_t)state, nullptr);
 }
 
 //Preinstantiate Object


### PR DESCRIPTION
Closes #1096

- USBKeyboard rework. Keycodes moved to https://github.com/spark/firmware/blob/8870980a4bfcaae30823cff27a0cee85ab52d379/wiring/inc/spark_wiring_usbkeyboard_scancode.h
- `Keyboard.write()` uses ASCII map to press appropriate keyboard buttons, see https://github.com/spark/firmware/blob/8870980a4bfcaae30823cff27a0cee85ab52d379/wiring/src/spark_wiring_usbkeyboard.cpp#L33
- `Keyboard.writeKey()`, `Keyboard.press()`, `Keyboard.release()` and `Keyboard.click()` use keycodes and modifier codes defined in `UsbKeyboardScanCode` and `UsbKeyboardModifier`, see https://github.com/spark/firmware/blob/8870980a4bfcaae30823cff27a0cee85ab52d379/wiring/inc/spark_wiring_usbkeyboard_scancode.h
- `Mouse.moveTo()` uses HID Digitizer Class to report absolute coordinates. Defaults to [0, 32767] range. Alternative range can be set using `Mouse.screenSize()`
- Linux X11 doesn't support HID devices reporting both absolute and relative coordinates. By default only `Mouse.moveTo()` works. In order for regular relative `Mouse.move()` to work, a call to `Mouse.enableMoveTo(false)` is required.
- `Mouse.move()` range extended to [-32767, 32767]
- `Mouse.wheel()` function added

Tests:
- `wiring/usbhid2`

TODO:
- Documentation

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)

### Enhancement

- USB HID enhancements, please see PR: [#1110](https://github.com/spark/firmware/pull/1110) for a list. Closes [#1096](https://github.com/spark/firmware/issues/1096)