### PR TITLE
Uninitialize WICED's WLAN module when turning off the WiFi

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -322,7 +322,8 @@ wlan_result_t wlan_activate()
 wlan_result_t wlan_deactivate()
 {
     wlan_disconnect_now();
-    return 0;
+    wiced_result_t result = wiced_wlan_connectivity_deinit();
+    return result;
 }
 
 wlan_result_t wlan_disconnect_now()

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -23,6 +23,7 @@
 #include "system_task.h"
 #include "system_cloud.h"
 #include "system_cloud_internal.h"
+#include "system_network_internal.h"
 #include "system_threading.h"
 #include "rtc_hal.h"
 #include "core_hal.h"
@@ -43,10 +44,12 @@ WakeupState wakeupState;
 
 static void network_suspend() {
     // save the current state so it can be restored on wakeup
-    wakeupState.wifi = !SPARK_WLAN_SLEEP;
-    wakeupState.wifiConnected = wakeupState.cloud | network_ready(0, 0, NULL) | network_connecting(0, 0, NULL);
 #ifndef SPARK_NO_CLOUD
     wakeupState.cloud = spark_cloud_flag_auto_connect();
+#endif
+    wakeupState.wifi = !SPARK_WLAN_SLEEP;
+    wakeupState.wifiConnected = wakeupState.cloud || network_ready(0, 0, NULL) || network_connecting(0, 0, NULL);
+#ifndef SPARK_NO_CLOUD
     // disconnect the cloud now, and clear the auto connect status
     spark_cloud_socket_disconnect();
     spark_cloud_flag_disconnect();
@@ -173,5 +176,7 @@ int system_sleep_pin_impl(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long sec
  */
 void system_sleep_pin(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds, uint32_t param, void* reserved)
 {
+    // Cancel current connection attempt to unblock the system thread
+    network.connect_cancel(true);
     system_sleep_pin_impl(wakeUpPin, edgeTriggerMode, seconds, param, reserved);
 }

--- a/user/tests/app/stop_mode_power_usage_issue_1098/app.cpp
+++ b/user/tests/app/stop_mode_power_usage_issue_1098/app.cpp
@@ -1,0 +1,42 @@
+#include "application.h"
+
+#define MIN_CONNECT_DURATION 1000 // Milliseconds
+#define MAX_CONNECT_DURATION 5000
+#define SLEEP_DURATION 5 // Seconds
+
+SYSTEM_MODE(MANUAL)
+SYSTEM_THREAD(ENABLED)
+
+namespace {
+
+SerialLogHandler logHandler(LOG_LEVEL_WARN, { // Default logging level
+    { "app", LOG_LEVEL_ALL } // Logging level for application messages
+});
+
+uint32_t t = 0, d = 0;
+
+void resetTimer() {
+    d = rand() % (MAX_CONNECT_DURATION - MIN_CONNECT_DURATION) + MIN_CONNECT_DURATION;
+    t = millis();
+}
+
+} // namespace
+
+void setup() {
+    // Set incorrect WiFi credentials to cause repeated connection attempts
+    WiFi.on();
+    WiFi.clearCredentials();
+    WiFi.setCredentials("param-pam-pam");
+    WiFi.connect();
+    resetTimer();
+}
+
+void loop() {
+    if (millis() - t >= d) {
+        LOG(INFO, "Entering stop mode");
+        // The current taken by the device should be around 3 mA when the stop mode is active
+        System.sleep(D1, RISING, SLEEP_DURATION);
+        LOG(INFO, "Leaving stop mode");
+        resetTimer();
+    }
+}


### PR DESCRIPTION
Fixes #1098

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### BUGFIX

- [Photon/P1] Previously, when entering Sleep-stop mode: `System.sleep(D1, RISING, 60);` while in the process of making a Wi-Fi connection resulted in some parts of the radio still being initialized, consuming about 10-15mA more than normal. Fixes [#1098](https://github.com/spark/firmware/issues/1098)