### PR TITLE
Typo causes a warning during compilation in wiring/no_fixture Cellular tests

### DIFF
--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -385,7 +385,7 @@ test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
     assertEqual(sz, requestSize);
 
     char* responseBuf = new char[2048];
-    memset(responseBuf, 0, sizeof(responseBuf));
+    memset(responseBuf, 0, 2048);
     int responseSize = 0;
     uint32_t mil = millis();
     while(1) {


### PR DESCRIPTION

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)

### Internal

- Typo caused a warning during compilation in wiring/no_fixture Cellular tests.