### PR TITLE
Adds a log string when `spark/device/ota_result` event is published

### DIFF
--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1177,7 +1177,7 @@ int finish_ota_firmware_update(FileTransfer::Descriptor& file, uint32_t flags, v
     LOG(INFO, "Send spark/device/ota_result event");
     LOG_PRINT(TRACE, (const char*)buf);
     LOG_PRINTF(TRACE, "\r\n");
-    Particle.publish("sspark/device/ota_result", (const char*)buf, 60, PRIVATE);
+    Particle.publish("spark/device/ota_result", (const char*)buf, 60, PRIVATE);
     HAL_Delay_Milliseconds(1000);
     Spark_Process_Events();
 

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1174,7 +1174,10 @@ int finish_ota_firmware_update(FileTransfer::Descriptor& file, uint32_t flags, v
 
     formatOtaUpdateStatusEventData(flags, result, &module, buf, sizeof(buf));
 
-    Particle.publish("spark/device/ota_result", (const char*)buf, 60, PRIVATE);
+    LOG(INFO, "Send spark/device/ota_result event");
+    LOG_PRINT(TRACE, (const char*)buf);
+    LOG_PRINTF(TRACE, "\r\n");
+    Particle.publish("sspark/device/ota_result", (const char*)buf, 60, PRIVATE);
     HAL_Delay_Milliseconds(1000);
     Spark_Process_Events();
 

--- a/user/tests/accept/features/support/env.rb
+++ b/user/tests/accept/features/support/env.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'aruba/cucumber'
 require 'concurrent/atomics'
 require 'em/pure_ruby' # Pure implementation is required by em-rubyserial


### PR DESCRIPTION

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled

N/A - fixes to 0.6.1-rc.1 commits

- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)