### PR TITLE
Bugfix for subscriptions checksum calculation

### DIFF
--- a/communication/src/subscriptions.h
+++ b/communication/src/subscriptions.h
@@ -73,7 +73,7 @@ public:
 			chk[0] = checksum;
 			chk[1] = calculate_crc((const uint8_t*)handler.device_id, sizeof(handler.device_id));
 			chk[2] = calculate_crc((const uint8_t*)handler.filter, sizeof(handler.filter));
-			chk[3] = calculate_crc((const uint8_t*)handler.scope, sizeof(handler.scope));
+			chk[3] = calculate_crc((const uint8_t*)&handler.scope, sizeof(handler.scope));
 			checksum = calculate_crc((const uint8_t*)chk, sizeof(chk));
 			return NO_ERROR;
 		});


### PR DESCRIPTION
`handler.scope` is an enum, and we want its address to be casted to `uint8_t*`, not its value

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### BUGFIX

- Particle.subscribe() used with same events but changing scope between PUBLIC and PRIVATE or vice versa would potentially result in non-registered subscriptions.  This was also crashing the GCC virtual device with a segfault when subscription checksums were calculated.