### PR TITLE
Revert Particle.publish() API changes

### DIFF
--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -356,6 +356,18 @@ Particle.publish("t", temperature, ttl, PRIVATE, NO_ACK);
 
 {{/if}}
 
+*`WITH_ACK` flag*
+
+This flag causes `Particle.publish()` to return only after receiving an acknowledgement that the published event has been received by the Cloud.
+
+```C++
+// SYNTAX
+
+Particle.publish("motion-detected", NULL, WITH_ACK);
+Particle.publish("motion-detected", NULL, PRIVATE, WITH_ACK);
+Particle.publish("motion-detected", NULL, ttl, PRIVATE, WITH_ACK);
+```
+
 
 ### Particle.subscribe()
 

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -29,7 +29,6 @@
 #include "spark_protocol_functions.h"
 #include "spark_wiring_system.h"
 #include "spark_wiring_watchdog.h"
-#include "spark_wiring_async.h"
 #include "interrupts_hal.h"
 #include "system_mode.h"
 #include <functional>
@@ -222,23 +221,22 @@ public:
       return _function(funcKey, std::bind(func, instance, _1));
     }
 
-    inline spark::Future<void> publish(const char *eventName, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, PublishFlag eventType=PUBLIC)
     {
         return publish(eventName, NULL, 60, PublishFlag::flag_t(eventType));
     }
 
-    inline spark::Future<void> publish(const char *eventName, const char *eventData, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, const char *eventData, PublishFlag eventType=PUBLIC)
     {
         return publish(eventName, eventData, 60, PublishFlag::flag_t(eventType));
     }
 
-    inline spark::Future<void> publish(const char *eventName, const char *eventData, PublishFlag f1, PublishFlag f2)
+    inline bool publish(const char *eventName, const char *eventData, PublishFlag f1, PublishFlag f2)
     {
         return publish(eventName, eventData, 60, f1.flag()+f2.flag());
     }
 
-
-    inline spark::Future<void> publish(const char *eventName, const char *eventData, int ttl, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, const char *eventData, int ttl, PublishFlag eventType=PUBLIC)
     {
         return publish(eventName, eventData, ttl, PublishFlag::flag_t(eventType));
     }
@@ -351,7 +349,7 @@ private:
 
     static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
 
-    static spark::Future<void> publish(const char *eventName, const char *eventData, int ttl, uint32_t flags);
+    static bool publish(const char *eventName, const char *eventData, int ttl, uint32_t flags);
 
     static ProtocolFacade* sp()
     {

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -1,5 +1,7 @@
 #include "spark_wiring_cloud.h"
 
+#include "spark_wiring_async.h"
+
 int CloudClass::call_raw_user_function(void* data, const char* param, void* reserved)
 {
     user_function_int_str_t* fn = (user_function_int_str_t*)(data);
@@ -30,7 +32,7 @@ bool CloudClass::register_function(cloud_function_t fn, void* data, const char* 
     return spark_function(NULL, (user_function_int_str_t*)&desc, NULL);
 }
 
-spark::Future<void> CloudClass::publish(const char *eventName, const char *eventData, int ttl, uint32_t flags) {
+bool CloudClass::publish(const char *eventName, const char *eventData, int ttl, uint32_t flags) {
 #ifndef SPARK_NO_CLOUD
     spark_send_event_data d = { sizeof(spark_send_event_data) };
 
@@ -45,8 +47,10 @@ spark::Future<void> CloudClass::publish(const char *eventName, const char *event
         p.fromDataPtr(d.handler_data); // Free wrapper object
     }
 
-    return p.future();
+    // TODO: Return future object instead of synchronous waiting
+    spark::Future<void> f = p.future();
+    return f.wait().isSucceeded();
 #else
-    return spark::Future<void>::makeFailed(spark::Error::NOT_SUPPORTED);
+    return false; // spark::Future<void>::makeFailed(spark::Error::NOT_SUPPORTED);
 #endif
 }


### PR DESCRIPTION
As long as we decided to release 0.6.1 instead of 0.7.0, we need to revert API breaking changes in `Particle.publish()` introduced by this PR: https://github.com/spark/firmware/pull/1144.

This PR also adds reference documentation for `WITH_ACK` flag.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
