### PR TITLE
Electron modem USART and buffer handling fixes

### DIFF
--- a/hal/src/electron/modem/electronserialpipe_hal.cpp
+++ b/hal/src/electron/modem/electronserialpipe_hal.cpp
@@ -218,13 +218,13 @@ void ElectronSerialPipe::rxIrqBuf(void)
         char c = USART_ReceiveData(USART3);
         _pipeRx.putc(c);
     } else {
-        /* TODO: Handle overflow?
-         * We should not read USART3->RDR register in order to
-         * signal to the modem that we are not ready to receive,
-         * then try to process and free the buffer.
-         */
-        (void)USART_ReceiveData(USART3);
+        USART_ITConfig(USART3, USART_IT_RXNE, DISABLE);
     }
+}
+
+void ElectronSerialPipe::rxResume(void)
+{
+    USART_ITConfig(USART3, USART_IT_RXNE, ENABLE);
 }
 
 /*******************************************************************************

--- a/hal/src/electron/modem/electronserialpipe_hal.h
+++ b/hal/src/electron/modem/electronserialpipe_hal.h
@@ -96,6 +96,10 @@ public:
     */
     void txIrqBuf(void);
 
+    /** resumes paused receiver (hardware flow control)
+    */
+    void rxResume();
+
 protected:
     //! start transmission helper
     void txStart(void);

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -2251,6 +2251,7 @@ int MDMParser::_getLine(Pipe<char>* pipe, char* buf, int len)
             { "\r\n>",                  NULL,               TYPE_PROMPT     }, // SMS
             { "\n>",                    NULL,               TYPE_PROMPT     }, // File
             { "\r\nABORTED\r\n",        NULL,               TYPE_ABORTED    }, // Current command aborted
+            { "\r\n",                   "\r\n",             TYPE_UNKNOWN    }, // If all else fails, break up generic strings
         };
         for (int i = 0; i < (int)(sizeof(lutF)/sizeof(*lutF)); i ++) {
             pipe->set(unkn);
@@ -2305,5 +2306,7 @@ int MDMElectronSerial::_send(const void* buf, int len)
 
 int MDMElectronSerial::getLine(char* buffer, int length)
 {
-    return _getLine(&_pipeRx, buffer, length);
+    int ret = _getLine(&_pipeRx, buffer, length);
+    rxResume();
+    return ret;
 }

--- a/hal/src/electron/modem/pipe_hal.h
+++ b/hal/src/electron/modem/pipe_hal.h
@@ -45,11 +45,11 @@ public:
     */
     Pipe(int n, T* b = NULL)
     {
-        _a = b ? NULL : n ? new T[n] : NULL;
+        _a = b ? NULL : n ? new T[n + 1] : NULL;
         _r = 0;
         _w = 0;
         _b = b ? b : _a;
-        _s = n;
+        _s = n + 1;
     }
     /** Destructor
         frees a allocated buffer.
@@ -96,10 +96,7 @@ public:
     */
     int free(void)
     {
-        int s = _r - _w;
-        if (s <= 0)
-            s += _s;
-        return s - 1;
+        return _s - size() - 1;
     }
 
     /* Add a single element to the buffer. (blocking)

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -81,6 +81,13 @@ test(CLOUD_02_device_will_connect_to_the_cloud_when_all_udp_sockets_consumed) {
     assertEqual(Particle.connected(), true);
 }
 
+test(CLOUD_03_close_consumed_sockets) {
+    for (int i = 0; i < 7; i++) {
+        if (socket_handle_valid(i))
+            socket_close(i);
+    }
+}
+
 void checkIPAddress(const char* name, const IPAddress& address)
 {
     if (address.version()==0 || address[0]==0)
@@ -92,7 +99,7 @@ void checkIPAddress(const char* name, const IPAddress& address)
     }
 }
 
-test(CLOUD_03_local_ip_cellular_config)
+test(CLOUD_04_local_ip_cellular_config)
 {
     connect_to_cloud(6*60*1000);
     checkIPAddress("local", Cellular.localIP());
@@ -348,6 +355,72 @@ test(BAND_SELECT_08_restore_defaults) {
     // Then band select will be default
     bool band_select_default = !is_bands_selected_not_equal_to_default_bands(band_sel, band_avail);
     assertEqual(band_select_default, true);
+}
+
+#define LOREM "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut elit nec mi bibendum mollis. Nam nec nisl mi. Donec dignissim iaculis purus, ut condimentum arcu semper quis. Phasellus efficitur ut arcu ac dignissim. In interdum sem id dictum luctus. Ut nec mattis sem. Nullam in aliquet lacus. Donec egestas nisi volutpat lobortis sodales. Aenean elementum magna ipsum, vitae pretium tellus lacinia eu. Phasellus commodo nisi at quam tincidunt, tempor gravida mauris facilisis. Duis tristique ligula ac pulvinar consectetur. Cras aliquam, leo ut eleifend molestie, arcu odio semper odio, quis sollicitudin metus libero et lorem. Donec venenatis congue commodo. Vivamus mattis elit metus, sed fringilla neque viverra eu. Phasellus leo urna, elementum vel pharetra sit amet, auctor non sapien. Phasellus at justo ac augue rutrum vulputate. In hac habitasse platea dictumst. Pellentesque nibh eros, placerat id laoreet sed, dapibus efficitur augue. Praesent pretium diam ac sem varius fermentum. Nunc suscipit dui risus sed"
+
+test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
+    // https://github.com/spark/firmware/issues/1104
+    const char request[] =
+        "POST /post HTTP/1.1\r\n"
+        "Host: httpbin.org\r\n"
+        "Connection: close\r\n"
+        "Content-Type: multipart/form-data; boundary=-------------aaaaaaaa\r\n"
+        "Content-Length: 1124\r\n"
+        "\r\n"
+        "---------------aaaaaaaa\r\n"
+        "Content-Disposition: form-data; name=\"field\"\r\n"
+        "\r\n"
+        LOREM "\r\n"
+        "---------------aaaaaaaa--\r\n";
+    const int requestSize = sizeof(request) - 1;
+
+    Cellular.connect();
+    waitFor(Cellular.ready, 60000);
+
+    TCPClient c;
+    int res = c.connect("httpbin.org", 80);
+
+    int sz = c.write((const uint8_t*)request, requestSize);
+    assertEqual(sz, requestSize);
+
+    char* responseBuf = new char[2048];
+    memset(responseBuf, 0, sizeof(responseBuf));
+    int responseSize = 0;
+    uint32_t mil = millis();
+    while(1) {
+        while (c.available()) {
+            responseBuf[responseSize++] = c.read();
+        }
+        if (!c.connected())
+            break;
+        if (millis() - mil >= 60000) {
+            break;
+        }
+    }
+
+    bool contains = false;
+    if (responseSize > 0 && !c.connected()) {
+        contains = strstr(responseBuf, LOREM) != nullptr;
+    }
+
+    delete responseBuf;
+
+    assertTrue(contains);
+}
+
+static int atCallback(int type, const char* buf, int len, int* lines) {
+    if (len && type == TYPE_UNKNOWN)
+        (*lines)++;
+    return WAIT;
+}
+
+test(MDM_02_at_commands_with_long_response_are_correctly_parsed_and_flow_controlled) {
+    // https://github.com/spark/firmware/issues/1138
+    int lines = 0;
+    int ret = Cellular.command(atCallback, &lines, 10000, "AT+CLAC\r\n");
+    assertEqual(ret, (int)RESP_OK);
+    assertMoreOrEqual(lines, 200);
 }
 
 #endif


### PR DESCRIPTION
Closes #1138 and #1104.

Fixes several issues:
- `USART_FLAG_TXE` was not checked when writing into DR register from system thread which caused an unsent data byte to be overwritten
- RX flow control was not correctly handled. When an internal `ElectronSerialPipe` buffer overflows, a data byte should be left in DR register to de-assert RTS line to ask modem to pause transmission for a while
- `ElectronSerialPipe` circular buffer was initialized to 1024 bytes, but the implementation allowed only 1023 bytes to be held inside the buffer
- `AT+CLAC`-like commands weren't parsed correctly (thanks @technobly)

Relevant tests:
- `MDM_01_socket_writes_with_length_more_than_1023_work_correctly`
- `MDM_02_at_commands_with_long_response_are_correctly_parsed_and_flow_controlled`

---

Doneness:
- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bugfixes

- [Electron] Fixed modem USART and buffer handling [[Fixes #1138]](https://github.com/spark/firmware/issues/1138) [[Fixes #1104]](https://github.com/spark/firmware/issues/1104)