### PR TITLE
Common tools for the Wiring library and unit testing

### DIFF
--- a/ci/build_boost.sh
+++ b/ci/build_boost.sh
@@ -1,4 +1,4 @@
 pushd $BOOST_ROOT
 ./bootstrap.sh
-./b2  --with-thread  --with-system --with-program_options --with-random  --threading=single
+./b2  --with-thread  --with-system --with-program_options --with-random --with-regex --threading=single
 popd

--- a/ci/install_boost.sh
+++ b/ci/install_boost.sh
@@ -9,4 +9,5 @@ test -d $BOOST_ROOT || (
    mv boost_$BOOST_VERSION  $BOOST_HOME
 ) 
 test -d $BOOST_ROOT || ( echo "boost root $BOOST_ROOT not created." && exit 1)
-export DYLD_LIBRARY_PATH=$BOOST_ROOT/stage/lib
+export DYLD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$DYLD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$LD_LIBRARY_PATH"

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 source ./ci/install_boost.sh
-./ci/unit_tests.sh &&
 ./ci/build_boost.sh &&
+./ci/unit_tests.sh &&
 ./ci/enumerate_build_matrix.sh

--- a/user/inc/application.h
+++ b/user/inc/application.h
@@ -63,6 +63,8 @@
 #include "spark_wiring_watchdog.h"
 #include "spark_wiring_thread.h"
 #include "spark_wiring_logging.h"
+#include "spark_wiring_json.h"
+#include "spark_wiring_vector.h"
 #include "fast_pin.h"
 #include "string_convert.h"
 #include "debug_output_handler.h"

--- a/user/tests/unit/json.cpp
+++ b/user/tests/unit/json.cpp
@@ -1,0 +1,794 @@
+#include "spark_wiring_json.h"
+#include "spark_wiring_print.h"
+
+#include "tools/stream.h"
+#include "tools/buffer.h"
+
+#include <boost/variant.hpp>
+
+#include <deque>
+#include <string>
+#include <cstdlib>
+
+namespace {
+
+using namespace spark;
+
+template<typename T>
+T fromString(const std::string &s, bool *ok = nullptr) {
+    char *end = nullptr;
+    const T val = strtod(s.c_str(), &end);
+    if (!end || *end != '\0') {
+        return T();
+    }
+    if (ok) {
+        *ok = true;
+    }
+    return val;
+}
+
+template<>
+bool fromString<bool>(const std::string &s, bool *ok) {
+    if (ok) {
+        *ok = true;
+    }
+    if (s.empty() || s == "false") { // Empty string or "false" in lower case
+        return false;
+    }
+    bool isNum = false;
+    const double val = fromString<double>(s, &isNum); // Check if string can be converted to a number
+    if (isNum) {
+        return val;
+    }
+    return true; // Any other non-empty string
+}
+
+template<typename T>
+inline T fromString(const JSONString &s, bool *ok = nullptr) {
+    return fromString<T>(std::string(s.data(), s.size()), ok);
+}
+
+void checkString(const JSONString &s, const std::string &str) {
+    const size_t n = s.size();
+    REQUIRE(n == str.size());
+    CHECK(s.isEmpty() == !n);
+    const char *d = s.data();
+    REQUIRE(d != nullptr);
+    CHECK(d[n] == '\0'); // JSONString::data() returns null-terminated string
+    CHECK(std::string(d, n) == str);
+}
+
+class Checker {
+public:
+    Checker() {
+    }
+
+    explicit Checker(const JSONValue &val) {
+        v_.push_back(val);
+    }
+
+    Checker& invalid() {
+        const JSONValue v = value();
+        REQUIRE(v.type() == JSON_TYPE_INVALID);
+        CHECK(v.isValid() == false); // Check conversions to other types
+        CHECK(v.toBool() == false);
+        CHECK(v.toInt() == 0);
+        CHECK(v.toDouble() == 0.0);
+        checkString(v.toString(), "");
+        return *this;
+    }
+
+    Checker& null() {
+        const JSONValue v = value();
+        REQUIRE(v.type() == JSON_TYPE_NULL);
+        CHECK(v.isNull() == true);
+        CHECK(v.isValid() == true);
+        CHECK(v.toBool() == false);
+        CHECK(v.toInt() == 0);
+        CHECK(v.toDouble() == 0.0);
+        checkString(v.toString(), "");
+        return *this;
+    }
+
+    Checker& boolean(bool val) {
+        const JSONValue v = value();
+        REQUIRE(v.type() == JSON_TYPE_BOOL);
+        CHECK(v.isBool() == true);
+        CHECK(v.isValid() == true);
+        CHECK(v.toBool() == val);
+        CHECK((bool)v.toInt() == val);
+        CHECK((bool)v.toDouble() == val);
+        checkString(v.toString(), val ? "true" : "false");
+        return *this;
+    }
+
+    template<typename T>
+    Checker& number(T val) {
+        const JSONValue v = value();
+        REQUIRE(v.type() == JSON_TYPE_NUMBER);
+        CHECK(v.isNumber());
+        CHECK(v.isValid());
+        CHECK((T)v.toBool() == (bool)val);
+        CHECK((T)v.toInt() == (int)val);
+        CHECK((T)v.toDouble() == (double)val);
+        CHECK(fromString<T>(v.toString()) == val);
+        return *this;
+    }
+
+    Checker& string(const std::string &str) {
+        const JSONValue v = value();
+        REQUIRE(v.type() == JSON_TYPE_STRING);
+        CHECK(v.isString() == true);
+        CHECK(v.isValid() == true);
+        const JSONString s = v.toString();
+        CHECK(v.toBool() == fromString<bool>(s));
+        CHECK(v.toInt() == fromString<int>(s));
+        CHECK(v.toDouble() == fromString<double>(s));
+        checkString(s, str);
+        return *this;
+    }
+
+    Checker& beginArray() {
+        const JSONValue v = value();
+        REQUIRE(v.type() == JSON_TYPE_ARRAY);
+        CHECK(v.isValid() == true);
+        CHECK(v.toBool() == false);
+        CHECK(v.toInt() == 0);
+        CHECK(v.toDouble() == 0.0);
+        checkString(v.toString(), "");
+        v_.push_back(JSONArrayIterator(v));
+        return *this;
+    }
+
+    Checker& endArray() {
+        const Variant v = v_.back();
+        if (v.which() != ARRAY) {
+            FAIL("Unexpected checker state");
+        }
+        v_.pop_back();
+        JSONArrayIterator it = boost::get<JSONArrayIterator>(v);
+        REQUIRE(it.count() == 0);
+        CHECK(it.next() == false);
+        return *this;
+    }
+
+    Checker& beginObject() {
+        const JSONValue v = value();
+        REQUIRE(v.type() == JSON_TYPE_OBJECT);
+        CHECK(v.isValid() == true);
+        CHECK(v.toBool() == false);
+        CHECK(v.toInt() == 0);
+        CHECK(v.toDouble() == 0.0);
+        checkString(v.toString(), "");
+        v_.push_back(JSONObjectIterator(v));
+        return *this;
+    }
+
+    Checker& endObject() {
+        const Variant v = v_.back();
+        if (v.which() != OBJECT) {
+            FAIL("Unexpected checker state");
+        }
+        v_.pop_back();
+        JSONObjectIterator it = boost::get<JSONObjectIterator>(v);
+        REQUIRE(it.count() == 0);
+        CHECK(it.next() == false);
+        return *this;
+    }
+
+    Checker& name(const std::string &str) {
+        Variant &v = v_.back();
+        if (v.which() != OBJECT) {
+            FAIL("Unexpected checker state");
+        }
+        JSONObjectIterator it = boost::get<JSONObjectIterator>(v);
+        const size_t n = it.count();
+        REQUIRE(it.next() == true);
+        CHECK(it.count() == n - 1);
+        checkString(it.name(), str);
+        v = it; // Update iterator
+        return *this;
+    }
+
+private:
+    enum Which {
+        BLANK,
+        VALUE,
+        ARRAY,
+        OBJECT
+    };
+
+    typedef boost::variant<boost::blank, JSONValue, JSONArrayIterator, JSONObjectIterator> Variant;
+
+    std::deque<Variant> v_;
+
+    JSONValue value() {
+        if (v_.empty()) {
+            FAIL("Unexpected checker state");
+        }
+        Variant &v = v_.back();
+        switch (v.which()) {
+        case VALUE: {
+            return boost::get<JSONValue>(v);
+        }
+        case ARRAY: { // JSONArrayIterator
+            JSONArrayIterator it = boost::get<JSONArrayIterator>(v);
+            const size_t n = it.count();
+            REQUIRE(it.next() == true);
+            CHECK(it.count() == n - 1);
+            v = it; // Update iterator
+            return it.value();
+        }
+        case OBJECT: { // JSONObjectIterator
+            const JSONObjectIterator it = boost::get<JSONObjectIterator>(v);
+            return it.value();
+        }
+        default:
+            FAIL("Unexpected checker state");
+            return JSONValue();
+        }
+    }
+};
+
+inline JSONValue parse(const std::string &json) {
+    return JSONValue::parseCopy(json.data(), json.size());
+}
+
+inline Checker check(const JSONValue &val) {
+    return Checker(val);
+}
+
+inline Checker check(const char *json) {
+    return Checker(parse(json));
+}
+
+} // namespace
+
+namespace spark {
+
+inline std::ostream& operator<<(std::ostream &strm, const JSONString &str) {
+    return strm << '"' << str.data() << '"';
+}
+
+} // namespace spark
+
+TEST_CASE("Parsing JSON") {
+    SECTION("null") {
+        check("null").null();
+    }
+
+    SECTION("bool") {
+        check("true").boolean(true);
+        check("false").boolean(false);
+    }
+
+    SECTION("number") {
+        SECTION("int") {
+            check("0").number(0);
+            check("1").number(1);
+            check("-1").number(-1);
+            check("12345").number(12345);
+            check("-12345").number(-12345);
+            check("-2147483648").number(-2147483648); // INT_MIN
+            check("2147483647").number(2147483647); // INT_MAX
+        }
+        SECTION("double") {
+            check("0.0").number(0.0);
+            check("1.0").number(1.0);
+            check("-1.0").number(-1.0);
+            check("0.5").number(0.5);
+            check("-0.5").number(-0.5);
+            check("3.1416").number(3.1416);
+            check("-3.1416").number(-3.1416);
+            check("2.22507e-308").number(2.22507e-308); // ~DBL_MIN
+            check("1.79769e+308").number(1.79769e+308); // ~DBL_MAX
+        }
+    }
+
+    SECTION("string") {
+        check("\"\"").string(""); // Empty string
+        check("\"abc\"").string("abc");
+        check("\"a\"").string("a"); // Single character
+        check("\"\\\"\"").string("\""); // Single escaped character
+        check("\"\\\"\\/\\\\\\b\\f\\n\\r\\t\"").string("\"/\\\b\f\n\r\t"); // Named escaped characters
+        check("\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\u0008\\u0009\\u000a\\u000b"
+                "\\u000c\\u000d\\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019"
+                "\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f\"").string(
+                std::string("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15"
+                        "\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f", 32)); // Control characters
+        check("\"\\u2014\"").string("\\u2014"); // Unicode characters are not processed
+    }
+
+    SECTION("array") {
+        SECTION("empty") {
+            check("[]").beginArray().endArray();
+        }
+        SECTION("single element") {
+            check("[null]").beginArray()
+                    .null()
+                    .endArray();
+        }
+        SECTION("primitive elements") {
+            check("[null,true,2,3.14,\"abcd\"]").beginArray()
+                    .null()
+                    .boolean(true)
+                    .number(2)
+                    .number(3.14)
+                    .string("abcd")
+                    .endArray();
+        }
+        SECTION("nested array") {
+            check("[1.1,[2.1,2.2,2.3],1.3]").beginArray()
+                    .number(1.1)
+                    .beginArray()
+                            .number(2.1)
+                            .number(2.2)
+                            .number(2.3)
+                            .endArray()
+                    .number(1.3)
+                    .endArray();
+        }
+        SECTION("nested object") {
+            check("[1.1,{\"2.1\":2.1,\"2.2\":2.2,\"2.3\":2.3},1.3]").beginArray()
+                    .number(1.1)
+                    .beginObject()
+                            .name("2.1").number(2.1)
+                            .name("2.2").number(2.2)
+                            .name("2.3").number(2.3)
+                            .endObject()
+                    .number(1.3)
+                    .endArray();
+        }
+        SECTION("deeply nested array") {
+            Checker c = check("[[[[[[[[[[[]]]]]]]]]]]");
+            c.beginArray();
+            for (int i = 0; i < 10; ++i) {
+                c.beginArray();
+            }
+            for (int i = 0; i < 10; ++i) {
+                c.endArray();
+            }
+            c.endArray();
+        }
+    }
+
+    SECTION("object") {
+        SECTION("empty") {
+            check("{}").beginObject().endObject();
+        }
+        SECTION("single element") {
+            check("{\"null\":null}").beginObject()
+                    .name("null").null()
+                    .endObject();
+        }
+        SECTION("primitive elements") {
+            check("{\"null\":null,\"bool\":true,\"int\":2,\"double\":3.14,\"string\":\"abcd\"}").beginObject()
+                    .name("null").null()
+                    .name("bool").boolean(true)
+                    .name("int").number(2)
+                    .name("double").number(3.14)
+                    .name("string").string("abcd")
+                    .endObject();
+        }
+        SECTION("nested object") {
+            check("{\"1.1\":1.1,\"1.2\":{\"2.1\":2.1,\"2.2\":2.2,\"2.3\":2.3},\"1.3\":1.3}").beginObject()
+                    .name("1.1").number(1.1)
+                    .name("1.2").beginObject()
+                            .name("2.1").number(2.1)
+                            .name("2.2").number(2.2)
+                            .name("2.3").number(2.3)
+                            .endObject()
+                    .name("1.3").number(1.3)
+                    .endObject();
+        }
+        SECTION("nested array") {
+            check("{\"1.1\":1.1,\"1.2\":[2.1,2.2,2.3],\"1.3\":1.3}").beginObject()
+                    .name("1.1").number(1.1)
+                    .name("1.2").beginArray()
+                            .number(2.1)
+                            .number(2.2)
+                            .number(2.3)
+                            .endArray()
+                    .name("1.3").number(1.3)
+                    .endObject();
+        }
+        SECTION("deeply nested object") {
+            Checker c = check("{\"1\":{\"2\":{\"3\":{\"4\":{\"5\":{\"6\":{\"7\":{\"8\":{\"9\":{\"10\":{}}}}}}}}}}}");
+            c.beginObject();
+            for (int i = 1; i <= 10; ++i) {
+                c.name(std::to_string(i)).beginObject();
+            }
+            for (int i = 1; i <= 10; ++i) {
+                c.endObject();
+            }
+            c.endObject();
+        }
+    }
+
+    SECTION("parsing errors") {
+        check("").invalid(); // Empty source data
+        check("[").invalid(); // Malformed array
+        check("]").invalid();
+        check("[1,").invalid();
+        check("{").invalid(); // Malformed object
+        check("}").invalid();
+        check("{null").invalid();
+        check("{false").invalid();
+        check("{1").invalid();
+        check("{\"1\"").invalid();
+        check("{\"1\":").invalid();
+        check("\"\\x\"").invalid(); // Unknown escaped character
+        check("\"\\U0001\"").invalid(); // Uppercase 'U'
+        check("\"\\u000x\"").invalid(); // Invalid hex value
+        check("\"\\u001\"").invalid();
+        check("\"\\u01\"").invalid();
+        check("\"\\u\"").invalid();
+    }
+}
+
+TEST_CASE("Writing JSON") {
+    test::OutputStream data;
+    JSONStreamWriter json(data);
+
+    SECTION("null") {
+        json.nullValue();
+        check(data).equals("null");
+    }
+
+    SECTION("bool") {
+        SECTION("true") {
+            json.value(true);
+            check(data).equals("true");
+        }
+        SECTION("false") {
+            json.value(false);
+            check(data).equals("false");
+        }
+    }
+
+    SECTION("number") {
+        SECTION("int") {
+            SECTION("0") {
+                json.value(0);
+                check(data).equals("0");
+            }
+            SECTION("1") {
+                json.value(1);
+                check(data).equals("1");
+            }
+            SECTION("-1") {
+                json.value(-1);
+                check(data).equals("-1");
+            }
+            SECTION("12345") {
+                json.value(12345);
+                check(data).equals("12345");
+            }
+            SECTION("-12345") {
+                json.value(-12345);
+                check(data).equals("-12345");
+            }
+            SECTION("min") {
+                json.value((int)-2147483648); // INT_MIN
+                check(data).equals("-2147483648");
+            }
+            SECTION("max") {
+                json.value((int)2147483647); // INT_MAX
+                check(data).equals("2147483647");
+            }
+        }
+        SECTION("double") {
+            SECTION("0.0") {
+                json.value(0.0);
+                check(data).equals("0");
+            }
+            SECTION("1.0") {
+                json.value(1.0);
+                check(data).equals("1");
+            }
+            SECTION("-1.0") {
+                json.value(-1.0);
+                check(data).equals("-1");
+            }
+            SECTION("0.5") {
+                json.value(0.5);
+                check(data).equals("0.5");
+            }
+            SECTION("-0.5") {
+                json.value(-0.5);
+                check(data).equals("-0.5");
+            }
+            SECTION("3.1416") {
+                json.value(3.1416);
+                check(data).equals("3.1416");
+            }
+            SECTION("-3.1416") {
+                json.value(-3.1416);
+                check(data).equals("-3.1416");
+            }
+            SECTION("min") {
+                json.value(2.22507e-308); // ~DBL_MIN
+                check(data).equals("2.22507e-308");
+            }
+            SECTION("max") {
+                json.value(1.79769e+308); // ~DBL_MAX
+                check(data).equals("1.79769e+308");
+            }
+        }
+    }
+
+    SECTION("string") {
+        SECTION("empty") {
+            json.value("");
+            check(data).equals("\"\"");
+        }
+        SECTION("test string") {
+            json.value("abc");
+            check(data).equals("\"abc\"");
+        }
+        SECTION("single character") {
+            json.value("a");
+            check(data).equals("\"a\"");
+        }
+        SECTION("single escaped character") {
+            json.value("\"");
+            check(data).equals("\"\\\"\"");
+        }
+        SECTION("named escaped characters") {
+            json.value("\"/\\\b\f\n\r\t");
+            check(data).equals("\"\\\"/\\\\\\b\\f\\n\\r\\t\""); // '/' is never escaped
+        }
+        SECTION("control characters") {
+            json.value("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16"
+                    "\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f", 32);
+            check(data).equals("\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\\t\\n\\u000b\\f\\r\\u000e"
+                    "\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c"
+                    "\\u001d\\u001e\\u001f\"");
+        }
+    }
+
+    SECTION("array") {
+        SECTION("empty") {
+            json.beginArray();
+            json.endArray();
+            check(data).equals("[]");
+        }
+        SECTION("single element") {
+            json.beginArray();
+            json.nullValue();
+            json.endArray();
+            check(data).equals("[null]");
+        }
+        SECTION("primitive elements") {
+            json.beginArray();
+            json.nullValue().value(true).value(2).value(3.14).value("abcd");
+            json.endArray();
+            check(data).equals("[null,true,2,3.14,\"abcd\"]");
+        }
+        SECTION("nested array") {
+            json.beginArray();
+            json.value(1.1);
+            json.beginArray();
+            json.value(2.1).value(2.2).value(2.3);
+            json.endArray();
+            json.value(1.3);
+            json.endArray();
+            check(data).equals("[1.1,[2.1,2.2,2.3],1.3]");
+        }
+        SECTION("nested object") {
+            json.beginArray();
+            json.value(1.1);
+            json.beginObject();
+            json.name("2.1").value(2.1);
+            json.name("2.2").value(2.2);
+            json.name("2.3").value(2.3);
+            json.endObject();
+            json.value(1.3);
+            json.endArray();
+            check(data).equals("[1.1,{\"2.1\":2.1,\"2.2\":2.2,\"2.3\":2.3},1.3]");
+        }
+        SECTION("deeply nested array") {
+            json.beginArray();
+            for (int i = 0; i < 10; ++i) {
+                json.beginArray();
+            }
+            for (int i = 0; i < 10; ++i) {
+                json.endArray();
+            }
+            json.endArray();
+            check(data).equals("[[[[[[[[[[[]]]]]]]]]]]");
+        }
+    }
+
+    SECTION("object") {
+        SECTION("empty") {
+            json.beginObject();
+            json.endObject();
+            check(data).equals("{}");
+        }
+        SECTION("single element") {
+            json.beginObject();
+            json.name("null").nullValue();
+            json.endObject();
+            check(data).equals("{\"null\":null}");
+        }
+        SECTION("primitive elements") {
+            json.beginObject();
+            json.name("null").nullValue();
+            json.name("bool").value(true);
+            json.name("int").value(2);
+            json.name("double").value(3.14);
+            json.name("string").value("abcd");
+            json.endObject();
+            check(data).equals("{\"null\":null,\"bool\":true,\"int\":2,\"double\":3.14,\"string\":\"abcd\"}");
+        }
+        SECTION("nested object") {
+            json.beginObject();
+            json.name("1.1").value(1.1);
+            json.name("1.2").beginObject();
+            json.name("2.1").value(2.1);
+            json.name("2.2").value(2.2);
+            json.name("2.3").value(2.3);
+            json.endObject();
+            json.name("1.3").value(1.3);
+            json.endObject();
+            check(data).equals("{\"1.1\":1.1,\"1.2\":{\"2.1\":2.1,\"2.2\":2.2,\"2.3\":2.3},\"1.3\":1.3}");
+        }
+        SECTION("nested array") {
+            json.beginObject();
+            json.name("1.1").value(1.1);
+            json.name("1.2").beginArray();
+            json.value(2.1).value(2.2).value(2.3);
+            json.endArray();
+            json.name("1.3").value(1.3);
+            json.endObject();
+            check(data).equals("{\"1.1\":1.1,\"1.2\":[2.1,2.2,2.3],\"1.3\":1.3}");
+        }
+        SECTION("deeply nested object") {
+            json.beginObject();
+            for (int i = 1; i <= 10; ++i) {
+                json.name(std::to_string(i).c_str()).beginObject();
+            }
+            for (int i = 1; i <= 10; ++i) {
+                json.endObject();
+            }
+            json.endObject();
+            check(data).equals("{\"1\":{\"2\":{\"3\":{\"4\":{\"5\":{\"6\":{\"7\":{\"8\":{\"9\":{\"10\":{}}}}}}}}}}}");
+        }
+        SECTION("escaped name characters") {
+            json.beginObject();
+            json.name("a\tb\n").value("a\tb\n");
+            json.endObject();
+            check(data).equals("{\"a\\tb\\n\":\"a\\tb\\n\"}");
+        }
+    }
+}
+
+TEST_CASE("JSONValue") {
+    SECTION("construction") {
+        const JSONValue v; // Constructs invalid value
+        check(v).invalid();
+    }
+
+    SECTION("in-place processing vs copying") {
+        SECTION("in-place processing") {
+            char json[] = "\"abc\"";
+            const JSONValue v = JSONValue::parse(json, sizeof(json));
+            json[2] = 'B';
+            check(v).string("aBc");
+        }
+        SECTION("copying") {
+            char json[] = "\"abc\"";
+            const JSONValue v = JSONValue::parseCopy(json, sizeof(json));
+            json[2] = 'B';
+            check(v).string("abc"); // Source data is not affected
+        }
+        SECTION("implicit copying") {
+            char json[] = "1x";
+            const JSONValue v = JSONValue::parse(json, 1); // No space for term. null
+            check(v).number(1);
+            const char *s = v.toString().data();
+            CHECK(s[1] == '\0'); // JSONString::data() returns null-terminated string
+            CHECK(json[1] == 'x');
+        }
+    }
+}
+
+TEST_CASE("JSONString") {
+    SECTION("construction") {
+        checkString(JSONString(), "");
+        checkString(JSONString(JSONValue()), ""); // Constructing from invalid JSONValue
+    }
+
+    SECTION("comparison") {
+        const JSONString s1(parse("\"\""));
+        const JSONString s2(parse("\"abc\""));
+        CHECK(s1 == JSONString()); // JSONString
+        CHECK(s1 == s1);
+        CHECK(s2 == s2);
+        CHECK(s1 != s2);
+        CHECK((s1 == "" && "" == s1)); // const char*
+        CHECK((s1 != "abc" && "abc" != s1));
+        CHECK((s2 == "abc" && "abc" == s2));
+        CHECK((s2 != "abcd" && "abcd" != s2));
+        CHECK((s1 == String() && String() == s1)); // String
+        CHECK((s1 != String("abc") && String("abc") != s1));
+        CHECK((s2 == String("abc") && String("abc") == s2));
+        CHECK((s2 != String("abcd") && String("abcd") != s2));
+    }
+
+    SECTION("casting") {
+        const JSONString s1(parse("\"\""));
+        const JSONString s2(parse("\"abc\""));
+        CHECK(strcmp((const char*)s1, "") == 0); // const char*
+        CHECK(strcmp((const char*)s2, "abc") == 0);
+        CHECK((String)s1 == String()); // String
+        CHECK((String)s2 == String("abc"));
+    }
+}
+
+TEST_CASE("JSONArrayIterator") {
+    SECTION("construction") {
+        JSONArrayIterator it1;
+        check(it1.value()).invalid();
+        CHECK(it1.count() == 0);
+        CHECK(it1.next() == false);
+        const JSONValue v;
+        JSONArrayIterator it2(v); // Constructing from invalid JSONValue
+        check(it2.value()).invalid();
+        CHECK(it2.count() == 0);
+        CHECK(it2.next() == false);
+    }
+}
+
+TEST_CASE("JSONObjectIterator") {
+    SECTION("construction") {
+        JSONObjectIterator it1;
+        checkString(it1.name(), "");
+        check(it1.value()).invalid();
+        CHECK(it1.count() == 0);
+        CHECK(it1.next() == false);
+        const JSONValue v;
+        JSONObjectIterator it2(v); // Constructing from invalid JSONValue
+        checkString(it2.name(), "");
+        check(it2.value()).invalid();
+        CHECK(it2.count() == 0);
+        CHECK(it2.next() == false);
+    }
+}
+
+TEST_CASE("JSONStreamWriter") {
+    SECTION("construction") {
+        test::OutputStream strm;
+        JSONStreamWriter w(strm);
+        CHECK(w.stream() == &strm);
+        check(strm).isEmpty();
+    }
+}
+
+TEST_CASE("JSONBufferWriter") {
+    SECTION("construction") {
+        test::Buffer buf; // Empty buffer
+        JSONBufferWriter w((char*)buf, buf.size());
+        CHECK(w.buffer() == (char*)buf);
+        CHECK(w.bufferSize() == buf.size());
+        CHECK(w.dataSize() == 0);
+    }
+
+    SECTION("exact buffer size") {
+        test::Buffer buf(25); // 25 bytes
+        JSONBufferWriter w((char*)buf, buf.size());
+        w.beginArray().nullValue().value(true).value(2).value(3.14).value("abcd").endArray();
+        CHECK(w.dataSize() == 25);
+        check(buf).equals("[null,true,2,3.14,\"abcd\"]");
+        CHECK(buf.isPaddingValid());
+    }
+
+    SECTION("too small buffer") {
+        test::Buffer buf;
+        JSONBufferWriter w((char*)buf, buf.size());
+        w.beginArray().nullValue().value(true).value(2).value(3.14).value("abcd").endArray();
+        CHECK(w.dataSize() == 25); // Size of the actual JSON data
+        CHECK(buf.isPaddingValid());
+    }
+}

--- a/user/tests/unit/makefile
+++ b/user/tests/unit/makefile
@@ -45,6 +45,7 @@ CPPSRC += $(call target_files,$(WIRING_SRC),spark_wiring_ipaddress.cpp)
 CPPSRC += $(call target_files,$(WIRING_SRC),spark_wiring_print.cpp)
 CPPSRC += $(call target_files,$(WIRING_SRC),spark_wiring_logging.cpp)
 CPPSRC += $(call target_files,$(WIRING_SRC),spark_wiring_fuel.cpp)
+CPPSRC += $(call target_files,$(WIRING_SRC),spark_wiring_json.cpp)
 CPPSRC += $(call target_files,$(WIRING_SRC),string_convert.cpp)
 CPPSRC += $(call target_files,$(SYSTEM)src/,system_utilities.cpp)
 CPPSRC += $(call target_files,$(SYSTEM)src/,system_mode.cpp)
@@ -56,6 +57,7 @@ LIB_SERVICES = services/
 
 CSRC += $(call target_files,$(LIB_SERVICES)src,rgbled.c)
 CSRC += $(call target_files,$(LIB_SERVICES)src,debug.c)
+CSRC += $(call target_files,$(LIB_SERVICES)src,jsmn.c)
 CPPSRC += $(call target_files,$(LIB_SERVICES)src,logging.cpp)
 
 
@@ -71,7 +73,7 @@ INCLUDE_DIRS += $(COMMUNICATION)src
 INCLUDE_DIRS += dynalib/inc
 
 # prefix $(SRC_ROOT)
-ABS_INCLUDE_DIRS += $(patsubst %,$(SRC_ROOT)/%,$(INCLUDE_DIRS)) 
+ABS_INCLUDE_DIRS += $(patsubst %,$(SRC_ROOT)/%,$(INCLUDE_DIRS))
 
 
 ifeq ("$(BOOST_ROOT)","")
@@ -80,7 +82,10 @@ else
 $(info BOOST_ROOT "$(BOOST_ROOT)")
 endif
 
+DEFINES += BOOST_NO_AUTO_PTR
 ABS_INCLUDE_DIRS += $(BOOST_ROOT)
+LIB_DIRS += $(BOOST_ROOT)/stage/lib
+LIBS += boost_regex
 
 CFLAGS += $(patsubst %,-I%,$(ABS_INCLUDE_DIRS)) -I.
 CFLAGS += -ffunction-sections -fdata-sections -Wall
@@ -92,9 +97,12 @@ CFLAGS += -Werror=deprecated-declarations
 CFLAGS += -MD -MP -MF $@.d
 CFLAGS += -DSPARK=1 -DPLATFORM_ID=3
 CFLAGS += -DDEBUG_BUILD
+CFLAGS += $(DEFINES:%=-D%)
 
 CPPFLAGS += -std=gnu++11
 CPPFLAGS += -DCATCH_CONFIG_SFINAE
+
+LDFLAGS += $(LIB_DIRS:%=-L%) $(LIBS:%=-l%)
 
 # Collect all object and dep files
 ALLOBJ += $(addprefix $(BUILD_PATH), $(CSRC:.c=.o))

--- a/user/tests/unit/tools/alloc.cpp
+++ b/user/tests/unit/tools/alloc.cpp
@@ -1,0 +1,109 @@
+#include "alloc.h"
+
+#include "catch.h"
+
+#include <algorithm>
+#include <cstring>
+
+// test::Allocator
+void* test::Allocator::malloc(size_t size) {
+    const std::lock_guard<std::recursive_mutex> lock(mutex_);
+    Buffer buf(size, padding_);
+    void* const ptr = buf.data();
+    alloc_.insert(std::make_pair(ptr, std::move(buf)));
+    return ptr;
+}
+
+void* test::Allocator::calloc(size_t n, size_t size) {
+    const std::lock_guard<std::recursive_mutex> lock(mutex_);
+    size *= n;
+    void* const ptr = malloc(size);
+    if (ptr) {
+        memset(ptr, 0, size);
+    }
+    return ptr;
+}
+
+void* test::Allocator::realloc(void* ptr, size_t size) {
+    const std::lock_guard<std::recursive_mutex> lock(mutex_);
+    try {
+        size_t origSize = 0; // Original buffer size
+        if (ptr) {
+            const auto it = alloc_.find(ptr);
+            if (it == alloc_.end()) {
+                throw std::runtime_error("Invalid realloc() detected");
+            }
+            origSize = it->second.size();
+        }
+        void* const newPtr = malloc(size);
+        if (newPtr && ptr) {
+            memcpy(newPtr, ptr, std::min(size, origSize)); // Copy user data from the original buffer
+            free(ptr);
+        }
+        return newPtr;
+    } catch (const std::exception& e) {
+        // realloc() and free() can be called in destructor, so we can't use CATCH_FAIL() here,
+        // as it throws exceptions
+        CATCH_WARN("test::Allocator: " << e.what());
+        failed_ = true;
+        return nullptr;
+    }
+}
+
+void test::Allocator::free(void* ptr) {
+    const std::lock_guard<std::recursive_mutex> lock(mutex_);
+    try {
+        if (!ptr) {
+            return;
+        }
+        if (free_.count(ptr)) {
+            throw std::runtime_error("Double free() detected");
+        }
+        const auto it = alloc_.find(ptr);
+        if (it == alloc_.end()) {
+            throw std::runtime_error("Invalid free() detected");
+        }
+        FreedBuffer f;
+        f.buffer = std::move(it->second);
+        f.data = (std::string)f.buffer; // User data before free() has been called
+        alloc_.erase(it);
+        const bool ok = f.buffer.isPaddingValid();
+        free_.insert(std::make_pair(ptr, std::move(f)));
+        if (!ok) {
+            throw std::runtime_error("Buffer overflow detected");
+        }
+    } catch (const std::exception& e) {
+        CATCH_WARN("test::Allocator: " << e.what());
+        failed_ = true;
+    }
+}
+
+void test::Allocator::reset() {
+    const std::lock_guard<std::recursive_mutex> lock(mutex_);
+    alloc_.clear();
+    free_.clear();
+    failed_ = false;
+}
+
+void test::Allocator::check() {
+    const std::lock_guard<std::recursive_mutex> lock(mutex_);
+    // Check all previously allocated buffers
+    if (!alloc_.empty()) {
+        FAIL("test::Allocator: Memory leak detected");
+    }
+    for (auto it = free_.begin(); it != free_.end(); ++it) {
+        const FreedBuffer& f = it->second;
+        if (!f.buffer.isPaddingValid() || (std::string)f.buffer != f.data) {
+            FAIL("test::Allocator: Memory corruption detected");
+        }
+    }
+    if (failed_) {
+        FAIL("test::Allocator: Memory check failed");
+    }
+}
+
+// test::DefaultAllocator
+test::Allocator* test::DefaultAllocator::instance() {
+    static Allocator alloc;
+    return &alloc;
+}

--- a/user/tests/unit/tools/alloc.h
+++ b/user/tests/unit/tools/alloc.h
@@ -1,0 +1,91 @@
+#ifndef TEST_TOOLS_ALLOC_H
+#define TEST_TOOLS_ALLOC_H
+
+#include "buffer.h"
+
+#include <unordered_map>
+#include <mutex>
+
+namespace test {
+
+class Allocator {
+public:
+    explicit Allocator(size_t padding = Buffer::DEFAULT_PADDING);
+
+    void* malloc(size_t size);
+    void* calloc(size_t n, size_t size);
+    void* realloc(void* ptr, size_t size);
+    void free(void* ptr);
+
+    void check();
+
+    void reset();
+
+    // This class is non-copyable
+    Allocator(const Allocator&) = delete;
+    Allocator& operator=(const Allocator&) = delete;
+
+private:
+    struct FreedBuffer {
+        Buffer buffer;
+        std::string data;
+    };
+
+    std::unordered_map<void*, Buffer> alloc_;
+    std::unordered_map<void*, FreedBuffer> free_;
+    size_t padding_;
+    bool failed_;
+
+    std::recursive_mutex mutex_;
+};
+
+class DefaultAllocator {
+public:
+    static void* malloc(size_t size);
+    static void* calloc(size_t n, size_t size);
+    static void* realloc(void* ptr, size_t size);
+    static void free(void* ptr);
+
+    static void check();
+
+    static void reset();
+
+private:
+    static Allocator* instance();
+};
+
+} // namespace test
+
+// test::Allocator
+inline test::Allocator::Allocator(size_t padding) :
+        padding_(padding),
+        failed_(false) {
+    reset();
+}
+
+// test::DefaultAllocator
+inline void* test::DefaultAllocator::malloc(size_t size) {
+    return instance()->malloc(size);
+}
+
+inline void* test::DefaultAllocator::calloc(size_t n, size_t size) {
+    return instance()->calloc(n, size);
+}
+
+inline void* test::DefaultAllocator::realloc(void* ptr, size_t size) {
+    return instance()->realloc(ptr, size);
+}
+
+inline void test::DefaultAllocator::free(void* ptr) {
+    instance()->free(ptr);
+}
+
+inline void test::DefaultAllocator::check() {
+    instance()->check();
+}
+
+inline void test::DefaultAllocator::reset() {
+    instance()->reset();
+}
+
+#endif // TEST_TOOLS_ALLOC_H

--- a/user/tests/unit/tools/buffer.cpp
+++ b/user/tests/unit/tools/buffer.cpp
@@ -1,0 +1,19 @@
+#include "buffer.h"
+
+#include "random.h"
+
+#include <cstring>
+
+// test::Buffer
+test::Buffer::Buffer(size_t size, size_t padding) :
+        d_(size + padding * 2, 0),
+        p_(randomBytes(padding)) { // Generate padding bytes
+    memcpy(&d_.front(), p_.data(), padding);
+    memcpy(&d_.front() + padding, randomBytes(size).data(), size); // Initialize buffer with random data
+    memcpy(&d_.front() + padding + size, p_.data(), padding);
+}
+
+bool test::Buffer::isPaddingValid() const {
+    return memcmp(d_.data(), p_.data(), p_.size()) == 0 &&
+            memcmp(d_.data() + d_.size() - p_.size(), p_.data(), p_.size()) == 0;
+}

--- a/user/tests/unit/tools/buffer.h
+++ b/user/tests/unit/tools/buffer.h
@@ -1,0 +1,56 @@
+#ifndef TEST_TOOLS_BUFFER_H
+#define TEST_TOOLS_BUFFER_H
+
+#include "check.h"
+
+#include <string>
+
+namespace test {
+
+class Buffer: public Checkable<std::string, Buffer> {
+public:
+    static const size_t DEFAULT_PADDING = 16;
+
+    explicit Buffer(size_t size = 0, size_t padding = DEFAULT_PADDING);
+
+    char* data();
+    const char* data() const;
+    size_t size() const;
+
+    bool isPaddingValid() const;
+
+    explicit operator char*();
+    explicit operator const char*() const;
+    explicit operator std::string() const; // Required by Checkable mixin
+
+private:
+    std::string d_, p_;
+};
+
+} // namespace test
+
+inline char* test::Buffer::data() {
+    return &d_.front() + p_.size();
+}
+
+inline const char* test::Buffer::data() const {
+    return &d_.front() + p_.size();
+}
+
+inline size_t test::Buffer::size() const {
+    return d_.size() - p_.size() * 2;
+}
+
+inline test::Buffer::operator char*() {
+    return data();
+}
+
+inline test::Buffer::operator const char*() const {
+    return data();
+}
+
+inline test::Buffer::operator std::string() const {
+    return d_.substr(p_.size(), size());
+}
+
+#endif // TEST_TOOLS_BUFFER_H

--- a/user/tests/unit/tools/catch.h
+++ b/user/tests/unit/tools/catch.h
@@ -1,0 +1,14 @@
+#ifndef TEST_TOOLS_CATCH_H
+#define TEST_TOOLS_CATCH_H
+
+#define CATCH_CONFIG_PREFIX_ALL
+#include <catch.hpp>
+
+// Non-prefixed aliases for some typical macros that don't clash with the firmware
+#define CHECK(...) CATCH_CHECK(__VA_ARGS__)
+#define REQUIRE(...) CATCH_REQUIRE(__VA_ARGS__)
+#define FAIL(...) CATCH_FAIL(__VA_ARGS__)
+#define TEST_CASE(...) CATCH_TEST_CASE(__VA_ARGS__)
+#define SECTION(...) CATCH_SECTION(__VA_ARGS__)
+
+#endif // TEST_TOOLS_CATCH_H

--- a/user/tests/unit/tools/check.h
+++ b/user/tests/unit/tools/check.h
@@ -1,0 +1,239 @@
+#ifndef TEST_TOOLS_CHECK_H
+#define TEST_TOOLS_CHECK_H
+
+#include "catch.h"
+#include "string.h"
+
+#include <type_traits>
+
+namespace test {
+
+namespace detail {
+
+class CheckableBase {
+};
+
+template<typename CheckerT, typename WrapperT>
+class CheckerBase {
+public:
+    typedef WrapperT WrapperType;
+
+    explicit CheckerBase(const WrapperT &wrapper) :
+            w_(wrapper) {
+    }
+
+    const WrapperT& end() const {
+        return w_;
+    }
+
+private:
+    const WrapperT& w_;
+};
+
+template<typename CheckerT>
+class CheckerBase<CheckerT, void> {
+public:
+    typedef CheckerT WrapperType;
+
+    const CheckerT& end() const {
+        return static_cast<const CheckerT&>(*this);
+    }
+};
+
+template<typename T, typename CheckerT, typename WrapperT>
+class BasicChecker: public CheckerBase<CheckerT, WrapperT> {
+public:
+    typedef BasicChecker<T, CheckerT, WrapperT> CheckerType;
+    typedef CheckerBase<CheckerT, WrapperT> CheckerBaseType;
+    typedef typename CheckerBaseType::WrapperType WrapperType;
+
+    template<typename... ArgsT>
+    explicit BasicChecker(T value, ArgsT&&... args) :
+            CheckerBaseType(std::forward<ArgsT>(args)...),
+            v_(std::move(value)) {
+    }
+
+    const WrapperType& equals(const T& value) const {
+        CHECK(v_ == value);
+        return this->end();
+    }
+
+    const WrapperType& lessThan(const T& value) const {
+        CHECK(v_ < value);
+        return this->end();
+    }
+
+    const WrapperType& lessThanOrEquals(const T& value) const {
+        CHECK(v_ <= value);
+        return this->end();
+    }
+
+    const WrapperType& greaterThan(const T& value) const {
+        CHECK(v_ > value);
+        return this->end();
+    }
+
+    const WrapperType& greaterThanOrEquals(const T& value) const {
+        CHECK(v_ >= value);
+        return this->end();
+    }
+
+    const T& value() const {
+        return v_;
+    }
+
+    operator T() const {
+        return v_;
+    }
+
+private:
+    T v_;
+};
+
+} // namespace test::detail
+
+template<typename T, typename WrapperT = void>
+class Checker: public detail::BasicChecker<T, Checker<T, WrapperT>, WrapperT> {
+public:
+    typedef Checker<T, WrapperT> CheckerType;
+    typedef detail::BasicChecker<T, CheckerType, WrapperT> CheckerBaseType;
+
+    using CheckerBaseType::CheckerBaseType;
+};
+
+template<typename WrapperT>
+class RegExpChecker;
+
+template<typename WrapperT>
+class Checker<std::string, WrapperT>: public detail::BasicChecker<std::string, Checker<std::string, WrapperT>, WrapperT> {
+public:
+    typedef Checker<std::string, WrapperT> CheckerType;
+    typedef detail::BasicChecker<std::string, CheckerType, WrapperT> CheckerBaseType;
+    typedef typename CheckerBaseType::WrapperType WrapperType;
+
+    using CheckerBaseType::CheckerBaseType;
+
+    const WrapperType& startsWith(const std::string& str) const {
+        const std::string &s = this->value();
+        if (s.size() < str.size() || s.substr(0, str.size()) != str) {
+            FAIL('"' << s << "\" doesn't start with \"" << str << '"');
+        }
+        return this->end();
+    }
+
+    const WrapperType& endsWith(const std::string& str) const {
+        const std::string &s = this->value();
+        if (s.size() < str.size() || s.substr(s.size() - str.size(), str.size()) != str) {
+            FAIL('"' << s << "\" doesn't end with \"" << str << '"');
+        }
+        return this->end();
+    }
+
+    const WrapperType& contains(const std::string& str) const {
+        const std::string &s = this->value();
+        if (s.find(str) == std::string::npos) {
+            FAIL('"' << s << "\" doesn't contain \"" << str << '"');
+        }
+        return this->end();
+    }
+
+    const WrapperType& isEmpty() const {
+        const std::string &s = this->value();
+        CHECK(s == "");
+        return this->end();
+    }
+
+    CheckerType lowerCase() const {
+        return CheckerType(toLowerCase(this->value()));
+    }
+
+    CheckerType upperCase() const {
+        return CheckerType(toUpperCase(this->value()));
+    }
+
+    CheckerType hex() const {
+        return CheckerType(toHex(this->value()));
+    }
+
+    CheckerType unhex() const {
+        return CheckerType(fromHex(this->value()));
+    }
+
+    CheckerType trim() const {
+        return CheckerType(trim(this->value()));
+    }
+
+    Checker<size_t, CheckerType> length() const {
+        const std::string &s = this->value();
+        return Checker<size_t, CheckerType>(s.size(), *this);
+    }
+
+    RegExpChecker<CheckerType> matches(const std::string &expr) const;
+};
+
+template<typename WrapperT>
+class Checker<const char*, WrapperT>: public Checker<std::string, WrapperT> {
+public:
+    typedef Checker<std::string, WrapperT> CheckerBaseType;
+
+    using CheckerBaseType::CheckerBaseType;
+};
+
+template<typename WrapperT>
+class RegExpChecker: public detail::CheckerBase<RegExpChecker<WrapperT>, WrapperT> {
+public:
+    typedef RegExpChecker<WrapperT> CheckerType;
+    typedef detail::CheckerBase<CheckerType, WrapperT> CheckerBaseType;
+    typedef typename CheckerBaseType::WrapperType WrapperType;
+
+    template<typename... ArgsT>
+    RegExpChecker(const std::string &str, const std::string &expr, ArgsT&&... args) :
+            CheckerBaseType(std::forward<ArgsT>(args)...),
+            m_(expr) {
+        if (!m_.isValid()) {
+            FAIL("Invalid regular expression: \"" << expr << '"');
+        }
+        if (!m_.match(str)) {
+            FAIL('"' << str << "\" doesn't match \"" << expr << '"');
+        }
+    }
+
+    Checker<std::string, CheckerType> at(size_t i) const {
+        if (i >= m_.size()) {
+            FAIL("Invalid subexpression index: " << i);
+        }
+        return Checker<std::string, CheckerType>(m_.at(i), *this);
+    }
+
+private:
+    RegExpMatcher m_;
+};
+
+template<typename WrapperT>
+inline RegExpChecker<Checker<std::string, WrapperT>> Checker<std::string, WrapperT>::matches(const std::string &expr) const {
+    return RegExpChecker<CheckerType>(this->value(), expr, *this);
+}
+
+template<typename T, typename CheckableT>
+class Checkable: public detail::CheckableBase {
+public:
+    Checker<T> check() const {
+        return Checker<T>((T)static_cast<const CheckableT&>(*this));
+    }
+};
+
+template<typename T, typename CheckableT>
+inline Checker<T> check(const Checkable<T, CheckableT> &c) {
+    return c.check();
+}
+
+template<typename T, typename std::enable_if<!std::is_base_of<detail::CheckableBase, T>::value>::type* = nullptr>
+inline Checker<T> check(const T &value) {
+    return Checker<T>(value);
+}
+
+} // namespace test
+
+using test::check;
+
+#endif // TEST_TOOLS_CHECK_H

--- a/user/tests/unit/tools/random.cpp
+++ b/user/tests/unit/tools/random.cpp
@@ -1,0 +1,50 @@
+#include "random.h"
+
+#include "catch.h"
+
+namespace {
+
+unsigned seed() {
+    std::random_device rd;
+    return rd();
+}
+
+} // namespace
+
+int test::randomInt(int min, int max) {
+    std::uniform_int_distribution<int> dist(min, max);
+    return dist(randomGenerator());
+}
+
+double test::randomDouble(double min, double max) {
+    std::uniform_real_distribution<double> dist(min, max);
+    return dist(randomGenerator());
+}
+
+std::string test::randomString(size_t size) {
+    static const std::string chars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()`~-_=+[{]}\\|;:'\",<.>/? ");
+    auto &gen = randomGenerator();
+    std::uniform_int_distribution<unsigned> dist(0, chars.size() - 1);
+    std::string s;
+    s.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        s += chars.at(dist(gen));
+    }
+    return s;
+}
+
+std::string test::randomBytes(size_t size) {
+    auto &gen = randomGenerator();
+    std::uniform_int_distribution<unsigned> dist(0, 255);
+    std::string s;
+    s.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        s += (char)dist(gen);
+    }
+    return s;
+}
+
+std::default_random_engine& test::randomGenerator() {
+    static /* thread_local */ std::default_random_engine gen(seed());
+    return gen;
+}

--- a/user/tests/unit/tools/random.h
+++ b/user/tests/unit/tools/random.h
@@ -1,0 +1,30 @@
+#ifndef TEST_TOOLS_RANDOM_H
+#define TEST_TOOLS_RANDOM_H
+
+#include <random>
+#include <string>
+#include <vector>
+
+namespace test {
+
+int randomInt(int min, int max); // [min, max]
+double randomDouble(double min, double max); // [min, max)
+
+std::string randomString(size_t size); // Generates printable string
+std::string randomString(size_t minSize, size_t maxSize);
+std::string randomBytes(size_t size);
+std::string randomBytes(size_t minSize, size_t maxSize);
+
+std::default_random_engine& randomGenerator();
+
+} // namespace test
+
+inline std::string test::randomString(size_t minSize, size_t maxSize) {
+    return randomString(randomInt(minSize, maxSize));
+}
+
+inline std::string test::randomBytes(size_t minSize, size_t maxSize) {
+    return randomBytes(randomInt(minSize, maxSize));
+}
+
+#endif // TEST_TOOLS_RANDOM_H

--- a/user/tests/unit/tools/stream.h
+++ b/user/tests/unit/tools/stream.h
@@ -1,0 +1,54 @@
+#ifndef TEST_TOOLS_STREAM_H
+#define TEST_TOOLS_STREAM_H
+
+#include "spark_wiring_print.h"
+
+#include "check.h"
+
+#include <string>
+
+namespace test {
+
+class OutputStream:
+        public Print,
+        public Checkable<std::string, OutputStream> {
+public:
+    OutputStream() = default;
+
+    const char* data() const;
+    size_t size() const;
+
+    virtual size_t write(const uint8_t *data, size_t size) override; // Print
+    virtual size_t write(uint8_t byte) override; // Print
+
+    explicit operator std::string() const; // Required by Checkable mixin
+
+private:
+    std::string s_;
+};
+
+} // namespace test
+
+// test::OutputStream
+inline const char* test::OutputStream::data() const {
+    return s_.c_str();
+}
+
+inline size_t test::OutputStream::size() const {
+    return s_.size();
+}
+
+inline size_t test::OutputStream::write(const uint8_t *data, size_t size) {
+    s_.append((const char*)data, size);
+    return size;
+}
+
+inline size_t test::OutputStream::write(uint8_t byte) {
+    return write(&byte, 1);
+}
+
+inline test::OutputStream::operator std::string() const {
+    return s_;
+}
+
+#endif // TEST_TOOLS_STREAM_H

--- a/user/tests/unit/tools/string.cpp
+++ b/user/tests/unit/tools/string.cpp
@@ -1,0 +1,82 @@
+#include "string.h"
+
+#include "catch.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim_all.hpp>
+#include <boost/algorithm/hex.hpp>
+
+// test::RegExpMatcher
+test::RegExpMatcher::RegExpMatcher(const std::string &expr) {
+    try {
+        r_.assign(expr);
+    } catch (const boost::regex_error&) {
+        CATCH_WARN("test::RegExpMatcher: Invalid expression: " << expr);
+    }
+}
+
+test::RegExpMatcher::RegExpMatcher(const std::string &str, const std::string &expr) :
+        RegExpMatcher(expr) {
+    if (!match(str)) {
+        r_ = boost::regex(); // Invalidate matcher
+    }
+}
+
+bool test::RegExpMatcher::match(const std::string &str) {
+    try {
+        if (r_.empty()) {
+            return false;
+        }
+        boost::smatch m;
+        if (!boost::regex_match(str, m, r_)) {
+            return false;
+        }
+        s_ = str;
+        m_ = m;
+        return true;
+    } catch (boost::regex_error&) {
+        return false;
+    }
+}
+
+std::string test::RegExpMatcher::at(size_t i) const {
+    i += 1; // Skip string matching whole expression
+    if (i >= m_.size()) {
+        return std::string();
+    }
+    return m_.str(i);
+}
+
+size_t test::RegExpMatcher::size() const {
+    if (m_.empty()) {
+        return 0;
+    }
+    return m_.size() - 1;
+}
+
+// test::
+std::string test::trim(const std::string &str) {
+    return boost::algorithm::trim_all_copy(str, std::locale::classic());
+}
+
+std::string test::toLowerCase(const std::string &str) {
+    return boost::algorithm::to_lower_copy(str, std::locale::classic());
+}
+
+std::string test::toUpperCase(const std::string &str) {
+    return boost::algorithm::to_upper_copy(str, std::locale::classic());
+}
+
+std::string test::toHex(const std::string &str) {
+    std::string s = boost::algorithm::hex(str);
+    boost::algorithm::to_lower(s, std::locale::classic());
+    return s;
+}
+
+std::string test::fromHex(const std::string &str) {
+    try {
+        return boost::algorithm::unhex(str);
+    } catch (const boost::algorithm::hex_decode_error&) {
+        return std::string();
+    }
+}

--- a/user/tests/unit/tools/string.h
+++ b/user/tests/unit/tools/string.h
@@ -1,0 +1,50 @@
+#ifndef TEST_TOOLS_STRING_H
+#define TEST_TOOLS_STRING_H
+
+#include <boost/regex.hpp>
+
+#include <string>
+
+namespace test {
+
+class RegExpMatcher {
+public:
+    RegExpMatcher() = default;
+    explicit RegExpMatcher(const std::string &expr);
+    RegExpMatcher(const std::string &str, const std::string &expr);
+
+    bool match(const std::string &str);
+
+    std::string at(size_t i) const;
+
+    size_t size() const;
+    bool isEmpty() const;
+
+    bool isValid() const;
+
+private:
+    boost::regex r_;
+    boost::smatch m_;
+    std::string s_;
+};
+
+std::string trim(const std::string &str);
+
+std::string toLowerCase(const std::string &str);
+std::string toUpperCase(const std::string &str);
+
+std::string toHex(const std::string &str);
+std::string fromHex(const std::string &str);
+
+} // namespace test
+
+// test::RegExpMatcher
+inline bool test::RegExpMatcher::isEmpty() const {
+    return m_.size() <= 1;
+}
+
+inline bool test::RegExpMatcher::isValid() const {
+    return !r_.empty();
+}
+
+#endif // TEST_TOOLS_STRING_H

--- a/user/tests/unit/vector.cpp
+++ b/user/tests/unit/vector.cpp
@@ -1,0 +1,672 @@
+#include "spark_wiring_vector.h"
+
+#include "tools/catch.h"
+#include "tools/alloc.h"
+
+#include <type_traits>
+
+namespace {
+
+template<typename VectorT>
+class Checker {
+public:
+    using T = typename VectorT::ValueType;
+
+    explicit Checker(const VectorT &vector) :
+            v_(vector) {
+    }
+
+    template<typename... ArgsT>
+    const Checker<VectorT>& values(ArgsT... args) const { // Implies size check
+        checkValues(0, args...);
+        return *this;
+    }
+
+    const Checker<VectorT>& size(int size) const {
+        checkSize(size);
+        return *this;
+    }
+
+    const Checker<VectorT>& capacity(int capacity) const {
+        checkCapacity(capacity);
+        return *this;
+    }
+
+private:
+    const VectorT &v_;
+
+    template<typename... ArgsT>
+    void checkValues(int index, const T& value, ArgsT... args) const {
+        REQUIRE(v_.size() > index);
+        REQUIRE(v_.at(index) == value);
+        checkValues(index + 1, args...);
+    }
+
+    void checkValues(int index, const T& value) const {
+        REQUIRE(v_.size() > index);
+        REQUIRE(v_.at(index) == value);
+        checkSize(index + 1);
+    }
+
+    void checkValues(int index) const {
+        checkSize(index);
+    }
+
+    void checkSize(int size) const {
+        REQUIRE(v_.size() == size);
+        REQUIRE(v_.size() <= v_.capacity());
+        if (size > 0) {
+            REQUIRE(v_.isEmpty() == false);
+        } else {
+            REQUIRE(v_.isEmpty() == true);
+        }
+    }
+
+    void checkCapacity(int capacity) const {
+        REQUIRE(v_.capacity() == capacity);
+        REQUIRE(v_.capacity() >= v_.size());
+        if (capacity > 0) {
+            REQUIRE(v_.data() != nullptr);
+        } else {
+            REQUIRE(v_.data() == nullptr);
+        }
+    }
+};
+
+// Non-trivially copyable wrapper for 'int' type
+class NonTrivialInt {
+public:
+    NonTrivialInt() :
+            v_(0) {
+        ++s_count;
+    }
+
+    NonTrivialInt(int value) :
+            v_(value) {
+        ++s_count;
+    }
+
+    NonTrivialInt(const NonTrivialInt &value) :
+            v_(value.v_) {
+        ++s_count;
+    }
+
+    NonTrivialInt(NonTrivialInt&& value) : NonTrivialInt() {
+        swap(*this, value);
+    }
+
+    ~NonTrivialInt() {
+        --s_count;
+    }
+
+    NonTrivialInt& operator=(NonTrivialInt value) {
+        swap(*this, value);
+        return *this;
+    }
+
+    NonTrivialInt& operator=(int value) {
+        v_ = value;
+        return *this;
+    }
+
+    bool operator==(const NonTrivialInt &value) const {
+        return v_ == value.v_;
+    }
+
+    bool operator==(int value) const {
+        return v_ == value;
+    }
+
+    bool operator!=(const NonTrivialInt &value) const {
+        return !(*this == value);
+    }
+
+    bool operator!=(int value) const {
+        return !(*this == value);
+    }
+
+    operator int() const {
+        return v_;
+    }
+
+    static size_t instanceCount() {
+        return s_count;
+    }
+
+private:
+    int v_;
+
+    static size_t s_count;
+
+    friend void swap(NonTrivialInt& value1, NonTrivialInt& value2) {
+        using std::swap;
+        swap(value1.v_, value2.v_);
+    }
+};
+
+size_t NonTrivialInt::s_count = 0;
+
+static_assert(!PARTICLE_VECTOR_TRIVIALLY_COPYABLE_TRAIT<NonTrivialInt>::value, "NonTrivialInt is too trivial!");
+
+template<typename T, typename AllocatorT>
+inline Checker<spark::Vector<T, AllocatorT>> check(const spark::Vector<T, AllocatorT> &vector) {
+    return Checker<spark::Vector<T, AllocatorT>>(vector);
+}
+
+template<typename VectorT>
+void testVector() {
+    using Vector = VectorT;
+    using T = typename Vector::ValueType;
+
+    SECTION("Vector()") {
+        SECTION("Vector()") {
+            const Vector a;
+            check(a).size(0).capacity(0);
+        }
+        SECTION("Vector(int n)") {
+            const Vector a(3); // n = 3
+            check(a).values(0, 0, 0).capacity(3);
+            const Vector b(0); // n = 0
+            check(b).size(0).capacity(0);
+        }
+        SECTION("Vector(int n, const T& value)") {
+            const Vector a(3, 1); // n = 3
+            check(a).values(1, 1, 1).capacity(3);
+            const Vector b(0, T(1)); // n = 0
+            check(b).size(0).capacity(0);
+        }
+        SECTION("Vector(const T* values, int n)") {
+            const T x[] = { 1, 2, 3 };
+            const Vector a(x, 3); // n = 3
+            check(a).values(1, 2, 3).capacity(3);
+            const Vector b(x, 0); // n = 0
+            check(b).size(0).capacity(0);
+        }
+        SECTION("Vector(std::initializer_list<T> values)") {
+            const Vector a({ 1, 2, 3 });
+            check(a).values(1, 2, 3).capacity(3);
+            const Vector b({}); // copy from empty initializer list
+            check(b).size(0).capacity(0);
+        }
+        SECTION("Vector(const Vector<T>& vector)") {
+            const Vector a({ 1, 2, 3 });
+            const Vector b(a);
+            check(b).values(1, 2, 3).capacity(3);
+            check(a).values(1, 2, 3).capacity(3); // source data is not affected
+            const Vector c;
+            const Vector d(c); // copy from empty vector
+            check(d).size(0).capacity(0);
+            check(c).size(0).capacity(0);
+        }
+        SECTION("Vector(Vector<T>&& vector)") {
+            Vector a({ 1, 2, 3 });
+            const Vector b(std::move(a));
+            check(b).values(1, 2, 3).capacity(3);
+            check(a).size(0).capacity(0); // source data has been moved
+            Vector c;
+            const Vector d(std::move(c)); // move from empty vector
+            check(d).size(0).capacity(0);
+            check(c).size(0).capacity(0);
+        }
+    }
+
+    SECTION("append()") {
+        SECTION("append(T value)") {
+            Vector a({ 1, 2, 3 });
+            REQUIRE(a.append(4));
+            check(a).values(1, 2, 3, 4).capacity(4);
+            Vector b;
+            REQUIRE(b.append(1)); // append to empty vector
+            check(b).values(1).capacity(1);
+        }
+        SECTION("append(int n, const T& value)") {
+            Vector a({ 1, 2, 3 });
+            REQUIRE(a.append(0, T(4))); // n = 0
+            check(a).values(1, 2, 3).capacity(3);
+            REQUIRE(a.append(1, 4)); // n = 1
+            check(a).values(1, 2, 3, 4).capacity(4);
+            REQUIRE(a.append(2, 5)); // n = 2
+            check(a).values(1, 2, 3, 4, 5, 5).capacity(6);
+            Vector b;
+            REQUIRE(b.append(3, 1)); // append to empty vector
+            check(b).values(1, 1, 1).capacity(3);
+        }
+        SECTION("append(const T* values, int n)") {
+            const T x[] = { 4 };
+            const T y[] = { 5, 6 };
+            Vector a({ 1, 2, 3 });
+            REQUIRE(a.append(x, 0)); // n = 0
+            check(a).values(1, 2, 3).capacity(3);
+            REQUIRE(a.append(x, 1)); // n = 1
+            check(a).values(1, 2, 3, 4).capacity(4);
+            REQUIRE(a.append(y, 2)); // n = 2
+            check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            Vector b;
+            REQUIRE(b.append(y, 2)); // append to empty vector
+            check(b).values(5, 6).capacity(2);
+        }
+        SECTION("append(const Vector<T>& vector)") {
+            const Vector x({ 1, 2, 3 });
+            const Vector y({ 4, 5, 6 });
+            const Vector z;
+            Vector a;
+            REQUIRE(a.append(x)); // append to empty vector
+            check(a).values(1, 2, 3).capacity(3);
+            REQUIRE(a.append(y));
+            check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            REQUIRE(a.append(z)); // append from empty vector
+            check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+        }
+    }
+
+    SECTION("prepend()") {
+        SECTION("prepend(T value)") {
+            Vector a({ 2, 3, 4 });
+            REQUIRE(a.prepend(1));
+            check(a).values(1, 2, 3, 4).capacity(4);
+            Vector b;
+            REQUIRE(b.prepend(1)); // prepend to empty vector
+            check(b).values(1).capacity(1);
+        }
+        SECTION("prepend(int n, const T& value)") {
+            Vector a({ 3, 4, 5 });
+            REQUIRE(a.prepend(0, T(2))); // n = 0
+            check(a).values(3, 4, 5).capacity(3);
+            REQUIRE(a.prepend(1, 2)); // n = 1
+            check(a).values(2, 3, 4, 5).capacity(4);
+            REQUIRE(a.prepend(2, 1)); // n = 2
+            check(a).values(1, 1, 2, 3, 4, 5).capacity(6);
+            Vector b;
+            REQUIRE(b.prepend(3, 1)); // prepend to empty vector
+            check(b).values(1, 1, 1).capacity(3);
+        }
+        SECTION("prepend(const T* values, int n)") {
+            const T x[] = { 1, 2 };
+            const T y[] = { 3 };
+            Vector a({ 4, 5, 6 });
+            REQUIRE(a.prepend(y, 0)); // n = 0
+            check(a).values(4, 5, 6).capacity(3);
+            REQUIRE(a.prepend(y, 1)); // n = 1
+            check(a).values(3, 4, 5, 6).capacity(4);
+            REQUIRE(a.prepend(x, 2)); // n = 2
+            check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            Vector b;
+            REQUIRE(b.prepend(x, 2)); // prepend to empty vector
+            check(b).values(1, 2).capacity(2);
+        }
+        SECTION("prepend(const Vector<T>& vector)") {
+            const Vector x({ 1, 2, 3 });
+            const Vector y({ 4, 5, 6 });
+            const Vector z;
+            Vector a;
+            REQUIRE(a.prepend(y)); // prepend to empty vector
+            check(a).values(4, 5, 6).capacity(3);
+            REQUIRE(a.prepend(x));
+            check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            REQUIRE(a.prepend(z)); // prepend from empty vector
+            check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+        }
+    }
+
+    SECTION("insert()") {
+        SECTION("insert(int i, T value)") {
+            Vector a({ 2, 4, 5 });
+            REQUIRE(a.insert(0, 1)); // i = 0
+            check(a).values(1, 2, 4, 5).capacity(4);
+            REQUIRE(a.insert(4, 6)); // i = size()
+            check(a).values(1, 2, 4, 5, 6).capacity(5);
+            REQUIRE(a.insert(2, 3)); // i = size() / 2
+            check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            Vector b;
+            REQUIRE(b.insert(0, 1)); // insert to empty vector
+            check(b).values(1).capacity(1);
+        }
+        SECTION("insert(int i, int n, const T& value)") {
+            SECTION("i = 0") {
+                Vector a({ 3, 4, 5 });
+                REQUIRE(a.insert(0, 0, T(2))); // n = 0
+                check(a).values(3, 4, 5).capacity(3);
+                REQUIRE(a.insert(0, 1, 2)); // n = 1
+                check(a).values(2, 3, 4, 5).capacity(4);
+                REQUIRE(a.insert(0, 2, 1)); // n = 2
+                check(a).values(1, 1, 2, 3, 4, 5).capacity(6);
+            }
+            SECTION("i = size()") {
+                Vector a({ 1, 2, 3 });
+                REQUIRE(a.insert(3, 0, T(4))); // n = 0
+                check(a).values(1, 2, 3).capacity(3);
+                REQUIRE(a.insert(3, 1, 4)); // n = 1
+                check(a).values(1, 2, 3, 4).capacity(4);
+                REQUIRE(a.insert(4, 2, 5)); // n = 2
+                check(a).values(1, 2, 3, 4, 5, 5).capacity(6);
+            }
+            SECTION("i = size() / 2") {
+                Vector a({ 1, 4, 5 });
+                REQUIRE(a.insert(1, 0, T(2))); // n = 0
+                check(a).values(1, 4, 5).capacity(3);
+                REQUIRE(a.insert(1, 1, 2)); // n = 1
+                check(a).values(1, 2, 4, 5).capacity(4);
+                REQUIRE(a.insert(2, 2, 3)); // n = 2
+                check(a).values(1, 2, 3, 3, 4, 5).capacity(6);
+            }
+            SECTION("size() == 0") {
+                Vector a;
+                REQUIRE(a.insert(0, 3, 1)); // insert to empty vector
+                check(a).values(1, 1, 1).capacity(3);
+            }
+        }
+        SECTION("insert(int i, const T* value, int n)") {
+            SECTION("i = 0") {
+                const T x[] = { 1, 2 };
+                const T y[] = { 3 };
+                Vector a({ 4, 5, 6 });
+                REQUIRE(a.insert(0, y, 0)); // n = 0
+                check(a).values(4, 5, 6).capacity(3);
+                REQUIRE(a.insert(0, y, 1)); // n = 1
+                check(a).values(3, 4, 5, 6).capacity(4);
+                REQUIRE(a.insert(0, x, 2)); // n = 2
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            }
+            SECTION("i = size()") {
+                const T x[] = { 4 };
+                const T y[] = { 5, 6 };
+                Vector a({ 1, 2, 3 });
+                REQUIRE(a.insert(3, x, 0)); // n = 0
+                check(a).values(1, 2, 3).capacity(3);
+                REQUIRE(a.insert(3, x, 1)); // n = 1
+                check(a).values(1, 2, 3, 4).capacity(4);
+                REQUIRE(a.insert(4, y, 2)); // n = 2
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            }
+            SECTION("i = size() / 2") {
+                const T x[] = { 2 };
+                const T y[] = { 3, 4 };
+                Vector a({ 1, 5, 6 });
+                REQUIRE(a.insert(1, x, 0)); // n = 0
+                check(a).values(1, 5, 6).capacity(3);
+                REQUIRE(a.insert(1, x, 1)); // n = 1
+                check(a).values(1, 2, 5, 6).capacity(4);
+                REQUIRE(a.insert(2, y, 2)); // n = 2
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            }
+            SECTION("size() == 0") {
+                const T x[] = { 1, 2, 3 };
+                Vector a;
+                REQUIRE(a.insert(0, x, 3)); // insert to empty vector
+                check(a).values(1, 2, 3).capacity(3);
+            }
+        }
+        SECTION("insert(int i, const Vector<T>& vector)") {
+            SECTION("i = 0") {
+                const Vector x({ 1, 2, 3 });
+                const Vector y;
+                Vector a({ 4, 5, 6 });
+                REQUIRE(a.insert(0, x));
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+                REQUIRE(a.insert(0, y)); // insert from empty vector
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            }
+            SECTION("i = size()") {
+                const Vector x({ 4, 5, 6 });
+                const Vector y;
+                Vector a({ 1, 2, 3 });
+                REQUIRE(a.insert(3, x));
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+                REQUIRE(a.insert(6, y)); // insert from empty vector
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            }
+            SECTION("i = size() / 2") {
+                const Vector x({ 2, 3, 4 });
+                const Vector y;
+                Vector a({ 1, 5, 6 });
+                REQUIRE(a.insert(1, x));
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+                REQUIRE(a.insert(3, y)); // insert from empty vector
+                check(a).values(1, 2, 3, 4, 5, 6).capacity(6);
+            }
+            SECTION("size() == 0") {
+                const Vector x({ 1, 2, 3 });
+                Vector a;
+                REQUIRE(a.insert(0, x)); // insert to empty vector
+                check(a).values(1, 2, 3).capacity(3);
+            }
+        }
+    }
+
+    SECTION("removeAt(int i, int n)") {
+        SECTION("i == 0 && n <= size()") {
+            Vector a({ 1, 2, 3, 4 });
+            a.removeAt(0, 0); // n = 0
+            check(a).values(1, 2, 3, 4).capacity(4);
+            a.removeAt(0); // n = 1 (default value)
+            check(a).values(2, 3, 4).capacity(4);
+            a.removeAt(0, 2); // n = 2
+            check(a).values(4).capacity(4);
+            a.removeAt(0, 1); // remaining element
+            check(a).size(0).capacity(4);
+        }
+        SECTION("i > 0 && i + n == size()") {
+            Vector a({ 1, 2, 3, 4 });
+            a.removeAt(4, 0); // n = 0
+            check(a).values(1, 2, 3, 4).capacity(4);
+            a.removeAt(3); // n = 1
+            check(a).values(1, 2, 3).capacity(4);
+            a.removeAt(1, 2); // n = 2
+            check(a).values(1).capacity(4);
+        }
+        SECTION("i > 0 && i + n < size()") {
+            Vector a({ 1, 2, 3, 4, 5 });
+            a.removeAt(2, 0); // n = 0
+            check(a).values(1, 2, 3, 4, 5).capacity(5);
+            a.removeAt(2); // n = 1
+            check(a).values(1, 2, 4, 5).capacity(5);
+            a.removeAt(1, 2); // n = 2
+            check(a).values(1, 5).capacity(5);
+        }
+        SECTION("n < 0 || n > size() - i") {
+            Vector a({ 1, 2, 3, 4, 5 });
+            a.removeAt(3, -1); // n = -1
+            check(a).values(1, 2, 3).capacity(5);
+            a.removeAt(1, 10); // n = 10
+            check(a).values(1).capacity(5);
+        }
+    }
+
+    SECTION("removeOne(const T& value)") {
+        Vector a({ 1, 2, 3, 1 });
+        REQUIRE(!a.removeOne(4)); // not found
+        REQUIRE(a.removeOne(1));
+        check(a).values(2, 3, 1).capacity(4);
+        REQUIRE(a.removeOne(3));
+        check(a).values(2, 1).capacity(4);
+        REQUIRE(a.removeOne(1));
+        check(a).values(2).capacity(4);
+        REQUIRE(a.removeOne(2));
+        check(a).size(0).capacity(4);
+        REQUIRE(!a.removeOne(1)); // remove from empty array
+    }
+
+    SECTION("removeAll(const T& value)") {
+        Vector a({ 1, 2, 3, 2, 1 });
+        REQUIRE(a.removeAll(4) == 0); // not found
+        REQUIRE(a.removeAll(1) == 2);
+        check(a).values(2, 3, 2).capacity(5);
+        REQUIRE(a.removeAll(3) == 1);
+        check(a).values(2, 2).capacity(5);
+        REQUIRE(a.removeAll(2) == 2);
+        check(a).size(0).capacity(5);
+        REQUIRE(a.removeAll(1) == 0); // remove from empty array
+    }
+
+    SECTION("takeFirst()") {
+        Vector a({ 1, 2, 3 });
+        REQUIRE(a.takeFirst() == 1);
+        check(a).values(2, 3).capacity(3);
+        REQUIRE(a.takeFirst() == 2);
+        check(a).values(3).capacity(3);
+        REQUIRE(a.takeFirst() == 3);
+        check(a).size(0).capacity(3);
+    }
+
+    SECTION("takeLast()") {
+        Vector a({ 1, 2, 3 });
+        REQUIRE(a.takeLast() == 3);
+        check(a).values(1, 2).capacity(3);
+        REQUIRE(a.takeLast() == 2);
+        check(a).values(1).capacity(3);
+        REQUIRE(a.takeLast() == 1);
+        check(a).size(0).capacity(3);
+    }
+
+    SECTION("takeAt(int i)") {
+        Vector a({ 1, 2, 3 });
+        REQUIRE(a.takeAt(1) == 2);
+        check(a).values(1, 3).capacity(3);
+        REQUIRE(a.takeAt(1) == 3);
+        check(a).values(1).capacity(3);
+        REQUIRE(a.takeAt(0) == 1);
+        check(a).size(0).capacity(3);
+    }
+
+    SECTION("first()") {
+        const Vector a({ 1, 2, 3});
+        REQUIRE(a.first() == 1);
+        Vector b({ 4, 5, 6 });
+        REQUIRE(b.first() == 4);
+        b.first() = 5;
+        check(b).values(5, 5, 6);
+    }
+
+    SECTION("last()") {
+        const Vector a({ 1, 2, 3});
+        REQUIRE(a.last() == 3);
+        Vector b({ 4, 5, 6 });
+        REQUIRE(b.last() == 6);
+        b.last() = 5;
+        check(b).values(4, 5, 5);
+    }
+
+    SECTION("at(int i)") {
+        const Vector a({ 1, 2, 3});
+        REQUIRE(a.at(1) == 2);
+        Vector b({ 4, 5, 6 });
+        REQUIRE(b.at(1) == 5);
+        b.at(1) = 4;
+        check(b).values(4, 4, 6);
+    }
+
+    SECTION("copy(int i, int n)") {
+        SECTION("i == 0 && n <= size()") {
+            const Vector a({ 1, 2 });
+            check(a.copy(0, 0)).size(0).capacity(0); // n = 0
+            check(a.copy(0, 1)).values(1).capacity(1); // n = 1
+            check(a.copy(0, 2)).values(1, 2).capacity(2); // n = 2
+        }
+        SECTION("i > 0 && i + n == size()") {
+            const Vector a({ 1, 2, 3 });
+            check(a.copy(3, 0)).size(0).capacity(0); // n = 0
+            check(a.copy(2, 1)).values(3).capacity(1); // n = 1
+            check(a.copy(1, 2)).values(2, 3).capacity(2); // n = 2
+        }
+        SECTION("i > 0 && i + n < size()") {
+            const Vector a({ 1, 2, 3, 4 });
+            check(a.copy(2, 0)).size(0).capacity(0); // n = 0
+            check(a.copy(2, 1)).values(3).capacity(1); // n = 1
+            check(a.copy(1, 2)).values(2, 3).capacity(2); // n = 2
+        }
+        SECTION("n < 0 || n > size() - i") {
+            const Vector a({ 1, 2, 3, 4, 5 });
+            check(a.copy(3, -1)).values(4, 5).capacity(2); // n = -1
+            check(a.copy(1, 10)).values(2, 3, 4, 5).capacity(4); // n = 10
+        }
+    }
+
+    SECTION("indexOf(const T& value, int i)") {
+        const Vector a({ 1, 2, 3, 2, 1 });
+        REQUIRE(a.indexOf(1) == 0); // i = 0 (default value)
+        REQUIRE(a.indexOf(1, 2) == 4); // i = 2
+        REQUIRE(a.indexOf(3) == 2);
+        REQUIRE(a.indexOf(4) == -1); // not found
+        const Vector b;
+        REQUIRE(b.indexOf(1) == -1); // search in empty array
+    }
+
+    SECTION("lastIndexOf(const T& value, int i)") {
+        const Vector a({ 1, 2, 3, 2, 1 });
+        REQUIRE(a.lastIndexOf(1) == 4); // i = size() - 1 (default value)
+        REQUIRE(a.lastIndexOf(1, 2) == 0); // i = 2
+        REQUIRE(a.lastIndexOf(3) == 2);
+        REQUIRE(a.lastIndexOf(4) == -1); // not found
+        const Vector b;
+        REQUIRE(b.lastIndexOf(1) == -1); // search in empty array
+    }
+
+    SECTION("contains(const T& value)") {
+        const Vector a({ 1, 2, 3, 2, 1 });
+        REQUIRE(a.contains(1));
+        REQUIRE(a.contains(3));
+        REQUIRE(!a.contains(4)); // not found
+        const Vector b;
+        REQUIRE(!b.contains(1)); // search in empty array
+    }
+
+    SECTION("fill(const T& value)") {
+        Vector a({ 1, 2, 3 });
+        check(a.fill(0)).values(0, 0, 0).capacity(3); // returns *this
+        check(a).values(0, 0, 0).capacity(3);
+        Vector b;
+        b.fill(0); // fill empty array
+        check(b).size(0).capacity(0);
+    }
+
+    SECTION("resize(int n") {
+        Vector a({ 1, 2, 3 });
+        check(a).size(3).capacity(3);
+        REQUIRE(a.resize(3)); // resize to the same size
+        check(a).size(3).capacity(3);
+        REQUIRE(a.resize(5));
+        check(a).values(1, 2, 3, 0, 0).capacity(5); // default-constructed elements
+        REQUIRE(a.resize(2));
+        check(a).values(1, 2).capacity(5);
+        REQUIRE(a.resize(4));
+        check(a).values(1, 2, 0, 0).capacity(5);
+        REQUIRE(a.resize(0));
+        check(a).size(0).capacity(5);
+        REQUIRE(a.resize(3)); // resize empty array
+        check(a).values(0, 0, 0).capacity(5);
+    }
+
+    SECTION("reserve(int n") {
+        Vector a({ 1, 2, 3 });
+        check(a).size(3).capacity(3);
+        REQUIRE(a.reserve(3)); // reserve the same capacity
+        check(a).size(3).capacity(3);
+        REQUIRE(a.reserve(5));
+        check(a).size(3).capacity(5);
+        REQUIRE(a.reserve(2));
+        check(a).size(3).capacity(5);
+        REQUIRE(a.append(4));
+        check(a).values(1, 2, 3, 4).capacity(5);
+    }
+}
+
+} // namespace
+
+TEST_CASE("Vector<int>") {
+    test::DefaultAllocator::reset();
+
+    using Vector = spark::Vector<int, test::DefaultAllocator>;
+    testVector<Vector>();
+
+    test::DefaultAllocator::check();
+}
+
+TEST_CASE("Vector<NonTrivialInt>") {
+    test::DefaultAllocator::reset();
+
+    using Vector = spark::Vector<NonTrivialInt, test::DefaultAllocator>;
+    testVector<Vector>();
+
+    test::DefaultAllocator::check();
+    CHECK(NonTrivialInt::instanceCount() == 0);
+}

--- a/wiring/inc/spark_wiring_json.h
+++ b/wiring/inc/spark_wiring_json.h
@@ -242,10 +242,6 @@ inline spark::JSONValue::JSONValue() :
         t_(nullptr) {
 }
 
-inline int spark::JSONValue::toInt() const {
-    return toDouble();
-}
-
 inline spark::JSONString spark::JSONValue::toString() const {
     return JSONString(t_, d_);
 }

--- a/wiring/inc/spark_wiring_json.h
+++ b/wiring/inc/spark_wiring_json.h
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SPARK_WIRING_JSON_H
+#define SPARK_WIRING_JSON_H
+
+#include "spark_wiring_print.h"
+#include "spark_wiring_string.h"
+
+#include "jsmn.h"
+
+#include <cstring>
+#include <memory>
+
+namespace spark {
+
+namespace detail {
+
+struct JSONData; // Parsed JSON data
+typedef std::shared_ptr<JSONData> JSONDataPtr;
+
+} // namespace spark::detail
+
+enum JSONType {
+    JSON_TYPE_INVALID,
+    JSON_TYPE_NULL,
+    JSON_TYPE_BOOL,
+    JSON_TYPE_NUMBER,
+    JSON_TYPE_STRING,
+    JSON_TYPE_ARRAY,
+    JSON_TYPE_OBJECT
+};
+
+class JSONString;
+class JSONArrayIterator;
+class JSONObjectIterator;
+
+// Immutable JSON value
+class JSONValue {
+public:
+    JSONValue(); // Constructs invalid value
+
+    bool toBool() const;
+    int toInt() const;
+    double toDouble() const;
+    JSONString toString() const;
+
+    JSONType type() const;
+
+    bool isNull() const;
+    bool isBool() const;
+    bool isNumber() const;
+    bool isString() const;
+    bool isArray() const;
+    bool isObject() const;
+
+    bool isValid() const;
+
+    static JSONValue parse(char *json, size_t size);
+    static JSONValue parseCopy(const char *json, size_t size);
+    static JSONValue parseCopy(const char *json);
+
+private:
+    detail::JSONDataPtr d_;
+    const jsmntok_t *t_; // Token representing this value
+
+    JSONValue(const jsmntok_t *token, detail::JSONDataPtr data);
+
+    static bool tokenize(const char *json, size_t size, jsmntok_t **tokens, size_t *count);
+    static bool stringize(jsmntok_t *tokens, size_t count, char *json);
+    static bool unescape(jsmntok_t *token, char *json);
+
+    friend class JSONString;
+    friend class JSONArrayIterator;
+    friend class JSONObjectIterator;
+};
+
+class JSONString {
+public:
+    JSONString();
+    explicit JSONString(const JSONValue &value);
+
+    const char* data() const; // Returns null-terminated string
+
+    size_t size() const;
+    bool isEmpty() const;
+
+    bool operator==(const char *str) const;
+    bool operator!=(const char *str) const;
+    bool operator==(const String &str) const;
+    bool operator!=(const String &str) const;
+    bool operator==(const JSONString &str) const;
+    bool operator!=(const JSONString &str) const;
+
+    explicit operator const char*() const;
+    explicit operator String() const;
+
+private:
+    detail::JSONDataPtr d_;
+    const char *s_;
+    size_t n_;
+
+    JSONString(const jsmntok_t *token, detail::JSONDataPtr data);
+
+    friend class JSONValue;
+    friend class JSONObjectIterator;
+};
+
+class JSONArrayIterator {
+public:
+    JSONArrayIterator();
+    explicit JSONArrayIterator(const JSONValue &value);
+
+    bool next();
+
+    JSONValue value() const;
+
+    size_t count() const; // Returns number of remaining elements
+
+private:
+    detail::JSONDataPtr d_;
+    const jsmntok_t *t_, *v_;
+    size_t n_;
+
+    JSONArrayIterator(const jsmntok_t *token, detail::JSONDataPtr data);
+};
+
+class JSONObjectIterator {
+public:
+    JSONObjectIterator();
+    explicit JSONObjectIterator(const JSONValue &value);
+
+    bool next();
+
+    JSONString name() const;
+    JSONValue value() const;
+
+    size_t count() const; // Returns number of remaining elements
+
+private:
+    detail::JSONDataPtr d_;
+    const jsmntok_t *t_, *k_, *v_;
+    size_t n_;
+
+    JSONObjectIterator(const jsmntok_t *token, detail::JSONDataPtr data);
+};
+
+// Abstract JSON document writer
+class JSONWriter {
+public:
+    JSONWriter();
+    virtual ~JSONWriter() = default;
+
+    JSONWriter& beginArray();
+    JSONWriter& endArray();
+    JSONWriter& beginObject();
+    JSONWriter& endObject();
+    JSONWriter& name(const char *name);
+    JSONWriter& name(const char *name, size_t size);
+    JSONWriter& name(const String &name);
+    JSONWriter& value(bool val);
+    JSONWriter& value(int val);
+    JSONWriter& value(unsigned val);
+    JSONWriter& value(double val);
+    JSONWriter& value(const char *val);
+    JSONWriter& value(const char *val, size_t size);
+    JSONWriter& value(const String &val);
+    JSONWriter& nullValue();
+
+protected:
+    virtual void write(const char *data, size_t size) = 0;
+    virtual void printf(const char *fmt, ...);
+
+private:
+    enum State {
+        BEGIN, // Beginning of a document or a compound value
+        NEXT, // Expecting next element of a compound value
+        VALUE // Expecting value of an object's property
+    };
+
+    State state_;
+
+    void writeSeparator();
+    void writeEscaped(const char *data, size_t size);
+    void write(char c);
+};
+
+class JSONStreamWriter: public JSONWriter {
+public:
+    explicit JSONStreamWriter(Print &stream);
+
+    Print* stream() const;
+
+protected:
+    virtual void write(const char *data, size_t size) override;
+
+private:
+    Print &strm_;
+};
+
+class JSONBufferWriter: public JSONWriter {
+public:
+    JSONBufferWriter(char *buf, size_t size);
+
+    char* buffer() const;
+    size_t bufferSize() const;
+
+    size_t dataSize() const; // Returned value can be greater than buffer size
+
+protected:
+    virtual void write(const char *data, size_t size) override;
+    virtual void printf(const char *fmt, ...) override;
+
+private:
+    char *buf_;
+    size_t bufSize_, n_;
+};
+
+bool operator==(const char *str1, const JSONString &str2);
+bool operator!=(const char *str1, const JSONString &str2);
+bool operator==(const String &str1, const JSONString &str2);
+bool operator!=(const String &str1, const JSONString &str2);
+
+} // namespace spark
+
+// spark::JSONValue
+inline spark::JSONValue::JSONValue() :
+        t_(nullptr) {
+}
+
+inline int spark::JSONValue::toInt() const {
+    return toDouble();
+}
+
+inline spark::JSONString spark::JSONValue::toString() const {
+    return JSONString(t_, d_);
+}
+
+inline bool spark::JSONValue::isNull() const {
+    return type() == JSON_TYPE_NULL;
+}
+
+inline bool spark::JSONValue::isBool() const {
+    return type() == JSON_TYPE_BOOL;
+}
+
+inline bool spark::JSONValue::isNumber() const {
+    return type() == JSON_TYPE_NUMBER;
+}
+
+inline bool spark::JSONValue::isString() const {
+    return type() == JSON_TYPE_STRING;
+}
+
+inline bool spark::JSONValue::isArray() const {
+    return type() == JSON_TYPE_ARRAY;
+}
+
+inline bool spark::JSONValue::isObject() const {
+    return type() == JSON_TYPE_OBJECT;
+}
+
+inline bool spark::JSONValue::isValid() const {
+    return type() != JSON_TYPE_INVALID;
+}
+
+inline spark::JSONValue spark::JSONValue::parseCopy(const char *json) {
+    return parseCopy(json, strlen(json));
+}
+
+// spark::JSONString
+inline spark::JSONString::JSONString() :
+        s_(""),
+        n_(0) {
+}
+
+inline spark::JSONString::JSONString(const JSONValue &value) :
+        JSONString(value.t_, value.d_) {
+}
+
+inline const char* spark::JSONString::data() const {
+    return s_;
+}
+
+inline size_t spark::JSONString::size() const {
+    return n_;
+}
+
+inline bool spark::JSONString::isEmpty() const {
+    return !n_;
+}
+
+inline bool spark::JSONString::operator==(const char *str) const {
+    return strcmp(s_, str) == 0;
+}
+
+inline bool spark::JSONString::operator!=(const char *str) const {
+    return !operator==(str);
+}
+
+inline bool spark::JSONString::operator!=(const String &str) const {
+    return !operator==(str);
+}
+
+inline bool spark::JSONString::operator!=(const JSONString &str) const {
+    return !operator==(str);
+}
+
+inline spark::JSONString::operator const char*() const {
+    return s_;
+}
+
+inline spark::JSONString::operator String() const {
+    return String(s_, n_);
+}
+
+// spark::JSONArrayIterator
+inline spark::JSONArrayIterator::JSONArrayIterator() :
+        t_(nullptr),
+        v_(nullptr),
+        n_(0) {
+}
+
+inline spark::JSONArrayIterator::JSONArrayIterator(const JSONValue &value) :
+        JSONArrayIterator(value.t_, value.d_) {
+}
+
+inline spark::JSONValue spark::JSONArrayIterator::value() const {
+    return JSONValue(v_, d_);
+}
+
+inline size_t spark::JSONArrayIterator::count() const {
+    return n_;
+}
+
+// spark::JSONObjectIterator
+inline spark::JSONObjectIterator::JSONObjectIterator() :
+        t_(nullptr),
+        k_(nullptr),
+        v_(nullptr),
+        n_(0) {
+}
+
+inline spark::JSONObjectIterator::JSONObjectIterator(const JSONValue &value) :
+        JSONObjectIterator(value.t_, value.d_) {
+}
+
+inline spark::JSONString spark::JSONObjectIterator::name() const {
+    return JSONString(k_, d_);
+}
+
+inline spark::JSONValue spark::JSONObjectIterator::value() const {
+    return JSONValue(v_, d_);
+}
+
+inline size_t spark::JSONObjectIterator::count() const {
+    return n_;
+}
+
+// spark::JSONWriter
+inline spark::JSONWriter::JSONWriter() :
+        state_(BEGIN) {
+}
+
+inline spark::JSONWriter& spark::JSONWriter::name(const char *name) {
+    return this->name(name, strlen(name));
+}
+
+inline spark::JSONWriter& spark::JSONWriter::name(const String &name) {
+    return this->name(name.c_str(), name.length());
+}
+
+inline spark::JSONWriter& spark::JSONWriter::value(const char *val) {
+    return value(val, strlen(val));
+}
+
+inline spark::JSONWriter& spark::JSONWriter::value(const String &val) {
+    return value(val.c_str(), val.length());
+}
+
+inline void spark::JSONWriter::write(char c) {
+    write(&c, 1);
+}
+
+// spark::JSONStreamWriter
+inline spark::JSONStreamWriter::JSONStreamWriter(Print &stream) :
+        strm_(stream) {
+}
+
+inline Print* spark::JSONStreamWriter::stream() const {
+    return &strm_;
+}
+
+inline void spark::JSONStreamWriter::write(const char *data, size_t size) {
+    strm_.write((const uint8_t*)data, size);
+}
+
+// spark::JSONBufferWriter
+inline spark::JSONBufferWriter::JSONBufferWriter(char *buf, size_t size) :
+        buf_(buf),
+        bufSize_(size),
+        n_(0) {
+}
+
+inline char* spark::JSONBufferWriter::buffer() const {
+    return buf_;
+}
+
+inline size_t spark::JSONBufferWriter::bufferSize() const {
+    return bufSize_;
+}
+
+inline size_t spark::JSONBufferWriter::dataSize() const {
+    return n_;
+}
+
+// spark::
+inline bool spark::operator==(const char *str1, const JSONString &str2) {
+    return str2 == str1;
+}
+
+inline bool spark::operator!=(const char *str1, const JSONString &str2) {
+    return str2 != str1;
+}
+
+inline bool spark::operator==(const String &str1, const JSONString &str2) {
+    return str2 == str1;
+}
+
+inline bool spark::operator!=(const String &str1, const JSONString &str2) {
+    return str2 != str1;
+}
+
+#endif // SPARK_WIRING_JSON_H

--- a/wiring/inc/spark_wiring_string.h
+++ b/wiring/inc/spark_wiring_string.h
@@ -63,6 +63,7 @@ public:
 	// fails, the string will be marked as invalid (i.e. "if (s)" will
 	// be false).
 	String(const char *cstr = "");
+	String(const char *cstr, unsigned int length);
 	String(const String &str);
         String(const Printable& printable);
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__

--- a/wiring/inc/spark_wiring_vector.h
+++ b/wiring/inc/spark_wiring_vector.h
@@ -1,0 +1,669 @@
+/*
+ * Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SPARK_WIRING_VECTOR_H
+#define SPARK_WIRING_VECTOR_H
+
+#include <cstring>
+#include <cstdlib>
+#include <type_traits>
+#include <iterator>
+#include <utility>
+
+// GCC didn't support std::is_trivially_copyable trait until 5.1.0
+#if defined(__GNUC__) && (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 < 50100)
+#define PARTICLE_VECTOR_TRIVIALLY_COPYABLE_TRAIT std::is_pod
+#else
+#define PARTICLE_VECTOR_TRIVIALLY_COPYABLE_TRAIT std::is_trivially_copyable
+#endif
+
+// Helper macros for SFINAE-based method selection
+#define PARTICLE_VECTOR_ENABLE_IF_TRIVIALLY_COPYABLE(T) \
+        typename EnableT = T, typename std::enable_if<PARTICLE_VECTOR_TRIVIALLY_COPYABLE_TRAIT<EnableT>::value, int>::type = 0
+
+#define PARTICLE_VECTOR_ENABLE_IF_NOT_TRIVIALLY_COPYABLE(T) \
+        typename EnableT = T, typename std::enable_if<!PARTICLE_VECTOR_TRIVIALLY_COPYABLE_TRAIT<EnableT>::value, int>::type = 0
+
+namespace spark {
+
+struct DefaultAllocator {
+    static void* malloc(size_t size);
+    static void* realloc(void* ptr, size_t size);
+    static void free(void* ptr);
+};
+
+template<typename T, typename AllocatorT = DefaultAllocator>
+class Vector {
+public:
+    typedef T ValueType;
+    typedef AllocatorT AllocatorType;
+
+    Vector();
+    explicit Vector(int n);
+    Vector(int n, const T& value);
+    Vector(const T* values, int n);
+    Vector(std::initializer_list<T> values);
+    Vector(const Vector<T, AllocatorT>& vector);
+    Vector(Vector<T, AllocatorT>&& vector);
+    ~Vector();
+
+    bool append(T value);
+    bool append(int n, const T& value);
+    bool append(const T* values, int n);
+    bool append(const Vector<T, AllocatorT>& vector);
+
+    bool prepend(T value);
+    bool prepend(int n, const T& value);
+    bool prepend(const T* values, int n);
+    bool prepend(const Vector<T, AllocatorT>& vector);
+
+    bool insert(int i, T value);
+    bool insert(int i, int n, const T& value);
+    bool insert(int i, const T* values, int n);
+    bool insert(int i, const Vector<T, AllocatorT>& vector);
+
+    void removeAt(int i, int n = 1);
+    bool removeOne(const T& value);
+    int removeAll(const T& value);
+
+    T takeFirst();
+    T takeLast();
+    T takeAt(int i);
+
+    T& first();
+    const T& first() const;
+    T& last();
+    const T& last() const;
+    T& at(int i);
+    const T& at(int i) const;
+
+    Vector<T, AllocatorT> copy(int i, int n) const;
+
+    int indexOf(const T& value, int i = 0) const;
+    int lastIndexOf(const T& value) const;
+    int lastIndexOf(const T& value, int i) const;
+
+    bool contains(const T& value) const;
+
+    Vector<T, AllocatorT>& fill(const T& value);
+
+    bool resize(int n);
+    int size() const;
+    bool isEmpty() const;
+
+    bool reserve(int n);
+    int capacity() const;
+    bool trimToSize();
+
+    void clear();
+
+    T* data();
+    const T* data() const;
+
+    T* begin();
+    const T* begin() const;
+    T* end();
+    const T* end() const;
+
+    T& operator[](int i);
+    const T& operator[](int i) const;
+
+    bool operator==(const Vector<T, AllocatorT> &vector) const;
+    bool operator!=(const Vector<T, AllocatorT> &vector) const;
+
+    Vector<T, AllocatorT>& operator=(Vector<T, AllocatorT> vector);
+
+private:
+    T* data_;
+    int size_, capacity_;
+
+    template<PARTICLE_VECTOR_ENABLE_IF_TRIVIALLY_COPYABLE(T)>
+    bool realloc(int n) {
+        T* d = nullptr;
+        if (n > 0) {
+            d = (T*)AllocatorT::realloc(data_, n * sizeof(T));
+            if (!d) {
+                return false;
+            }
+        } else {
+            AllocatorT::free(data_);
+        }
+        data_ = d;
+        capacity_ = n;
+        return true;
+    }
+
+    template<PARTICLE_VECTOR_ENABLE_IF_NOT_TRIVIALLY_COPYABLE(T)>
+    bool realloc(int n) {
+        T* d = nullptr;
+        if (n > 0) {
+            d = (T*)AllocatorT::malloc(n * sizeof(T));
+            if (!d) {
+                return false;
+            }
+            move(d, data_, data_ + size_);
+        }
+        AllocatorT::free(data_);
+        data_ = d;
+        capacity_ = n;
+        return true;
+    }
+
+    // TODO: Use standard algorithms like std::uninitialized_copy() and std::uninitialized_move()
+    // instead of custom implementations
+    template<PARTICLE_VECTOR_ENABLE_IF_TRIVIALLY_COPYABLE(T)>
+    static void copy(T* dest, const T* p, const T* end) {
+        ::memcpy(dest, p, (end - p) * sizeof(T));
+    }
+
+    template<PARTICLE_VECTOR_ENABLE_IF_NOT_TRIVIALLY_COPYABLE(T)>
+    static void copy(T* dest, const T* p, const T* end) {
+        for (; p != end; ++p, ++dest) {
+            new(dest) T(*p);
+        }
+    }
+
+    template<typename IteratorT>
+    static void copy(IteratorT dest, IteratorT it, IteratorT end) {
+        for (; it != end; ++it, ++dest) {
+            new(dest) T(*it);
+        }
+    }
+
+    template<PARTICLE_VECTOR_ENABLE_IF_TRIVIALLY_COPYABLE(T)>
+    static void move(T* dest, const T* p, const T* end) {
+        ::memmove(dest, p, (end - p) * sizeof(T));
+    }
+
+    template<PARTICLE_VECTOR_ENABLE_IF_NOT_TRIVIALLY_COPYABLE(T)>
+    static void move(T* dest, T* p, T* end) {
+        if (dest > p && dest < end) {
+            // Move elements in reverse order
+            --p;
+            --end;
+            dest += end - p - 1;
+            for (; end != p; --end, --dest) {
+                new(dest) T(std::move(*end));
+                end->~T();
+            }
+        } else if (dest != p) {
+            for (; p != end; ++p, ++dest) {
+                new(dest) T(std::move(*p));
+                p->~T();
+            }
+        }
+    }
+
+    static T* find(T* p, const T* end, const T& value) {
+        for (; p != end; ++p) {
+            if (*p == value) {
+                return p;
+            }
+        }
+        return nullptr;
+    }
+
+    static T* rfind(T* p, const T* end, const T& value) {
+        for (; p != end; --p) {
+            if (*p == value) {
+                return p;
+            }
+        }
+        return nullptr;
+    }
+
+    template<typename... ArgsT>
+    static void construct(T* p, const T* end, ArgsT&&... args) {
+        for (; p != end; ++p) {
+            new(p) T(std::forward<ArgsT>(args)...);
+        }
+    }
+
+    static void destruct(T* p, const T* end) {
+        for (; p != end; ++p) {
+            p->~T();
+        }
+    }
+
+    template<typename V, typename A>
+    friend void swap(Vector<V, A>& vector, Vector<V, A>& vector2);
+};
+
+template<typename T, typename AllocatorT>
+void swap(Vector<T, AllocatorT>& vector, Vector<T, AllocatorT>& vector2);
+
+} // namespace spark
+
+// spark::DefaultAllocator
+inline void* spark::DefaultAllocator::malloc(size_t size) {
+    return ::malloc(size);
+}
+
+inline void* spark::DefaultAllocator::realloc(void* ptr, size_t size) {
+    return ::realloc(ptr, size);
+}
+
+inline void spark::DefaultAllocator::free(void* ptr) {
+    ::free(ptr);
+}
+
+// spark::Vector
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::Vector() :
+        data_(nullptr),
+        size_(0),
+        capacity_(0) {
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::Vector(int n) : Vector() {
+    if (n > 0 && realloc(n)) {
+        construct(data_, data_ + n);
+        size_ = n;
+    }
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::Vector(int n, const T& value) : Vector() {
+    if (n > 0 && realloc(n)) {
+        construct(data_, data_ + n, value);
+        size_ = n;
+    }
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::Vector(const T* values, int n) : Vector() {
+    if (n > 0 && realloc(n)) {
+        copy(data_, values, values + n);
+        size_ = n;
+    }
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::Vector(std::initializer_list<T> values) : Vector() {
+    const size_t n = values.size();
+    if (n > 0 && realloc(n)) {
+        copy(data_, values.begin(), values.end());
+        size_ = n;
+    }
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::Vector(const Vector<T, AllocatorT>& vector) : Vector() {
+    if (vector.size_ > 0 && realloc(vector.size_)) {
+        copy(data_, vector.data_, vector.data_ + vector.size_);
+        size_ = vector.size_;
+    }
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::Vector(Vector<T, AllocatorT>&& vector) : Vector() {
+    swap(*this, vector);
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>::~Vector() {
+    destruct(data_, data_ + size_);
+    AllocatorT::free(data_);
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::append(T value) {
+    return insert(size_, std::move(value));
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::append(int n, const T& value) {
+    return insert(size_, n, value);
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::append(const T* values, int n) {
+    return insert(size_, values, n);
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::append(const Vector<T, AllocatorT> &vector) {
+    return insert(size_, vector);
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::prepend(T value) {
+    return insert(0, std::move(value));
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::prepend(int n, const T& value) {
+    return insert(0, n, value);
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::prepend(const T* values, int n) {
+    return insert(0, values, n);
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::prepend(const Vector<T, AllocatorT> &vector) {
+    return insert(0, vector);
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::insert(int i, T value) {
+    if (size_ + 1 > capacity_ && !realloc(size_ + 1)) {
+        return false;
+    }
+    T* const p = data_ + i;
+    move(p + 1, p, data_ + size_);
+    new(p) T(std::move(value));
+    ++size_;
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::insert(int i, int n, const T& value) {
+    if (size_ + n > capacity_ && !realloc(size_ + n)) {
+        return false;
+    }
+    T* const p = data_ + i;
+    move(p + n, p, data_ + size_);
+    construct(p, p + n, value);
+    size_ += n;
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::insert(int i, const T* values, int n) {
+    if (size_ + n > capacity_ && !realloc(size_ + n)) {
+        return false;
+    }
+    T* const p = data_ + i;
+    move(p + n, p, data_ + size_);
+    copy(p, values, values + n);
+    size_ += n;
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::insert(int i, const Vector<T, AllocatorT> &vector) {
+    return insert(i, vector.data_, vector.size_);
+}
+
+template<typename T, typename AllocatorT>
+inline void spark::Vector<T, AllocatorT>::removeAt(int i, int n) {
+    if (n < 0 || i + n > size_) {
+        n = size_ - i;
+    }
+    T* const p = data_ + i;
+    destruct(p, p + n);
+    move(p, p + n, data_ + size_);
+    size_ -= n;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::removeOne(const T &value) {
+    T* const p = find(data_, data_ + size_, value);
+    if (!p) {
+        return false;
+    }
+    p->~T();
+    move(p, p + 1, data_ + size_);
+    --size_;
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline int spark::Vector<T, AllocatorT>::removeAll(const T &value) {
+    T* p = data_;
+    T* end = p + size_;
+    while ((p = find(p, end, value))) {
+        p->~T();
+        move(p, p + 1, end);
+        --end;
+    }
+    const int n = size_ - (end - data_);
+    size_ -= n;
+    return n;
+}
+
+template<typename T, typename AllocatorT>
+inline T spark::Vector<T, AllocatorT>::takeFirst() {
+    return takeAt(0);
+}
+
+template<typename T, typename AllocatorT>
+inline T spark::Vector<T, AllocatorT>::takeLast() {
+    return takeAt(size_ - 1);
+}
+
+template<typename T, typename AllocatorT>
+inline T spark::Vector<T, AllocatorT>::takeAt(int i) {
+    T* const p = data_ + i;
+    const T v(std::move(*p));
+    p->~T();
+    move(p, p + 1, data_ + size_);
+    --size_;
+    return v;
+}
+
+template<typename T, typename AllocatorT>
+inline T& spark::Vector<T, AllocatorT>::first() {
+    return data_[0];
+}
+
+template<typename T, typename AllocatorT>
+inline const T& spark::Vector<T, AllocatorT>::first() const {
+    return data_[0];
+}
+
+template<typename T, typename AllocatorT>
+inline T& spark::Vector<T, AllocatorT>::last() {
+    return data_[size_ - 1];
+}
+
+template<typename T, typename AllocatorT>
+inline const T& spark::Vector<T, AllocatorT>::last() const {
+    return data_[size_ - 1];
+}
+
+template<typename T, typename AllocatorT>
+inline T& spark::Vector<T, AllocatorT>::at(int i) {
+    return data_[i];
+}
+
+template<typename T, typename AllocatorT>
+inline const T& spark::Vector<T, AllocatorT>::at(int i) const {
+    return data_[i];
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT> spark::Vector<T, AllocatorT>::copy(int i, int n) const {
+    if (n < 0 || i + n > size_) {
+        n = size_ - i;
+    }
+    Vector<T, AllocatorT> v;
+    if (n > 0 && v.realloc(n)) {
+        const T* const p = data_ + i;
+        copy(v.data_, p, p + n);
+        v.size_ = n;
+    }
+    return v;
+}
+
+template<typename T, typename AllocatorT>
+inline int spark::Vector<T, AllocatorT>::indexOf(const T &value, int i) const {
+    const T* const p = find(data_ + i, data_ + size_, value);
+    if (!p) {
+        return -1;
+    }
+    return p - data_;
+}
+
+template<typename T, typename AllocatorT>
+inline int spark::Vector<T, AllocatorT>::lastIndexOf(const T &value) const {
+    return lastIndexOf(value, size_ - 1);
+}
+
+template<typename T, typename AllocatorT>
+inline int spark::Vector<T, AllocatorT>::lastIndexOf(const T &value, int i) const {
+    const T* const p = rfind(data_ + i, data_ - 1, value);
+    if (!p) {
+        return -1;
+    }
+    return p - data_;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::contains(const T &value) const {
+    return find(data_, data_ + size_, value);
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>& spark::Vector<T, AllocatorT>::fill(const T& value) {
+    destruct(data_, data_ + size_);
+    construct(data_, data_ + size_, value);
+    return *this;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::resize(int n) {
+    if (n > size_) {
+        if (n > capacity_ && !realloc(n)) {
+            return false;
+        }
+        construct(data_ + size_, data_ + n);
+        size_ = n;
+    } else if (n >= 0) {
+        destruct(data_ + n, data_ + size_);
+        size_ = n;
+    }
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline int spark::Vector<T, AllocatorT>::size() const {
+    return size_;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::isEmpty() const {
+    return size_ == 0;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::reserve(int n) {
+    if (n > capacity_ && !realloc(n)) {
+        return false;
+    }
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline int spark::Vector<T, AllocatorT>::capacity() const {
+    return capacity_;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::trimToSize() {
+    if (capacity_ > size_ && !realloc(size_)) {
+        return false;
+    }
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline void spark::Vector<T, AllocatorT>::clear() {
+    destruct(data_, data_ + size_);
+    size_ = 0;
+}
+
+template<typename T, typename AllocatorT>
+inline T* spark::Vector<T, AllocatorT>::data() {
+    return data_;
+}
+
+template<typename T, typename AllocatorT>
+inline const T* spark::Vector<T, AllocatorT>::data() const {
+    return data_;
+}
+
+template<typename T, typename AllocatorT>
+inline T* spark::Vector<T, AllocatorT>::begin() {
+    return data_;
+}
+
+template<typename T, typename AllocatorT>
+const T* spark::Vector<T, AllocatorT>::begin() const {
+    return data_;
+}
+
+template<typename T, typename AllocatorT>
+T* spark::Vector<T, AllocatorT>::end() {
+    return data_ + size_;
+}
+
+template<typename T, typename AllocatorT>
+const T* spark::Vector<T, AllocatorT>::end() const {
+    return data_ + size_;
+}
+
+template<typename T, typename AllocatorT>
+inline T& spark::Vector<T, AllocatorT>::operator[](int i) {
+    return data_[i];
+}
+
+template<typename T, typename AllocatorT>
+inline const T& spark::Vector<T, AllocatorT>::operator[](int i) const {
+    return data_[i];
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::operator==(const Vector<T, AllocatorT> &vector) const {
+    if (size_ != vector.size_) {
+        return false;
+    }
+    const T* p = data_;
+    const T* p2 = vector.data_;
+    const T* const end = p + size_;
+    for (; p != end; ++p, ++p2) {
+        if (*p != *p2) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template<typename T, typename AllocatorT>
+inline bool spark::Vector<T, AllocatorT>::operator!=(const Vector<T, AllocatorT> &vector) const {
+    return !(*this == vector);
+}
+
+template<typename T, typename AllocatorT>
+inline spark::Vector<T, AllocatorT>& spark::Vector<T, AllocatorT>::operator=(Vector<T, AllocatorT> vector) {
+    swap(*this, vector);
+    return *this;
+}
+
+// spark::
+template<typename T, typename AllocatorT>
+inline void spark::swap(Vector<T, AllocatorT>& vector, Vector<T, AllocatorT>& vector2) {
+    using std::swap;
+    swap(vector.data_, vector2.data_);
+    swap(vector.size_, vector2.size_);
+    swap(vector.capacity_, vector2.capacity_);
+}
+
+#endif // SPARK_WIRING_VECTOR_H

--- a/wiring/inc/spark_wiring_vector.h
+++ b/wiring/inc/spark_wiring_vector.h
@@ -452,11 +452,11 @@ inline T spark::Vector<T, AllocatorT>::takeLast() {
 template<typename T, typename AllocatorT>
 inline T spark::Vector<T, AllocatorT>::takeAt(int i) {
     T* const p = data_ + i;
-    const T v(std::move(*p));
+    T v(std::move(*p));
     p->~T();
     move(p, p + 1, data_ + size_);
     --size_;
-    return v;
+    return std::move(v);
 }
 
 template<typename T, typename AllocatorT>

--- a/wiring/src/spark_wiring_json.cpp
+++ b/wiring/src/spark_wiring_json.cpp
@@ -1,0 +1,578 @@
+/*
+ * Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "spark_wiring_json.h"
+
+#include <algorithm>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdarg>
+
+namespace {
+
+// Skips token and all its children tokens if any
+const jsmntok_t* skipToken(const jsmntok_t *t) {
+    size_t n = 1;
+    do {
+        if (t->type == JSMN_OBJECT) {
+            n += t->size * 2; // Number of name and value tokens
+        } else if (t->type == JSMN_ARRAY) {
+            n += t->size; // Number of value tokens
+        }
+        ++t;
+        --n;
+    } while (n);
+    return t;
+}
+
+double doubleFromToken(const jsmntok_t *t, const char *json, bool *ok = nullptr) {
+    // SPARK_ASSERT(t->type == JSMN_PRIMITIVE);
+    const char* const s = json + t->start;
+    char *end = nullptr;
+    const double val = strtod(s, &end);
+    if (!end || *end != '\0') {
+        return 0.0; // Error
+    }
+    if (ok) {
+        *ok = true;
+    }
+    return val;
+}
+
+inline bool boolFromToken(const jsmntok_t *t, const char *json) {
+    // SPARK_ASSERT(t->type == JSMN_PRIMITIVE);
+    const char* const s = json + t->start;
+    return *s == 't'; // Literal names are always in lower case
+}
+
+uint32_t hexToInt(const char *s, size_t size, bool *ok = nullptr) {
+    uint32_t val = 0;
+    const char* const end = s + size;
+    while (s != end) {
+        uint32_t n = 0;
+        const char c = *s;
+        if (c >= '0' && c <= '9') {
+            n = c - '0';
+        } else if (c >= 'a' && c <= 'f') {
+            n = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'F') {
+            n = c - 'A' + 10;
+        } else {
+            return 0; // Error
+        }
+        val = (val << 4) | n;
+        ++s;
+    }
+    if (ok) {
+        *ok = true;
+    }
+    return val;
+}
+
+} // namespace
+
+// spark::detail::JSONData
+struct spark::detail::JSONData {
+    jsmntok_t *tokens;
+    char *json;
+    bool copy;
+
+    JSONData() :
+            tokens(nullptr),
+            json(nullptr),
+            copy(false) {
+    }
+
+    ~JSONData() {
+        delete[] tokens;
+        if (copy) {
+            delete[] json;
+        }
+    }
+};
+
+// spark::JSONValue
+spark::JSONValue::JSONValue(const jsmntok_t *t, detail::JSONDataPtr d) :
+        JSONValue() {
+    if (t) {
+        t_ = t;
+        d_ = d;
+    }
+}
+
+bool spark::JSONValue::toBool() const {
+    switch (type()) {
+    case JSON_TYPE_BOOL:
+        return boolFromToken(t_, d_->json);
+    case JSON_TYPE_NUMBER:
+        return doubleFromToken(t_, d_->json);
+    case JSON_TYPE_STRING: {
+        const char* const s = d_->json + t_->start;
+        if (*s == '\0' || strcmp(s, "false") == 0) { // Empty string or "false" in lower case
+            return false;
+        }
+        bool ok = false;
+        const bool val = doubleFromToken(t_, d_->json, &ok); // Check if string can be converted to a number
+        if (ok) {
+            return val;
+        }
+        return true; // Any other non-empty string
+    }
+    default:
+        return false;
+    }
+}
+
+double spark::JSONValue::toDouble() const {
+    switch (type()) {
+    case JSON_TYPE_BOOL:
+        return boolFromToken(t_, d_->json);
+    case JSON_TYPE_NUMBER:
+    case JSON_TYPE_STRING:
+        return doubleFromToken(t_, d_->json);
+    default:
+        return 0.0;
+    }
+}
+
+spark::JSONType spark::JSONValue::type() const {
+    if (!t_) {
+        return JSON_TYPE_INVALID;
+    }
+    switch (t_->type) {
+    case JSMN_PRIMITIVE: {
+        const char c = d_->json[t_->start];
+        if (c == '-' || (c >= '0' && c <= '9')) {
+            return JSON_TYPE_NUMBER;
+        } else if (c == 't' || c == 'f') { // Literal names are always in lower case
+            return JSON_TYPE_BOOL;
+        } else if (c == 'n') {
+            return JSON_TYPE_NULL;
+        }
+        return JSON_TYPE_INVALID;
+    }
+    case JSMN_STRING:
+        return JSON_TYPE_STRING;
+    case JSMN_ARRAY:
+        return JSON_TYPE_ARRAY;
+    case JSMN_OBJECT:
+        return JSON_TYPE_OBJECT;
+    default:
+        return JSON_TYPE_INVALID;
+    }
+}
+
+spark::JSONValue spark::JSONValue::parse(char *json, size_t size) {
+    detail::JSONDataPtr d(new(std::nothrow) detail::JSONData);
+    if (!d) {
+        return JSONValue();
+    }
+    size_t tokenCount = 0;
+    if (!tokenize(json, size, &d->tokens, &tokenCount)) {
+        return JSONValue();
+    }
+    const jsmntok_t *t = d->tokens; // Root token
+    if (t->type == JSMN_PRIMITIVE) {
+        // RFC 7159 allows JSON document to consist of a single primitive value, such as a number.
+        // In this case, original data is copied to a larger buffer to ensure room for term. null
+        // character (see stringize() method)
+        d->json = new(std::nothrow) char[size + 1];
+        if (!d->json) {
+            return JSONValue();
+        }
+        memcpy(d->json, json, size);
+        d->copy = true; // Set ownership flag
+    } else {
+        d->json = json;
+    }
+    if (!stringize(d->tokens, tokenCount, d->json)) {
+        return JSONValue();
+    }
+    return JSONValue(t, d);
+}
+
+spark::JSONValue spark::JSONValue::parseCopy(const char *json, size_t size) {
+    detail::JSONDataPtr d(new(std::nothrow) detail::JSONData);
+    if (!d) {
+        return JSONValue();
+    }
+    size_t tokenCount = 0;
+    if (!tokenize(json, size, &d->tokens, &tokenCount)) {
+        return JSONValue();
+    }
+    d->json = new(std::nothrow) char[size + 1];
+    if (!d->json) {
+        return JSONValue();
+    }
+    memcpy(d->json, json, size); // TODO: Copy only token data
+    d->copy = true;
+    if (!stringize(d->tokens, tokenCount, d->json)) {
+        return JSONValue();
+    }
+    return JSONValue(d->tokens, d);
+}
+
+bool spark::JSONValue::tokenize(const char *json, size_t size, jsmntok_t **tokens, size_t *count) {
+    jsmn_parser parser;
+    parser.size = sizeof(jsmn_parser);
+    jsmn_init(&parser, nullptr);
+    const int n = jsmn_parse(&parser, json, size, nullptr, 0, nullptr); // Get number of tokens
+    if (n <= 0) {
+        return false; // Parsing error
+    }
+    std::unique_ptr<jsmntok_t[]> t(new(std::nothrow) jsmntok_t[n]);
+    if (!t) {
+        return false;
+    }
+    jsmn_init(&parser, nullptr); // Reset parser
+    if (jsmn_parse(&parser, json, size, t.get(), n, nullptr) <= 0) {
+        return false;
+    }
+    *tokens = t.release();
+    *count = n;
+    return true;
+}
+
+bool spark::JSONValue::stringize(jsmntok_t *t, size_t count, char *json) {
+    const jsmntok_t* const end = t + count;
+    while (t != end) {
+        if (t->type == JSMN_STRING) {
+            if (!unescape(t, json)) {
+                return false; // Malformed string
+            }
+            json[t->end] = '\0';
+        } else if (t->type == JSMN_PRIMITIVE) {
+            json[t->end] = '\0';
+        }
+        ++t;
+    }
+    return true;
+}
+
+bool spark::JSONValue::unescape(jsmntok_t *t, char *json) {
+    char *str = json + t->start; // Destination string
+    const char* const end = json + t->end; // End of the source string
+    const char *s1 = str; // Beginning of an unescaped sequence
+    const char *s = s1;
+    while (s != end) {
+        if (*s == '\\') {
+            if (s != s1) {
+                const size_t n = s - s1;
+                memmove(str, s1, n); // Shift preceeding characters
+                str += n;
+                s1 = s;
+            }
+            ++s;
+            if (s == end) {
+                return false; // Unexpected end of string
+            }
+            if (*s == 'u') { // Arbitrary character, e.g. "\u001f"
+                ++s;
+                if (end - s < 4) {
+                    return false; // Unexpected end of string
+                }
+                bool ok = false;
+                const uint32_t u = ::hexToInt(s, 4, &ok); // Unicode code point or UTF-16 surrogate pair
+                if (!ok) {
+                    return false; // Invalid escaped sequence
+                }
+                if (u <= 0x7f) { // Processing only code points within the basic latin block
+                    *str = u;
+                    ++str;
+                    s1 += 6; // Skip escaped sequence
+                }
+                s += 4;
+            } else {
+                switch (*s) {
+                case '"':
+                case '\\':
+                case '/':
+                    *str = *s;
+                    break;
+                case 'b': // Backspace
+                    *str = 0x08;
+                    break;
+                case 't': // Tab
+                    *str = 0x09;
+                    break;
+                case 'n': // Line feed
+                    *str = 0x0a;
+                    break;
+                case 'f': // Form feed
+                    *str = 0x0c;
+                    break;
+                case 'r': // Carriage return
+                    *str = 0x0d;
+                    break;
+                default:
+                    return false; // Invalid escaped sequence
+                }
+                ++str;
+                ++s;
+                s1 = s; // Skip escaped sequence
+            }
+        } else {
+            ++s;
+        }
+    }
+    if (s != s1) {
+        const size_t n = s - s1;
+        memmove(str, s1, n); // Shift remaining characters
+        str += n;
+    }
+    t->end = str - json; // Update string length
+    return true;
+}
+
+// spark::JSONString
+spark::JSONString::JSONString(const jsmntok_t *t, detail::JSONDataPtr d) :
+        JSONString() {
+    if (t && (t->type == JSMN_STRING || t->type == JSMN_PRIMITIVE)) {
+        if (t->type != JSMN_PRIMITIVE || d->json[t->start] != 'n') { // Nulls are treated as empty strings
+            s_ = d->json + t->start;
+            n_ = t->end - t->start;
+        }
+        d_ = d;
+    }
+}
+
+bool spark::JSONString::operator==(const String &str) const {
+    return n_ == str.length() && strncmp(s_, str.c_str(), n_) == 0;
+}
+
+bool spark::JSONString::operator==(const JSONString &str) const {
+    return n_ == str.n_ && strncmp(s_, str.s_, n_) == 0;
+}
+
+// spark::JSONObjectIterator
+spark::JSONObjectIterator::JSONObjectIterator(const jsmntok_t *t, detail::JSONDataPtr d) :
+        JSONObjectIterator() {
+    if (t && t->type == JSMN_OBJECT) {
+        t_ = t + 1; // First property's name
+        n_ = t->size; // Number of properties
+        d_ = d;
+    }
+}
+
+bool spark::JSONObjectIterator::next() {
+    if (!n_) {
+        return false;
+    }
+    k_ = t_; // Name
+    ++t_;
+    v_ = t_; // Value
+    --n_;
+    if (n_) {
+        t_ = skipToken(t_);
+    }
+    return true;
+}
+
+// spark::JSONArrayIterator
+spark::JSONArrayIterator::JSONArrayIterator(const jsmntok_t *t, detail::JSONDataPtr d) :
+        JSONArrayIterator() {
+    if (t && t->type == JSMN_ARRAY) {
+        t_ = t + 1; // First element
+        n_ = t->size; // Number of elements
+        d_ = d;
+    }
+}
+
+bool spark::JSONArrayIterator::next() {
+    if (!n_) {
+        return false;
+    }
+    v_ = t_;
+    --n_;
+    if (n_) {
+        t_ = skipToken(t_);
+    }
+    return true;
+}
+
+// spark::JSONWriter
+spark::JSONWriter& spark::JSONWriter::beginArray() {
+    writeSeparator();
+    write('[');
+    state_ = BEGIN;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::endArray() {
+    write(']');
+    state_ = NEXT;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::beginObject() {
+    writeSeparator();
+    write('{');
+    state_ = BEGIN;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::endObject() {
+    write('}');
+    state_ = NEXT;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::name(const char *name, size_t size) {
+    writeSeparator();
+    writeEscaped(name, size);
+    state_ = VALUE;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::value(bool val) {
+    writeSeparator();
+    if (val) {
+        write("true", 4);
+    } else {
+        write("false", 5);
+    }
+    state_ = NEXT;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::value(int val) {
+    writeSeparator();
+    printf("%d", val);
+    state_ = NEXT;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::value(unsigned val) {
+    writeSeparator();
+    printf("%u", val);
+    state_ = NEXT;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::value(double val) {
+    writeSeparator();
+    printf("%g", val);
+    state_ = NEXT;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::value(const char *val, size_t size) {
+    writeSeparator();
+    writeEscaped(val, size);
+    state_ = NEXT;
+    return *this;
+}
+
+spark::JSONWriter& spark::JSONWriter::nullValue() {
+    writeSeparator();
+    write("null", 4);
+    state_ = NEXT;
+    return *this;
+}
+
+void spark::JSONWriter::printf(const char *fmt, ...) {
+    char buf[16];
+    va_list args;
+    va_start(args, fmt);
+    int n = vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    if ((size_t)n >= sizeof(buf)) {
+        char buf[n + 1]; // Use larger buffer
+        va_start(args, fmt);
+        n = vsnprintf(buf, sizeof(buf), fmt, args);
+        va_end(args);
+        if (n > 0) {
+            write(buf, n);
+        }
+    } else if (n > 0) {
+        write(buf, n);
+    }
+}
+
+void spark::JSONWriter::writeSeparator() {
+    switch (state_) {
+    case NEXT:
+        write(',');
+        break;
+    case VALUE:
+        write(':');
+        break;
+    default:
+        break;
+    }
+}
+
+void spark::JSONWriter::writeEscaped(const char *str, size_t size) {
+    write('"');
+    const char* const end = str + size;
+    const char *s = str;
+    while (s != end) {
+        const char c = *s;
+        if (c == '"' || c == '\\' || (c >= 0 && c <= 0x1f)) {
+            write(str, s - str); // Write preceeding characters
+            write('\\');
+            switch (c) {
+            case '"':
+            case '\\':
+                write(c);
+                break;
+            case 0x08: // Backspace
+                write('b');
+                break;
+            case 0x09: // Tab
+                write('t');
+                break;
+            case 0x0a: // Line feed
+                write('n');
+                break;
+            case 0x0c: // Form feed
+                write('f');
+                break;
+            case 0x0d: // Carriage return
+                write('r');
+                break;
+            default:
+                // All other control characters are written in hex, e.g. "\u001f"
+                printf("u%04x", (unsigned)c);
+                break;
+            }
+            str = s + 1;
+        }
+        ++s;
+    }
+    if (s != str) {
+        write(str, s - str); // Write remaining characters
+    }
+    write('"');
+}
+
+// spark::JSONBufferWriter
+void spark::JSONBufferWriter::write(const char *data, size_t size) {
+    if (n_ < bufSize_) {
+        memcpy(buf_ + n_, data, std::min(size, bufSize_ - n_));
+    }
+    n_ += size;
+}
+
+void spark::JSONBufferWriter::printf(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    const int n = vsnprintf(buf_ + n_, (n_ < bufSize_) ? bufSize_ - n_ : 0, fmt, args);
+    va_end(args);
+    n_ += n;
+}

--- a/wiring/src/spark_wiring_string.cpp
+++ b/wiring/src/spark_wiring_string.cpp
@@ -72,6 +72,12 @@ String::String(const char *cstr)
 	if (cstr) copy(cstr, strlen(cstr));
 }
 
+String::String(const char *cstr, unsigned int length)
+{
+	init();
+	if (cstr) copy(cstr, length);
+}
+
 String::String(const String &value)
 {
 	init();


### PR DESCRIPTION
This PR is a part 1 of 2 of the code adding support for [runtime logging configuration](https://github.com/spark/firmware/pull/1127), and contains various common tools which I think can be reviewed separately, in order to simplify overall review process. Some background on the topic can be found here: #1037.

This PR adds the following:

**Vector container** ([spark_wiring_vector.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/wiring/inc/spark_wiring_vector.h#L50))

The problem is that we can't really use STL containers in our firmware (though we do use `std::vector` in some places), as none of them are designed to work with disabled exceptions: it's not possible to write custom allocator that doesn't use exceptions, and standard APIs do not provide any alternative mechanism for error handling. Logging framework uses `spark::Vector` extensively, e.g. to maintain a prefix tree for category-based filtering, list of active log handlers, etc.

**Application-side JSON parser/writer classes** ([spark_wiring_json.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/wiring/inc/spark_wiring_json.h#L53))

These classes are mostly wrappers for jsmn library, which is a part of the system module, with added support for type conversions and escaped strings (latter is essential for [JSON log message formatter](https://github.com/spark/firmware/blob/feature/usb_logging_2_of_2/wiring/src/spark_wiring_logging.cpp#L517)). It's also quite handy to use JSON for parameterized [acceptance tests](https://github.com/spark/firmware/blob/feature/usb_logging_2_of_2/user/tests/accept/features/logging/log_config.feature#L107). Usage example can be found [here](https://github.com/spark/firmware/blob/feature/usb_logging_2_of_2/user/tests/accept/features/logging/log_config_app/app.cpp).

**Helper tools for unit testing**
- [tools/random.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/user/tests/unit/tools/random.h) - random number/string generation.
- [tools/string.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/user/tests/unit/tools/string.h) - string utilities.
- [tools/stream.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/user/tests/unit/tools/stream.h) - Wiring-compatible output stream.
- [tools/buffer.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/user/tests/unit/tools/buffer.h) - wrapper class for a buffer with padding bytes.
- [tools/alloc.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/user/tests/unit/tools/alloc.h) - allocator class allowing to detect memory usage errors.
- [tools/check.h](https://github.com/spark/firmware/blob/feature/usb_logging_1_of_2/user/tests/unit/tools/check.h) - mixin for "checkable" types. Example usage:

``` cpp
#include "tools/stream.h"

TEST_CASE() {
    test::OutputStream stream;
    uint8_t buf[] = { 1, 2, 3, 255 };
    stream.write(buf, sizeof(buf));
    check(stream).hex().equals("010203ff");
}

TEST_CASE() {
    std::string s = "one,two,three";
    check(s).matches("(.+),(.+),(.+)")
            .at(0).equals("one")
            .at(1).equals("two")
            .at(2).equals("three");
}
```

---

Doneness:
- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled

N/A see part 2 of 2 #1127 
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)
