### PR TITLE
Feature/rgb service rgbhal update

### DIFF
--- a/services/src/led_service.cpp
+++ b/services/src/led_service.cpp
@@ -18,7 +18,7 @@
 #include "led_service.h"
 
 #include "rgbled_hal.h"
-
+#include "rgbled.h"
 #include "debug.h"
 
 // TODO: Move synchronization macros to some header file
@@ -251,7 +251,7 @@ private:
     // Splits 32-bit RGB value into 16-bit color components (as expected by HAL) and applies
     // brightness correction
     static void scaleColor(uint32_t color, uint8_t value, Color* scaled) {
-        const uint32_t v = (uint32_t)value * Get_RGB_LED_Max_Value();
+        const uint32_t v = (uint32_t)value * LED_Callbacks.Led_Rgb_Get_Max_Value(nullptr);
         scaled->r = (((color >> 16) & 0xff) * v) >> 16;
         scaled->g = (((color >> 8) & 0xff) * v) >> 16;
         scaled->b = ((color & 0xff) * v) >> 16;
@@ -259,10 +259,10 @@ private:
 
     // Sets LED color and invokes user callback
     static void setLedColor(const Color& color) {
-        Set_RGB_LED_Values(color.r, color.g, color.b);
+        LED_Callbacks.Led_Rgb_Set_Values(color.r, color.g, color.b, nullptr);
         if (led_update_handler) {
             // User callback expects RGB values to be in 0 - 255 range
-            const uint32_t v = Get_RGB_LED_Max_Value();
+            const uint32_t v = LED_Callbacks.Led_Rgb_Get_Max_Value(nullptr);
             const uint8_t r = ((uint32_t)color.r << 8) / v;
             const uint8_t g = ((uint32_t)color.g << 8) / v;
             const uint8_t b = ((uint32_t)color.b << 8) / v;

--- a/user/tests/unit/led_service.cpp
+++ b/user/tests/unit/led_service.cpp
@@ -96,9 +96,13 @@ inline std::ostream& operator<<(std::ostream& strm, const Color& color) {
 class Led {
 public:
     Led() {
+        mocks_.OnCallFunc(HAL_Led_Rgb_Set_Values).Do([&](uint16_t r, uint16_t g, uint16_t b, void*) {
+            color_ = Color(normalize(r), normalize(g), normalize(b));
+        });
         mocks_.OnCallFunc(Set_RGB_LED_Values).Do([&](uint16_t r, uint16_t g, uint16_t b) {
             color_ = Color(normalize(r), normalize(g), normalize(b));
         });
+        mocks_.OnCallFunc(HAL_Led_Rgb_Get_Max_Value).Return(MAX_COLOR_VALUE);
         mocks_.OnCallFunc(Get_RGB_LED_Max_Value).Return(MAX_COLOR_VALUE);
         LED_SetBrightness(255); // Set maximum brightness by default
         reset();

--- a/user/tests/unit/rgbled.cpp
+++ b/user/tests/unit/rgbled.cpp
@@ -13,16 +13,27 @@ static uint16_t rgb_values[3];
 class Mocks {
 public:
     Mocks() {
+        mocks_.OnCallFunc(HAL_Led_Rgb_Set_Values).Do([&](uint16_t r, uint16_t g, uint16_t b, void*) {
+            rgb_values[0] = r;
+            rgb_values[1] = g;
+            rgb_values[2] = b;
+        });
         mocks_.OnCallFunc(Set_RGB_LED_Values).Do([&](uint16_t r, uint16_t g, uint16_t b) {
             rgb_values[0] = r;
             rgb_values[1] = g;
             rgb_values[2] = b;
+        });
+        mocks_.OnCallFunc(HAL_Led_Rgb_Get_Values).Do([&](uint16_t* rgb, void*) {
+            for (int i=0; i<3; i++) {
+                rgb[i] = rgb_values[i];
+            }
         });
         mocks_.OnCallFunc(Get_RGB_LED_Values).Do([&](uint16_t* rgb) {
             for (int i=0; i<3; i++) {
                 rgb[i] = rgb_values[i];
             }
         });
+        mocks_.OnCallFunc(HAL_Led_Rgb_Get_Max_Value).Return(2048);
         mocks_.OnCallFunc(Get_RGB_LED_Max_Value).Return(2048);
     }
 
@@ -50,7 +61,7 @@ void assertLEDRGB(uint8_t r, uint8_t g, uint8_t b, uint8_t brightness, uint8_t f
     actual[1] = g;
     actual[2] = b;
     for (int i=0; i<3; i++) {
-        actual[i] = (uint32_t(actual[i])*brightness*Get_RGB_LED_Max_Value())>>16;
+        actual[i] = (uint32_t(actual[i])*brightness*HAL_Led_Rgb_Get_Max_Value(nullptr))>>16;
         actual[i] = actual[i]*fade/99;
         REQUIRE((actual[i]>>8) == (rgb_values[i]>>8) );
     }

--- a/user/tests/wiring/no_fixture/led.cpp
+++ b/user/tests/wiring/no_fixture/led.cpp
@@ -72,7 +72,8 @@ test(LED_01_Updated) {
     uint32_t end = rgbNotifyCount;
     RGB.onChange(NULL);
 
-    assertMore((end-start), uint32_t(20)); // I think it's meant to be 100Hz, but this is fine as a smoke test
+    // onChange callback is called every 25ms, so 500ms / 25ms = 20
+    assertMoreOrEqual((end-start), uint32_t(20));
 }
 
 


### PR DESCRIPTION
- RGB LED Service should use LED_Callbacks struct to obtain rgbled_hal functions.
- Mock both old and new rgbled_hal functions in unit tests
- Fixes `LED_01_Updated` test from `wiring/no_fixture`

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled

N/A - fixes to 0.6.1-rc.1 commits

- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)