### PR TITLE
[Electron] SYSTEM_04_button_mirror test fix

### DIFF
--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -88,6 +88,7 @@ test(SYSTEM_04_button_mirror)
     auto pinmap = HAL_Pin_Map();
     System.on(button_click, onButtonClick);
 
+    // "Click" setup button 3 times
     // First click
     pinMode(D1, INPUT_PULLDOWN);
     // Just in case manually trigger EXTI interrupt
@@ -102,9 +103,17 @@ test(SYSTEM_04_button_mirror)
     EXTI_GenerateSWInterrupt(pinmap[D1].gpio_pin);
     delay(300);
     pinMode(D1, INPUT_PULLUP);
+    delay(100);
+
+    // Third click
+    pinMode(D1, INPUT_PULLDOWN);
+    // Just in case manually trigger EXTI interrupt
+    EXTI_GenerateSWInterrupt(pinmap[D1].gpio_pin);
+    delay(300);
+    pinMode(D1, INPUT_PULLUP);
     delay(300);
 
-    assertEqual(s_button_clicks, 2);
+    assertEqual(s_button_clicks, 3);
 }
 
 test(SYSTEM_05_button_mirror_disable)


### PR DESCRIPTION
SYSTEM_04_button_mirror should "click" SETUP button 3 times instead of 2, as double-click causes Electron to enter soft power down mode.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled

N/A - fixes to 0.6.1-rc.1 commits

- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)