### PR TITLE
fixes docs to install arm-none-eabi-gcc version 4.9.3 20150303

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -22,7 +22,27 @@ message if the version is older than this.
 **OS X** users can install the toolchain with [Homebrew](http://brew.sh/):
 - `brew tap PX4/homebrew-px4`
 - `brew update`
-- `brew install gcc-arm-none-eabi-49`
+- copy/paste this in Terminal and press ENTER to create the proper Brew formula
+```
+echo -e "require 'formula'
+
+class GccArmNoneEabi49 < Formula
+  homepage 'https://launchpad.net/gcc-arm-embdded'
+  version '20150306'
+  url 'https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q1-update/+download/gcc-arm-none-eabi-4_9-2015q1-20150306-mac.tar.bz2'
+  sha256 '049469f06c35d1a7c6d333236bc62ed340531c4377b4e16ce8c5aa8d134e8e8b'
+
+  def install
+    ohai 'Copying binaries...'
+    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', \"#{prefix}/\"
+  end
+end" > /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/gcc-arm-none-eabi-49.rb
+```
+
+- install it!
+```
+brew install gcc-arm-none-eabi-49
+```
 - `arm-none-eabi-gcc --version` (should now say v4.9.x)
 
 If you are upgrading an existing installation you will have to unlink and link your symblinks:


### PR DESCRIPTION
The `homebrew-px4` tap keeps updating the latest GCC compiler version and does not have `gcc-arm-non-eabi-49` any longer.  This edit to the documentation preserves the info needed to install v4.9.3 20150303 of arm-none-eabi-gcc which is the recommended version to use locally when building firmware.

Fixes #1077 
Closes #1103 #1078

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled (N/A)
- [x] Run unit/integration/application tests on device (N/A)
- [x] Add documentation (N/A)
- [x] Add to CHANGELOG.md after merging (add links to docs and issues) (N/A)
