### PR TITLE
Additional argument for led_update() function for future extension

### DIFF
--- a/services/inc/led_service.h
+++ b/services/inc/led_service.h
@@ -73,8 +73,9 @@ void led_set_update_enabled(int enabled, void* reserved);
 int led_update_enabled(void* reserved);
 
 // Updates LED color according to a number of ticks passed since previous update. This function needs
-// to be called periodically
-void led_update(system_tick_t ticks, void* reserved);
+// to be called periodically. TODO: If `status` is not null, LED will be updated only if specified
+// status has a highest priority among other active statuses
+void led_update(system_tick_t ticks, LEDStatusData* status, void* reserved);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/services/inc/services_dynalib.h
+++ b/services/inc/services_dynalib.h
@@ -65,7 +65,7 @@ DYNALIB_FN(31, services, LED_SetCallbacks, void(LedCallbacks, void*))
 DYNALIB_FN(32, services, led_set_status_active, void(LEDStatusData*, int, void*))
 DYNALIB_FN(33, services, led_set_update_enabled, void(int, void*))
 DYNALIB_FN(34, services, led_update_enabled, int(void*))
-DYNALIB_FN(35, services, led_update, void(system_tick_t, void*))
+DYNALIB_FN(35, services, led_update, void(system_tick_t, LEDStatusData*, void*))
 
 DYNALIB_END(services)
 

--- a/services/src/led_service.cpp
+++ b/services/src/led_service.cpp
@@ -287,6 +287,6 @@ int led_update_enabled(void* reserved) {
     return (ledService.isUpdateEnabled() ? 1 : 0);
 }
 
-void led_update(system_tick_t ticks, void* reserved) {
+void led_update(system_tick_t ticks, LEDStatusData* status, void* reserved) {
     ledService.update(ticks);
 }

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -409,7 +409,7 @@ extern "C" void HAL_SysTick_Handler(void)
     static uint16_t ledUpdateTicks = LED_UPDATE_INTERVAL;
 
     if (--ledUpdateTicks == 0) {
-        led_update(LED_UPDATE_INTERVAL, nullptr);
+        led_update(LED_UPDATE_INTERVAL, nullptr, nullptr);
         ledUpdateTicks = LED_UPDATE_INTERVAL;
     }
 

--- a/user/tests/unit/led_service.cpp
+++ b/user/tests/unit/led_service.cpp
@@ -130,7 +130,7 @@ private:
 };
 
 inline void update(system_tick_t ticks = 0) {
-    led_update(ticks, nullptr);
+    led_update(ticks, nullptr, nullptr);
 }
 
 class PatternChecker {


### PR DESCRIPTION
This PR adds additional argument for dynalib-exported `led_update()` function (not used in any way at the moment). Motivation is to support real-time LED updates that comply to the LED priorities specified by the system in future.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [x] Add to CHANGELOG.md after merging (add links to docs and issues)