### PR TITLE
Generate system event when low battery condition is detected

### DIFF
--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -7324,6 +7324,7 @@ These are the system events produced by the system, their numeric value (what yo
  | button_click | 4096 | event sent each time setup button is clicked. | `int clicks = system_button_clicks(param); ` retrieves the number of clicks so far. |
 | button_final_click | 8192 | sent after a run of one or more clicks not followed by additional clicks. Unlike the `button_click` event, the `button_final_click` event is sent once, at the end of a series of clicks. | `int clicks = system_button_clicks(param); ` retrieves the number of times the button was pushed. |
 | time_changed | 16384 | device time changed | `time_changed_manually` or `time_changed_sync` |
+| low_battery | 32768 | generated when low battery condition is detected. | not used |
 
 
 ## System Modes

--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -56,6 +56,7 @@ enum SystemEvents {
     button_click = 1<<12,           // generated for every click in series - data is number of clicks in the lower 4 bits.
     button_final_click = 1<<13,     // generated for last click in series - data is the number of clicks in the lower 4 bits.
     time_changed = 1<<14,
+    low_battery = 1<<15,            // generated when low battery condition is detected
 
     all_events = 0xFFFFFFFFFFFFFFFF
 };

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -306,7 +306,7 @@ void system_power_management_update()
         static bool wasCharging = false; // Whether the battery was charging last time when this function was called
         const uint8_t status = power.getSystemStatus();
         const bool charging = (status >> 4) & 0x03;
-        if (!charging && wasCharging) { // Check if charging has been stopped
+        if (charging && !wasCharging) { // Check if the battery has started to charge
             lowBattEventNotified = false; // Allow 'low_battery' event to be generated again
         }
         wasCharging = charging;

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -302,11 +302,22 @@ void system_power_management_update()
         power.begin();
         power.setInputCurrentLimit(900);     // 900mA
         power.setChargeCurrent(0,0,0,0,0,0); // 512mA
+        static bool lowBattEventNotified = false; // Whether 'low_battery' event was generated already
+        static bool wasCharging = false; // Whether the battery was charging last time when this function was called
+        const uint8_t status = power.getSystemStatus();
+        const bool charging = (status >> 4) & 0x03;
+        if (!charging && wasCharging) { // Check if charging has been stopped
+            lowBattEventNotified = false; // Allow 'low_battery' event to be generated again
+        }
+        wasCharging = charging;
         FuelGauge fuel;
         bool LOWBATT = fuel.getAlert();
         if (LOWBATT) {
             fuel.clearAlert(); // Clear the Low Battery Alert flag if set
-            system_notify_event(low_battery);
+            if (!lowBattEventNotified) {
+                lowBattEventNotified = true;
+                system_notify_event(low_battery);
+            }
         }
 //        if (LOG_ENABLED(INFO)) {
 //        		INFO(" %s", (LOWBATT)?"Low Battery Alert":"PMIC Interrupt");

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -306,6 +306,7 @@ void system_power_management_update()
         bool LOWBATT = fuel.getAlert();
         if (LOWBATT) {
             fuel.clearAlert(); // Clear the Low Battery Alert flag if set
+            system_notify_event(low_battery);
         }
 //        if (LOG_ENABLED(INFO)) {
 //        		INFO(" %s", (LOWBATT)?"Low Battery Alert":"PMIC Interrupt");


### PR DESCRIPTION
This PR adds `low_battery` system event, which is generated when low battery condition is detected. The event doesn't carry any data.

I don't have any battery, nor adjustable power supply unit to test this PR properly, so any help with the testing would be appreciated. Test application can be as simple as the following:

``` cpp
#include "application.h"

SYSTEM_MODE(MANUAL); // Electron will be offline!!!

SerialLogHandler logHandler(LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

void lowBatteryHandler() {
    Log.warn("Low battery!");
}

void setup() {
	FuelGauge().setAlertThreshold(32); // MAX 32% (default 10%)
	System.on(low_battery, lowBatteryHandler);
}

void loop() {
	FuelGauge().quickStart();
	String stats = String(FuelGauge().getAlertThreshold()) + "(\%) "
		+ String(FuelGauge().getSoC()) + "(\%) "
		+ String(FuelGauge().getVCell()) + "(V)";
	Log.info("Battery stats: %s", stats.c_str());
	delay(1000);
}
```

According to [current code](https://github.com/spark/firmware/blob/develop/system/src/main.cpp#L280), default threshold for low battery alarm is set to 10%.

---

Doneness:
- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Features

- Added `low_battery` system event, which is generated when low battery condition is detected. This is when the battery falls below the SoC threshold (default 10%, max settable 32%).  The event can only be generated again if the system goes from a non-charging to charing state after the event is generated. The event doesn't carry any data.  [[PR #1154]](https://github.com/spark/firmware/pull/1154)