### PR TITLE
Workaround for 100% CPU usage problem on the virtual device

### DIFF
--- a/services/inc/config.h
+++ b/services/inc/config.h
@@ -37,4 +37,10 @@
 #define DEFAULT_SEC_INACTIVITY          0
 #define DEFAULT_SEC_NETOPS              20
 
+// Number of application loop iterations after which the main thread is suspended for some short time.
+// This is primarily used to workaround 100% CPU usage on the virtual device platform
+#ifndef SUSPEND_APPLICATION_THREAD_LOOP_COUNT
+#define SUSPEND_APPLICATION_THREAD_LOOP_COUNT 25
+#endif
+
 #endif /* CONFIG_H_ */

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -53,6 +53,11 @@
 #include "spark_wiring_cellular_printable.h"
 #include "system_rgbled.h"
 
+#if PLATFORM_ID == 3
+// Application loop uses std::this_thread::sleep_for() to workaround 100% CPU usage on the GCC platform
+#include <thread>
+#endif
+
 using namespace spark;
 
 /* Private typedef -----------------------------------------------------------*/
@@ -529,6 +534,15 @@ void app_loop(bool threaded)
             }
         }
     }
+#if PLATFORM_ID == 3
+    // Suspend thread execution for some minimum time on every Nth loop iteration in order to workaround
+    // 100% CPU usage on the virtual device platform
+    static uint32_t loops = 0;
+    if (++loops >= 25) {
+        loops = 0;
+        std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+    }
+#endif // PLATFORM_ID == 3
 }
 
 

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -534,11 +534,11 @@ void app_loop(bool threaded)
             }
         }
     }
-#if PLATFORM_ID == 3
+#if PLATFORM_ID == 3 && SUSPEND_APPLICATION_THREAD_LOOP_COUNT
     // Suspend thread execution for some minimum time on every Nth loop iteration in order to workaround
     // 100% CPU usage on the virtual device platform
     static uint32_t loops = 0;
-    if (++loops >= 25) {
+    if (++loops >= SUSPEND_APPLICATION_THREAD_LOOP_COUNT) {
         loops = 0;
         std::this_thread::sleep_for(std::chrono::nanoseconds(1));
     }


### PR DESCRIPTION
This PR fixes #1036 by suspending main thread for some minimum time on every Nth iteration of the application loop. That's probably not the best solution possible, but it allowed to reduce CPU usage from 100 to 10-15% on my machine (Intel Core i7), while keeping reasonable performance comparing to the real devices.

Note that calling `std::this_thread::yield()` has appeared to be insufficient to workaround the problem, also a simple unconditional sleep on each iteration makes an application significantly slower comparing to the same application running on the real device (at least 7 times slower in my tests).

Below is the simple test application that can be used to check how many times application loop is being invoked per second:

```cpp
#include "application.h"

SYSTEM_MODE(MANUAL)

SerialLogHandler logHandler(LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

uint32_t t = 0;
unsigned n = 0;

void setup() {
    t = millis();
}

void loop() {
    ++n;
    if (millis() - t >= 1000) {
        Log.info("%u", n);
        t = millis();
        n = 0;
    }
}
```

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
…atform