### PR TITLE
Fix error message for long function names

### DIFF
--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -76,7 +76,7 @@ public:
     static inline bool variable(const T &name, const Types& ... args)
     {
         static_assert(!IsStringLiteral(name) || sizeof(name) <= USER_VAR_KEY_LENGTH + 1,
-            "\n\nIn Particle.variable, name must be less than " __XSTRING(USER_VAR_KEY_LENGTH) " characters\n\n");
+            "\n\nIn Particle.variable, name must be " __XSTRING(USER_VAR_KEY_LENGTH) " characters or less\n\n");
 
         return _variable(name, args...);
     }
@@ -186,7 +186,7 @@ public:
     {
 #if PLATFORM_ID!=3
         static_assert(!IsStringLiteral(name) || sizeof(name) <= USER_FUNC_KEY_LENGTH + 1,
-            "\n\nIn Particle.function, name must be less than " __XSTRING(USER_FUNC_KEY_LENGTH) " characters\n\n");
+            "\n\nIn Particle.function, name must be " __XSTRING(USER_FUNC_KEY_LENGTH) " characters or less\n\n");
 #endif
         return _function(name, args...);
     }


### PR DESCRIPTION
@ScruffR reported a typo in the error message when doing `Particle.function("superLongNameOfFunction", myFunction);`

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
