### PR TITLE
Fixes System.sleep(seconds) or SLEEP_MODE_WLAN behavior

### DIFF
--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -117,6 +117,10 @@ void system_sleep(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, v
     switch (sleepMode)
     {
         case SLEEP_MODE_WLAN:
+            if (seconds)
+            {
+                HAL_RTC_Set_UnixAlarm((time_t) seconds);
+            }
             break;
 
         case SLEEP_MODE_DEEP:

--- a/user/tests/wiring/sleep/sleep.cpp
+++ b/user/tests/wiring/sleep/sleep.cpp
@@ -79,3 +79,14 @@ test(sleep_1_interrupts_attached_handler_is_not_detached_after_stop_mode)
 
     detachInterrupt(pin);
 }
+
+/*
+ * Issue #1155, broken by PR #1051/#1076
+ */
+test(sleep_2_system_sleep_sleep_mode_wlan_works_correctly)
+{
+    System.sleep(10);
+    assertTrue(Particle.disconnected());
+    waitFor(Particle.connected, 120000);
+    assertTrue(Particle.connected());
+}


### PR DESCRIPTION
Closes #1155

Fixes a bug introduced by PR #1051/#1076.

Relevant tests:
- `wiring/sleep` (`sleep_2_system_sleep_sleep_mode_wlan_works_correctly`)

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bugfixes

- System.sleep(30) wasn't reapplying power to the network device after set time.  [[Fixes #1155]](https://github.com/spark/firmware/pull/1156)