### PR TITLE
Move Keyboard and Mouse object instantiation into a function to reduce user-part binary size

### DIFF
--- a/wiring/inc/spark_wiring_usbkeyboard.h
+++ b/wiring/inc/spark_wiring_usbkeyboard.h
@@ -61,7 +61,9 @@ private:
   void sendReport();
 };
 
-extern USBKeyboard Keyboard;
+extern USBKeyboard& _fetch_usbkeyboard();
+#define Keyboard _fetch_usbkeyboard()
+
 #endif
 
 #endif

--- a/wiring/inc/spark_wiring_usbmouse.h
+++ b/wiring/inc/spark_wiring_usbmouse.h
@@ -98,7 +98,9 @@ public:
 	bool isPressed(uint8_t button = MOUSE_LEFT);	// check LEFT by default
 };
 
-extern USBMouse Mouse;
+extern USBMouse& _fetch_usbmouse();
+#define Mouse _fetch_usbmouse()
+
 #endif
 
 #endif

--- a/wiring/src/spark_wiring_usbkeyboard.cpp
+++ b/wiring/src/spark_wiring_usbkeyboard.cpp
@@ -354,6 +354,10 @@ void USBKeyboard::sendReport()
     }
 }
 
-//Preinstantiate Object
-USBKeyboard Keyboard;
+USBKeyboard& _fetch_usbkeyboard()
+{
+  static USBKeyboard _usbkeyboard;
+  return _usbkeyboard;
+}
+
 #endif

--- a/wiring/src/spark_wiring_usbmouse.cpp
+++ b/wiring/src/spark_wiring_usbmouse.cpp
@@ -187,6 +187,10 @@ void USBMouse::enableMoveTo(bool state)
     HAL_USB_HID_Set_State(0x03, (uint8_t)state, nullptr);
 }
 
-//Preinstantiate Object
-USBMouse Mouse;
+USBMouse& _fetch_usbmouse()
+{
+  static USBMouse _usbmouse;
+  return _usbmouse;
+}
+
 #endif


### PR DESCRIPTION
Allows the compiler to garbage collect USBKeyboard and USBMouse implementations if they are not used in user code, saving flash space.

```
arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 4.9.3 20141119 (release) [ARM/embedded-4_9-branch revision 218278]

Electron, 0.6.1-rc.1, app/blank:
   text	   data	    bss	    dec	    hex	filename
   5564	      8	   1640	   7212	   1c2c	../../../build/target/user-part/platform-10-m/blank.elf

Electron, this PR, app/blank:
   text	   data	    bss	    dec	    hex	filename
   4684	      8	   1572	   6264	   1878	../../../build/target/user-part/platform-10-m/blank.elf

Electron, this PR, app/blank + Mouse.begin() and Keyboard.begin():
   text	   data	    bss	    dec	    hex	filename
   5676	      8	   1652	   7336	   1ca8	../../../build/target/user-part/platform-10-m/blank.elf

```

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Enhancement

- [[PR #1224]](https://github.com/spark/firmware/pull/1224) Allow the compiler to garbage collect USBKeyboard and USBMouse implementations if they are not used in user code, saving flash space.