### PR TITLE
Disable dynamically configurable logging by default

### DIFF
--- a/user/tests/accept/features/logging/log_config_app/app.cpp
+++ b/user/tests/accept/features/logging/log_config_app/app.cpp
@@ -2,6 +2,9 @@
 
 SYSTEM_MODE(MANUAL)
 
+// Enable dynamically configurable logging
+STARTUP(System.enableFeature(FEATURE_CONFIGURABLE_LOGGING))
+
 bool usb_request_custom_handler(char* buf, size_t bufSize, size_t reqSize, size_t* repSize) {
     const char* msg = "Test message";
     const char* cat = "app"; // Category name

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -24,6 +24,7 @@
 #define SPARK_WIRING_SYSTEM_H
 #include "spark_wiring_ticks.h"
 #include "spark_wiring_string.h"
+#include "spark_wiring_platform.h"
 #include "spark_wiring_version.h"
 #include "system_mode.h"
 #include "system_update.h"
@@ -68,6 +69,11 @@ private:
 const SleepNetworkFlag SLEEP_NETWORK_OFF(SystemSleepNetwork::Off);
 const SleepNetworkFlag SLEEP_NETWORK_STANDBY(SystemSleepNetwork::Standby);
 
+#if Wiring_LogConfig
+enum LoggingFeature {
+    FEATURE_CONFIGURABLE_LOGGING = 1
+};
+#endif
 
 class SystemClass {
 public:
@@ -198,6 +204,10 @@ public:
     {
         return HAL_Feature_Set(feature, false);
     }
+
+#if Wiring_LogConfig
+    bool enableFeature(LoggingFeature feature);
+#endif
 
     String version()
     {

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -4,9 +4,14 @@
 #include "rgbled.h"
 #include "spark_wiring_wifi.h"
 #include "spark_wiring_cloud.h"
+#include "spark_wiring_logging.h"
 #include "system_task.h"
+#include "system_control.h"
 #include "system_network.h"
 
+#if Wiring_LogConfig
+extern bool(*log_process_config_request_callback)(char*, size_t, size_t, size_t*, DataFormat);
+#endif
 
 SystemClass System;
 
@@ -53,3 +58,10 @@ uint32_t SystemClass::freeMemory()
     HAL_Core_Runtime_Info(&info, NULL);
     return info.freeheap;
 }
+
+#if Wiring_LogConfig
+bool SystemClass::enableFeature(LoggingFeature) {
+    log_process_config_request_callback = spark::logProcessConfigRequest;
+    return true;
+}
+#endif


### PR DESCRIPTION
This PR makes dynamically configurable logging enabled only if application calls `System.enableFeature(FEATURE_CONFIGURABLE_LOGGING)` explicitly. This allows to significantly reduce size of application binary for applications that don't use logging.

No documentation is provided, since we currently don't have support for dynamically configurable logging in our developer tools, such as the CLI.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled

N/A updates to exiting PR's submitted for 0.6.1-rc.1 (CHANGELOG updated)

- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)

