### PR TITLE
Pass pointer to enum data to perform checksum

### DIFF
--- a/communication/src/subscriptions.h
+++ b/communication/src/subscriptions.h
@@ -73,7 +73,7 @@ public:
 			chk[0] = checksum;
 			chk[1] = calculate_crc((const uint8_t*)handler.device_id, sizeof(handler.device_id));
 			chk[2] = calculate_crc((const uint8_t*)handler.filter, sizeof(handler.filter));
-			chk[3] = calculate_crc((const uint8_t*)handler.scope, sizeof(handler.scope));
+			chk[3] = calculate_crc((const uint8_t*)&handler.scope, sizeof(handler.scope));
 			checksum = calculate_crc((const uint8_t*)chk, sizeof(chk));
 			return NO_ERROR;
 		});


### PR DESCRIPTION
Fixes a segfault on the gcc virtual device due to dereferencing memory location 0 or 1. The fix applies to all platforms.

---

Doneness:
- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
  Fixes a segfault on the GCC virtual device
