### PR TITLE
-Wundef warnings on by default / preprocessor fixes 

### DIFF
--- a/build/gcc-tools.mk
+++ b/build/gcc-tools.mk
@@ -14,8 +14,7 @@ endif
 
 # C compiler flags
 CFLAGS +=  -g3 -m64 -O$(GCC_OPTIMIZE) -gdwarf-2
-CFLAGS += -Wno-unused-local-typedefs -Wno-return-type-c-linkage 
-CPPFLAGS += -Wno-unused-private-field
+CFLAGS += -Wno-unused-local-typedefs
 ASFLAGS +=  -g3
 
 
@@ -27,7 +26,10 @@ ifneq ($(MAKE_OS),OSX)
 LDFLAGS += -Xlinker --gc-sections
 endif
 
-
+ifeq ($(MAKE_OS),OSX)
+CFLAGS += -Wno-return-type-c-linkage
+CPPFLAGS += -Wno-unused-private-field
+endif
 
 
 

--- a/build/module-defaults.mk
+++ b/build/module-defaults.mk
@@ -60,6 +60,8 @@ CFLAGS += -ffunction-sections -fdata-sections -Wall -Wno-switch -Wno-error=depre
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -DSPARK=1 -DPARTICLE=1
 
+CFLAGS += -Wundef
+
 ifdef START_DFU_FLASHER_SERIAL_SPEED
 CFLAGS += -DSTART_DFU_FLASHER_SERIAL_SPEED=$(START_DFU_FLASHER_SERIAL_SPEED)
 endif

--- a/dynalib/inc/dynalib.h
+++ b/dynalib/inc/dynalib.h
@@ -53,7 +53,7 @@
     dynalib_##tablename
 
 
-#if __cplusplus >= 201103 // C++11
+#if defined(__cplusplus) && __cplusplus >= 201103 // C++11
 
 #include <type_traits>
 
@@ -69,7 +69,7 @@ constexpr const void* dynalib_checked_cast(T2 *p) {
 #define DYNALIB_STATIC_ASSERT(cond, msg) \
     static_assert(cond, msg)
 
-#elif __STDC_VERSION__ >= 199901 && !__STRICT_ANSI__ // C99 with GNU extensions
+#elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901) && !(defined(__STRICT_ANSI__) && __STRICT_ANSI__) // C99 with GNU extensions
 
 #define DYNALIB_FN_EXPORT(index, tablename, name, type) \
     __builtin_choose_expr(__builtin_types_compatible_p(type, __typeof__(name)), (const void*)&name, sizeof(struct { \

--- a/hal/src/gcc/boost_asio.cpp
+++ b/hal/src/gcc/boost_asio.cpp
@@ -19,4 +19,4 @@
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
 #endif
-#include <boost/asio/impl/src.hpp>
+#include "boost_asio_impl_src_wrap.h"

--- a/hal/src/gcc/boost_asio_impl_src_wrap.h
+++ b/hal/src/gcc/boost_asio_impl_src_wrap.h
@@ -1,0 +1,2 @@
+#pragma GCC system_header
+#include <boost/asio/impl/src.hpp>

--- a/hal/src/gcc/boost_asio_wrap.h
+++ b/hal/src/gcc/boost_asio_wrap.h
@@ -1,0 +1,2 @@
+#pragma GCC system_header
+#include <boost/asio.hpp>

--- a/hal/src/gcc/boost_program_options_wrap.h
+++ b/hal/src/gcc/boost_program_options_wrap.h
@@ -1,0 +1,2 @@
+#pragma GCC system_header
+#include <boost/program_options.hpp>

--- a/hal/src/gcc/boost_signals2_wrap.h
+++ b/hal/src/gcc/boost_signals2_wrap.h
@@ -1,0 +1,2 @@
+#pragma GCC system_header
+#include <boost/signals2.hpp>

--- a/hal/src/gcc/boost_thread_wrap.h
+++ b/hal/src/gcc/boost_thread_wrap.h
@@ -1,0 +1,2 @@
+#pragma GCC system_header
+#include <boost/thread/thread.hpp>

--- a/hal/src/gcc/delay_hal.cpp
+++ b/hal/src/gcc/delay_hal.cpp
@@ -19,8 +19,13 @@
 #include "delay_hal.h"
 #include "timer_hal.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/thread/thread.hpp>
+#include "boost_thread_wrap.h"
+
+#pragma GCC diagnostic pop
 
 void HAL_Delay_Milliseconds(uint32_t millis)
 {

--- a/hal/src/gcc/device_config.cpp
+++ b/hal/src/gcc/device_config.cpp
@@ -24,7 +24,7 @@
 #include <istream>
 #include <iostream>
 
-#include <boost/program_options.hpp>
+#include "boost_program_options_wrap.h"
 #include <boost/format.hpp>
 
 namespace po = boost::program_options;

--- a/hal/src/gcc/device_globals.h
+++ b/hal/src/gcc/device_globals.h
@@ -9,7 +9,7 @@
 // cc1plus: error: unrecognized command line option "-Wno-return-type-c-linkage" [-Werror]
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
 #endif
-#include <boost/asio.hpp>
+#include "boost_asio_wrap.h"
 #pragma GCC diagnostic pop
 
 extern boost::asio::io_service device_io_service;

--- a/hal/src/gcc/gpio_hal.cpp
+++ b/hal/src/gcc/gpio_hal.cpp
@@ -2,7 +2,7 @@
 #include "gpio_hal.h"
 #include <string>
 #include <utility>
-#include <boost/signals2.hpp>
+#include "boost_signals2_wrap.h"
 
 using std::string;
 

--- a/hal/src/gcc/pinger.cpp
+++ b/hal/src/gcc/pinger.cpp
@@ -21,7 +21,7 @@
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
 #endif
-#include <boost/asio.hpp>
+#include "boost_asio_wrap.h"
 #pragma GCC diagnostic pop
 
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -162,7 +162,7 @@ class SocketUsartServer : public SocketUsartBase {
 
 
 Usart& usartMap(unsigned index) {
-#if SPARK_TEST_DRIVER==1
+#if defined(SPARK_TEST_DRIVER) && SPARK_TEST_DRIVER==1
 static SocketUsartServer usart1 = SocketUsartServer();
 static SocketUsartServer usart2 = SocketUsartServer();
 #else

--- a/modules/shared/stm32f2xx/inc/system_part2_loader.c
+++ b/modules/shared/stm32f2xx/inc/system_part2_loader.c
@@ -23,7 +23,7 @@ extern void* sbrk_heap_top;
  */
 void system_part2_pre_init() {
     // initialize dependent modules
-#if MODULE_HAS_SYSTEM_PART3
+#if defined(MODULE_HAS_SYSTEM_PART3) && MODULE_HAS_SYSTEM_PART3
     module_system_part3_pre_init();
 #endif
     module_system_part1_pre_init();
@@ -44,7 +44,7 @@ void system_part2_pre_init() {
 
     // now call any C++ constructors in this module's dependencies
 
-#if MODULE_HAS_SYSTEM_PART3
+#if defined(MODULE_HAS_SYSTEM_PART3) && MODULE_HAS_SYSTEM_PART3
     module_system_part3_init();
 #endif
     module_system_part1_init();

--- a/newlib_nano/src/mallocr.c
+++ b/newlib_nano/src/mallocr.c
@@ -52,7 +52,7 @@
 #define DEFINE_MEMALIGN
 #define DEFINE_CFREE
 
-#if DEBUG
+#if defined(DEBUG) && DEBUG
 #include <assert.h>
 #else
 #define assert(x) ((void)0)

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/hw_config.h
@@ -42,6 +42,7 @@
 #if defined(HAS_SERIAL_FLASH)
 #include "spi_flash.h"
 #endif
+#include "module_info.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/flash_mal.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/flash_mal.c
@@ -102,7 +102,7 @@ uint32_t EndOfFlashSector(flash_device_t device, uint32_t address)
 		uint16_t sector = addressToSectorIndex(address);
 		end = sectorIndexToStartAddress(sector+1);
 	}
-#if USE_SERIAL_FLASH
+#ifdef USE_SERIAL_FLASH
 	else if (device==FLASH_SERIAL)
 	{
 		uint16_t sector = address / sFLASH_PAGESIZE;

--- a/platform/shared/inc/platforms.h
+++ b/platform/shared/inc/platforms.h
@@ -34,7 +34,7 @@
 #define PLATFORM_P1                         8
 #define PLATFORM_ETHERNET_PROTO             9
 #define PLATFORM_ELECTRON_PRODUCTION        10
-
+#define PLATFORM_NEWHAL                     60000
 
 #endif	/* PLATFORMS_H */
 

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -514,7 +514,7 @@ void app_loop(bool threaded)
                 if (system_mode()!=SAFE_MODE)
                  setup();
                 SPARK_WIRING_APPLICATION = 1;
-#if !MODULAR_FIRMWARE
+#if !(defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE)
                 _post_loop();
 #endif
             }
@@ -524,7 +524,7 @@ void app_loop(bool threaded)
             if (system_mode()!=SAFE_MODE) {
                 loop();
                 DECLARE_SYS_HEALTH(RAN_Loop);
-#if !MODULAR_FIRMWARE
+#if !(defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE)
                 _post_loop();
 #endif
 #if Wiring_Cellular == 1

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -685,7 +685,7 @@ int Spark_Handshake(bool presence_announce)
         }
 
         bool udp = HAL_Feature_Get(FEATURE_CLOUD_UDP);
-#if PLATFORM_ID!=PLATFORM_ELECTRON || !defined(MODULAR_FIRMWARE)
+#if PLATFORM_ID!=PLATFORM_ELECTRON_PRODUCTION || !defined(MODULAR_FIRMWARE)
         ultoa(HAL_OTA_FlashLength(), buf, 10);
         LOG(INFO,"Send spark/hardware/max_binary event");
         Particle.publish("spark/hardware/max_binary", buf, 60, PRIVATE);

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -438,7 +438,7 @@ public:
             off_now();
 
             SPARK_WLAN_SLEEP = 1;
-#if !SPARK_NO_CLOUD
+#ifndef SPARK_NO_CLOUD
             if (disconnect_cloud) {
                 spark_cloud_flag_disconnect();
             }

--- a/user/import.mk
+++ b/user/import.mk
@@ -23,6 +23,11 @@ USER_LIB_DEP = $(USER_LIB_DIR)/libuser.a
 
 CFLAGS += -DINCLUDE_PLATFORM=1
 
+# platforms.h
+ifeq ($(PLATFORM_ID),3)
+INCLUDE_DIRS += $(PROJECT_ROOT)/platform/shared/inc
+endif
+
 # gcc HAL is different for test driver and test subject
 ifeq "$(SPARK_TEST_DRIVER)" "1"
 USER_FLAVOR+=-driver

--- a/user/tests/libraries/unit-test/ParticleFunbag.cpp
+++ b/user/tests/libraries/unit-test/ParticleFunbag.cpp
@@ -234,7 +234,7 @@ int SparkTestRunner::testStatusColor() {
  * Returns the number of bytes of data available in the variable
  */
 int advanceLog() {
-#if FLASHEE_EEPROM
+#ifdef FLASHEE_EEPROM
     int end = sizeof(buf)-1;
     int read = cblog->read_soft(buf, end);
     buf[read] = 0;  // terminate string

--- a/user/tests/libraries/unit-test/flashee-eeprom.cpp
+++ b/user/tests/libraries/unit-test/flashee-eeprom.cpp
@@ -16,7 +16,7 @@
  */
 #include "flashee-eeprom.h"
 
-#if FLASHEE_FATFS_SUPPORT
+#if FLASHEE_FAT_FS_SUPPORT
 #include "diskio.h"
 #include "FlashIO.h"
 #include "ff.h"
@@ -73,7 +73,7 @@ bool FlashDevice::comparePage(const void* data, flash_addr_t address, page_size_
 }
 #endif
 
-#if FLASHEE_FATFS_SUPPORT
+#if FLASHEE_FAT_FS_SUPPORT
 
 FRESULT Flashee::Devices::createFATRegion(flash_addr_t startAddress, flash_addr_t endAddress,
     FATFS* pfs, FormatCmd formatCmd) {

--- a/user/tests/libraries/unit-test/flashee-eeprom.h
+++ b/user/tests/libraries/unit-test/flashee-eeprom.h
@@ -31,7 +31,7 @@
 #endif
 
 
-#if FLASHEE_FATFS_SUPPORT
+#if FLASHEE_FAT_FS_SUPPORT
 #include "FlashIO.h"
 #endif
 
@@ -581,7 +581,7 @@ public:
         return device ? new CircularBuffer(*device) : NULL;
     }
 
-#if FLASHEE_FATFS_SUPPORT
+#if FLASHEE_FAT_FS_SUPPORT
     /**
      * Allocates a region of flash for storing a FAT filesystem. If an existing filesystem
      * has alredy been created elsewhere, that volume is closed. (Only one volume can be

--- a/user/tests/unit/makefile
+++ b/user/tests/unit/makefile
@@ -78,6 +78,7 @@ INCLUDE_DIRS += $(HAL)shared
 INCLUDE_DIRS += $(HAL)inc
 INCLUDE_DIRS += $(COMMUNICATION)src
 INCLUDE_DIRS += dynalib/inc
+INCLUDE_DIRS += platform/shared/inc
 
 # prefix $(SRC_ROOT)
 ABS_INCLUDE_DIRS += $(patsubst %,$(SRC_ROOT)/%,$(INCLUDE_DIRS))

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -117,7 +117,7 @@ test(system_waitfor) {
 test(system_config_set) {
 
     API_COMPILE(System.set(SYSTEM_CONFIG_DEVICE_KEY, NULL, 123));
-#if PLATFORM == photon
+#if PLATFORM_ID == PLATFORM_PHOTON_PRODUCTION
     API_COMPILE(System.set(SYSTEM_CONFIG_SOFTAP_PREFIX, "hello"));
     API_COMPILE(System.set(SYSTEM_CONFIG_SOFTAP_SUFFIX, "hello"));
 #endif

--- a/wiring/inc/fast_pin.h
+++ b/wiring/inc/fast_pin.h
@@ -21,6 +21,8 @@
 #ifndef FAST_PIN_H
 #define	FAST_PIN_H
 
+#include "platforms.h"
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
@@ -136,7 +138,7 @@ inline int32_t pinReadFast(pin_t _pin)
 void pinResetFast(pin_t _pin);
 void pinSetFast(pin_t _pin);
 void pinReadFast(pin_t _pin);
-#elif PLATFORM==newhal
+#elif PLATFORM_ID==PLATFORM_NEWHAL
     // no need to generate a warning for newhal
     #define pinSetFast(pin) digitalWrite(pin, HIGH)
     #define pinResetFast(pin) digitalWrite(pin, LOW)

--- a/wiring/inc/spark_wiring_platform.h
+++ b/wiring/inc/spark_wiring_platform.h
@@ -1,6 +1,7 @@
 #ifndef SPARK_WIRING_PLATFORM_H
 #define	SPARK_WIRING_PLATFORM_H
 
+#include "platforms.h"
 #include "inet_hal.h"
 
 /**
@@ -43,7 +44,7 @@
 
 #if PLATFORM_ID==6      // photon
 #define Wiring_WiFi 1
-#define Wiring_IPv6 1
+#define Wiring_IPv6 0
 #define Wiring_SPI1 1
 #define Wiring_Serial2 1
 #define Wiring_USBSerial1 1
@@ -64,7 +65,7 @@
 
 #if PLATFORM_ID==8      // P1 / bm14
 #define Wiring_WiFi 1
-#define Wiring_IPv6 1
+#define Wiring_IPv6 0
 #define Wiring_SPI1 1
 #define Wiring_Serial2 1
 #define Wiring_USBSerial1 1
@@ -145,6 +146,10 @@
 
 #ifndef Wiring_LogConfig
 #define Wiring_LogConfig 0
+#endif
+
+#ifndef Wiring_IPv6
+#define Wiring_IPv6 0
 #endif
 
 #endif	/* SPARK_WIRING_PLATFORM_H */

--- a/wiring/src/spark_wiring_interrupts.cpp
+++ b/wiring/src/spark_wiring_interrupts.cpp
@@ -26,6 +26,7 @@
  ******************************************************************************
  */
 #include "spark_wiring_interrupts.h"
+#include "spark_wiring_platform.h"
 
 static wiring_interrupt_handler_t* handlers[TOTAL_PINS];
 

--- a/wiring/src/spark_wiring_ipaddress.cpp
+++ b/wiring/src/spark_wiring_ipaddress.cpp
@@ -26,6 +26,7 @@
 
 #include "spark_wiring_ipaddress.h"
 #include "spark_wiring_print.h"
+#include "spark_wiring_platform.h"
 #include "string.h"
 
 IPAddress::IPAddress()

--- a/wiring_globals/makefile
+++ b/wiring_globals/makefile
@@ -7,6 +7,6 @@ TARGET_TYPE = a
 BUILD_PATH_EXT = $(BUILD_TARGET_PLATFORM)
 
 # the only true dependency is Wiring, the others are transitive dependencies
-DEPENDENCIES = wiring hal services system communication
+DEPENDENCIES = wiring hal services system platform communication
 
 include ../build/arm-tlm.mk


### PR DESCRIPTION
This PR introduces the following changes:
- Turns on `-Wundef` when building firmware. Coupled with `-Werror`, this should allow to catch all the broken preprocessor conditionals
- Fixes preprocessor errors encountered after ^
- Due to a bug in gcc, `#pragma GCC diagnostic` doesn't seem to be applied (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431) causing errors when including boost. Boost headers that cause errors with `-Wundef` and `-Werror` are wrapped in separate header files with `#pragma GCC system_header` which causes warnings to be treated as warnings again.

This PR also fixes #1139.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation (specifically what errors may have been lurking before and how they might have affected users)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bugfix

- [[PR #1234]](https://github.com/spark/firmware/pull/1234) [[Fixes #1139]](https://github.com/spark/firmware/issues/1139) [Electron] `spark/hardware/max_binary` event was sent in error, adding 69 more bytes of data to handshake (full or session resume). Also fixes other preprocessor errors.