### PR TITLE
Socket HAL bugfix (virtual device)

### DIFF
--- a/hal/src/gcc/socket_hal.cpp
+++ b/hal/src/gcc/socket_hal.cpp
@@ -281,15 +281,16 @@ sock_result_t socket_receive(sock_handle_t sd, void* buffer, socklen_t len, syst
     handle.io_control(command);
     std::size_t available = command.get();
     sock_result_t result = 0;
-    if (_timeout || available)
-    available = handle.read_some(boost::asio::buffer(buffer, len), ec);
-    result = ec.value() ? -abs(ec.value()) : available;
-    if (ec.value()) {
-        if (ec.value() == boost::system::errc::resource_deadlock_would_occur || // EDEADLK (35)
-            ec.value() == boost::system::errc::resource_unavailable_try_again) { // EAGAIN (11)
-            result = 0; // No data available
-        } else {
-            DEBUG("socket receive error: %d %s, read=%d", ec.value(), ec.message().c_str(), available);
+    if (_timeout || available) {
+        available = handle.read_some(boost::asio::buffer(buffer, len), ec);
+        result = ec.value() ? -abs(ec.value()) : available;
+        if (ec.value()) {
+            if (ec.value() == boost::system::errc::resource_deadlock_would_occur || // EDEADLK (35)
+                ec.value() == boost::system::errc::resource_unavailable_try_again) { // EAGAIN (11)
+                result = 0; // No data available
+            } else {
+                DEBUG("socket receive error: %d %s, read=%d", ec.value(), ec.message().c_str(), available);
+            }
         }
     }
     return result;


### PR DESCRIPTION
This PR fixes seemingly random cloud connection errors on virtual device, caused by incorrect error handling in `socket_receive()`: socket hal uses global `ec` variable for exceptionless error handling, and previously any error on unrelated socket (such as socket used for multicast announcement) might affect cloud connection.

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### BUGFIX

- [GCC Virtual Device] Error in socket_hal's socket_receive() logic caused random cloud connection errors.  PR [#1134](https://github.com/spark/firmware/pull/1134)