### PR TITLE
[Electron] Fixes double newline parser issue on G350 introduced in 428835a

### DIFF
--- a/hal/src/electron/modem/enums_hal.h
+++ b/hal/src/electron/modem/enums_hal.h
@@ -167,6 +167,7 @@ enum {
     TYPE_PLUS       = 0x400000,
     TYPE_TEXT       = 0x500000,
     TYPE_ABORTED    = 0x600000,
+    TYPE_DBLNEWLINE = 0x700000,
 
     // special timout constant
     TIMEOUT_BLOCKING = 0xffffffff

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -2253,36 +2253,40 @@ int MDMParser::_getLine(Pipe<char>* pipe, char* buf, int len)
             { "\r\n>",                  NULL,               TYPE_PROMPT     }, // SMS
             { "\n>",                    NULL,               TYPE_PROMPT     }, // File
             { "\r\nABORTED\r\n",        NULL,               TYPE_ABORTED    }, // Current command aborted
-            { "\r\n\r\n",               "\r\n",             TYPE_DBLNEWLINE }, // Double CRLF detected, discard one and reprocess line
+            { "\r\n\r\n",               "\r\n",             TYPE_DBLNEWLINE }, // Double CRLF detected
             { "\r\n",                   "\r\n",             TYPE_UNKNOWN    }, // If all else fails, break up generic strings
         };
         for (int i = 0; i < (int)(sizeof(lutF)/sizeof(*lutF)); i ++) {
             pipe->set(unkn);
             int ln = _parseFormated(pipe, len, lutF[i].fmt);
-            if (ln == WAIT && fr)
+            if (ln == WAIT && fr) {
                 return WAIT;
-            if ((ln != NOT_FOUND) && (unkn > 0))
+            }
+            if ((ln != NOT_FOUND) && (unkn > 0)) {
                 return TYPE_UNKNOWN | pipe->get(buf, unkn);
-            if (ln > 0)
+            }
+            if (ln > 0) {
                 return lutF[i].type  | pipe->get(buf, ln);
+            }
         }
         for (int i = 0; i < (int)(sizeof(lut)/sizeof(*lut)); i ++) {
             pipe->set(unkn);
             int ln = _parseMatch(pipe, len, lut[i].sta, lut[i].end);
-            if (ln == WAIT && fr)
+            if (ln == WAIT && fr) {
                 return WAIT;
-            // Double CRLF detected, discard one and reprocess line.
-            // This resolves a case on G350 where "\r\n" is generated after +USORF response, but missing
-            // on U260/U270, which would otherwise generate "\r\n\r\nOK\r\n" which is not parsable.
-            if ((ln > 0) && (lut[i].type == TYPE_DBLNEWLINE) && (unkn == 0)) {
-                char tmp[2];
-                pipe->get(tmp, 2);
-                break;
             }
-            if ((ln != NOT_FOUND) && (unkn > 0))
+            // Double CRLF detected, discard it.
+            // This resolves a case on G350 where "\r\n" is generated after +USORF response, but missing
+            // on U260/U270, which would otherwise generate "\r\n\r\nOK\r\n" which is not parseable.
+            if ((ln > 0) && (lut[i].type == TYPE_DBLNEWLINE) && (unkn == 0)) {
+                return TYPE_UNKNOWN | pipe->get(buf, 2);
+            }
+            if ((ln != NOT_FOUND) && (unkn > 0)) {
                 return TYPE_UNKNOWN | pipe->get(buf, unkn);
-            if (ln > 0)
+            }
+            if (ln > 0) {
                 return lut[i].type | pipe->get(buf, ln);
+            }
         }
         // UNKNOWN
         unkn ++;


### PR DESCRIPTION
Fixes double newline parser issue on G350 introduced in 428835a

This resolves a case on G350 where **\r\n** is generated after **+USORF** response, but missing
on U260/U270, which would otherwise generate **\r\n\r\nOK\r\n** which is not parseable.  This was preventing the G350 from handshaking with the Cloud on v0.6.1-rc.1.

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [x] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bug fixes

- [[PR #1231]](https://github.com/spark/firmware/pull/1231) [Electron] fixes double newline parser issue on G350 introduced in 428835a v0.6.1-rc.1