### PR TITLE
adding logging here without { } was publishing safe mode unconditionally

### DIFF
--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -697,9 +697,10 @@ int Spark_Handshake(bool presence_announce)
             LOG(INFO,"spark/hardware/ota_chunk_size event");
             Particle.publish("spark/hardware/ota_chunk_size", buf, 60, PRIVATE);
         }
-        if (system_mode()==SAFE_MODE)
+        if (system_mode()==SAFE_MODE) {
             LOG(INFO,"Send spark/device/safemode event");
             Particle.publish("spark/device/safemode","", 60, PRIVATE);
+        }
 #if defined(SPARK_SUBSYSTEM_EVENT_NAME)
         if (!HAL_core_subsystem_version(buf, sizeof (buf)) && *buf)
         {


### PR DESCRIPTION
Adding logging here without { } was publishing safe mode unconditionally

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device (N/A)
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bugfixes

- [[PR #1230]](https://github.com/spark/firmware/pull/1230) Safe Mode event was being published unconditionally