### PR TITLE
Particle.publish() flags fixes

### DIFF
--- a/user/tests/unit/flags.cpp
+++ b/user/tests/unit/flags.cpp
@@ -1,0 +1,258 @@
+#include "spark_wiring_flags.h"
+
+#include "tools/catch.h"
+
+#include <limits>
+
+namespace {
+
+using namespace particle;
+
+enum FlagUint {
+    FLAG_1 = 0x01,
+    FLAG_2 = 0x02,
+    FLAG_NONE = 0x00,
+    FLAG_ALL = std::numeric_limits<unsigned>::max()
+};
+
+enum class FlagUint8: uint8_t {
+    FLAG_1 = 0x01,
+    FLAG_2 = 0x02,
+    FLAG_NONE = 0x00,
+    FLAG_ALL = 0xff
+};
+
+enum class FlagUint64: uint64_t {
+    FLAG_1 = 0x01,
+    FLAG_2 = 0x02,
+    FLAG_NONE = 0x00,
+    FLAG_ALL = 0xffffffffffffffffull
+};
+
+PARTICLE_DEFINE_FLAG_OPERATORS(FlagUint)
+PARTICLE_DEFINE_FLAG_OPERATORS(FlagUint8)
+PARTICLE_DEFINE_FLAG_OPERATORS(FlagUint64)
+
+template<typename FlagsT>
+void testFlags() {
+    using Flags = FlagsT;
+    using Enum = typename Flags::EnumType;
+    using Value = typename Flags::ValueType;
+
+    SECTION("Flags()") {
+        // Flags()
+        Flags f1;
+        CHECK(f1.value() == 0x00);
+        // Flags(ValueType)
+        Flags f2(0x01);
+        CHECK(f2.value() == 0x01);
+        // Flags(T)
+        Flags f3(Enum::FLAG_1);
+        CHECK(f3.value() == 0x01);
+        // Flags(const Flags&)
+        Flags f4(f3);
+        CHECK(f4.value() == f3.value());
+    }
+
+    SECTION("operator|()") {
+        // operator|(T, T)
+        Flags f1;
+        f1 = Enum::FLAG_NONE | Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        f1 = Enum::FLAG_1 | Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        f1 = Enum::FLAG_1 | Enum::FLAG_2;
+        CHECK(f1.value() == 0x03);
+        // operator|(T, Flags)
+        Flags f2;
+        f2 = Enum::FLAG_NONE | Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 = Enum::FLAG_1 | Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 = Enum::FLAG_1 | Flags(Enum::FLAG_2);
+        CHECK(f2.value() == 0x03);
+        // operator|(Flags, T)
+        Flags f3;
+        f3 = Flags(Enum::FLAG_NONE) | Enum::FLAG_1;
+        CHECK(f3.value() == 0x01);
+        f3 = Flags(Enum::FLAG_1) | Enum::FLAG_1;
+        CHECK(f3.value() == 0x01);
+        f3 = Flags(Enum::FLAG_1) | Enum::FLAG_2;
+        CHECK(f3.value() == 0x03);
+        // operator|(Flags, Flags)
+        Flags f4;
+        f4 = Flags(Enum::FLAG_NONE) | Flags(Enum::FLAG_1);
+        CHECK(f4.value() == 0x01);
+        f4 = Flags(Enum::FLAG_1) | Flags(Enum::FLAG_1);
+        CHECK(f4.value() == 0x01);
+        f4 = Flags(Enum::FLAG_1) | Flags(Enum::FLAG_2);
+        CHECK(f4.value() == 0x03);
+    }
+
+    SECTION("operator|=()") {
+        // operator|=(T)
+        Flags f1;
+        f1 |= Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        f1 |= Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        f1 |= Enum::FLAG_2;
+        CHECK(f1.value() == 0x03);
+        // operator|=(Flags)
+        Flags f2;
+        f2 |= Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 |= Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 |= Flags(Enum::FLAG_2);
+        CHECK(f2.value() == 0x03);
+    }
+
+    SECTION("operator&()") {
+        // operator&(T, Flags)
+        Flags f1;
+        f1 = Enum::FLAG_NONE & Flags(Enum::FLAG_1);
+        CHECK(f1.value() == 0x00);
+        f1 = Enum::FLAG_1 & Flags(Enum::FLAG_1);
+        CHECK(f1.value() == 0x01);
+        f1 = Enum::FLAG_1 & Flags(Enum::FLAG_2);
+        CHECK(f1.value() == 0x00);
+        // operator&(Flags, T)
+        Flags f2;
+        f2 = Flags(Enum::FLAG_NONE) & Enum::FLAG_1;
+        CHECK(f2.value() == 0x00);
+        f2 = Flags(Enum::FLAG_1) & Enum::FLAG_1;
+        CHECK(f2.value() == 0x01);
+        f2 = Flags(Enum::FLAG_1) & Enum::FLAG_2;
+        CHECK(f2.value() == 0x00);
+        // operator&(Flags, Flags)
+        Flags f3;
+        f3 = Flags(Enum::FLAG_NONE) & Flags(Enum::FLAG_1);
+        CHECK(f3.value() == 0x00);
+        f3 = Flags(Enum::FLAG_1) & Flags(Enum::FLAG_1);
+        CHECK(f3.value() == 0x01);
+        f3 = Flags(Enum::FLAG_1) & Flags(Enum::FLAG_2);
+        CHECK(f3.value() == 0x00);
+    }
+
+    SECTION("operator&=()") {
+        // operator&=(T)
+        Flags f1(0x03);
+        f1 &= Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        f1 &= Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        f1 &= Enum::FLAG_2;
+        CHECK(f1.value() == 0x00);
+        // operator&=(Flags)
+        Flags f2(0x03);
+        f2 &= Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 &= Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 &= Flags(Enum::FLAG_2);
+        CHECK(f2.value() == 0x00);
+    }
+
+    SECTION("operator^()") {
+        // operator^(T, Flags)
+        Flags f2;
+        f2 = Enum::FLAG_NONE ^ Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 = Enum::FLAG_1 ^ Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x00);
+        f2 = Enum::FLAG_1 ^ Flags(Enum::FLAG_2);
+        CHECK(f2.value() == 0x03);
+        // operator^(Flags, T)
+        Flags f3;
+        f3 = Flags(Enum::FLAG_NONE) ^ Enum::FLAG_1;
+        CHECK(f3.value() == 0x01);
+        f3 = Flags(Enum::FLAG_1) ^ Enum::FLAG_1;
+        CHECK(f3.value() == 0x00);
+        f3 = Flags(Enum::FLAG_1) ^ Enum::FLAG_2;
+        CHECK(f3.value() == 0x03);
+        // operator^(Flags, Flags)
+        Flags f4;
+        f4 = Flags(Enum::FLAG_NONE) ^ Flags(Enum::FLAG_1);
+        CHECK(f4.value() == 0x01);
+        f4 = Flags(Enum::FLAG_1) ^ Flags(Enum::FLAG_1);
+        CHECK(f4.value() == 0x00);
+        f4 = Flags(Enum::FLAG_1) ^ Flags(Enum::FLAG_2);
+        CHECK(f4.value() == 0x03);
+    }
+
+    SECTION("operator^=()") {
+        // operator^=(T)
+        Flags f1;
+        f1 ^= Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        f1 ^= Enum::FLAG_1;
+        CHECK(f1.value() == 0x00);
+        f1 ^= Enum::FLAG_2;
+        CHECK(f1.value() == 0x02);
+        // operator^=(Flags)
+        Flags f2;
+        f2 ^= Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        f2 ^= Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x00);
+        f2 ^= Flags(Enum::FLAG_2);
+        CHECK(f2.value() == 0x02);
+    }
+
+    SECTION("operator~()") {
+        Flags f1 = ~Flags(Enum::FLAG_NONE);
+        CHECK(f1.value() == (Value)Enum::FLAG_ALL);
+        Flags f2 = ~Flags(Enum::FLAG_ALL);
+        CHECK(f2.value() == (Value)Enum::FLAG_NONE);
+    }
+
+    SECTION("operator=()") {
+        // operator=(T)
+        Flags f1;
+        f1 = Enum::FLAG_1;
+        CHECK(f1.value() == 0x01);
+        // operator=(Flags)
+        Flags f2;
+        f2 = Flags(Enum::FLAG_1);
+        CHECK(f2.value() == 0x01);
+        // operator=(ValueType)
+        Flags f3;
+        f3 = 0x01;
+        CHECK(f3.value() == 0x01);
+    }
+
+    SECTION("operator ValueType()") {
+        Flags f1(0x01);
+        CHECK((Value)f1 == 0x01);
+        CHECK(f1); // acts as implicit operator bool()
+        Flags f2;
+        CHECK((Value)f2 == 0x00);
+        CHECK_FALSE(f2);
+    }
+
+    SECTION("operator!()") {
+        Flags f1(0x01);
+        CHECK_FALSE(!f1);
+        Flags f2;
+        CHECK(!f2);
+    }
+
+    SECTION("underlying type fits all flag values") {
+        Flags f1(Enum::FLAG_ALL);
+        CHECK(f1.value() == (Value)Enum::FLAG_ALL);
+        Flags f2((Value)Enum::FLAG_ALL);
+        CHECK(f2.value() == (Value)Enum::FLAG_ALL);
+        Flags f3;
+        f3 = (Value)Enum::FLAG_ALL;
+        CHECK(f3.value() == (Value)Enum::FLAG_ALL);
+    }
+}
+
+} // namespace
+
+TEST_CASE("Flags<T>") {
+    testFlags<Flags<FlagUint>>();
+    testFlags<Flags<FlagUint8>>();
+    testFlags<Flags<FlagUint64>>();
+}

--- a/user/tests/unit/tools/catch.h
+++ b/user/tests/unit/tools/catch.h
@@ -6,7 +6,9 @@
 
 // Non-prefixed aliases for some typical macros that don't clash with the firmware
 #define CHECK(...) CATCH_CHECK(__VA_ARGS__)
+#define CHECK_FALSE(...) CATCH_CHECK_FALSE(__VA_ARGS__)
 #define REQUIRE(...) CATCH_REQUIRE(__VA_ARGS__)
+#define REQUIRE_FALSE(...) CATCH_REQUIRE_FALSE(__VA_ARGS__)
 #define FAIL(...) CATCH_FAIL(__VA_ARGS__)
 #define TEST_CASE(...) CATCH_TEST_CASE(__VA_ARGS__)
 #define SECTION(...) CATCH_SECTION(__VA_ARGS__)

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -64,7 +64,7 @@ test(api_spark_variable) {
     API_COMPILE(Particle.variable("mystring", valueString));
     API_COMPILE(Particle.variable("mystring", constValueString));
     API_COMPILE(Particle.variable("mystring", valueSmartString));
-    
+
     // This should gives a compiler error about too long name
     //API_COMPILE(Particle.variable("mystring123456789", valueString));
 
@@ -91,44 +91,37 @@ test(api_spark_function) {
 }
 
 test(api_spark_publish) {
+    // Particle.publish(const char*, const char*, ...)
+    API_COMPILE(Particle.publish("event"));
+    API_COMPILE(Particle.publish("event", PUBLIC));
+    API_COMPILE(Particle.publish("event", PUBLIC, NO_ACK));
+    API_COMPILE(Particle.publish("event", PUBLIC | NO_ACK)); // traditional syntax
 
-    API_COMPILE(Particle.publish("public event name"));
+    API_COMPILE(Particle.publish("event", "data"));
+    API_COMPILE(Particle.publish("event", "data", PUBLIC));
+    API_COMPILE(Particle.publish("event", "data", PUBLIC, NO_ACK));
+    API_COMPILE(Particle.publish("event", "data", PUBLIC | NO_ACK));
 
-    API_COMPILE(Particle.publish("public event name", "event data"));
+    API_COMPILE(Particle.publish("event", "data", 60));
+    API_COMPILE(Particle.publish("event", "data", 60, PUBLIC));
+    API_COMPILE(Particle.publish("event", "data", 60, PUBLIC, NO_ACK));
+    API_COMPILE(Particle.publish("event", "data", 60, PUBLIC | NO_ACK));
 
-    API_COMPILE(Particle.publish("public event name", "event data"));
+    // Particle.publish(String, String, ...)
+    API_COMPILE(Particle.publish(String("event")));
+    API_COMPILE(Particle.publish(String("event"), PUBLIC));
+    API_COMPILE(Particle.publish(String("event"), PUBLIC, NO_ACK));
+    API_COMPILE(Particle.publish(String("event"), PUBLIC | NO_ACK));
 
-    API_COMPILE(Particle.publish("public event name", "event data", 60));
+    API_COMPILE(Particle.publish(String("event"), String("data")));
+    API_COMPILE(Particle.publish(String("event"), String("data"), PUBLIC));
+    API_COMPILE(Particle.publish(String("event"), String("data"), PUBLIC, NO_ACK));
+    API_COMPILE(Particle.publish(String("event"), String("data"), PUBLIC | NO_ACK));
 
-    API_COMPILE(Particle.publish("public event name", "event data", 60, PUBLIC));
-
-    API_COMPILE(Particle.publish("private event name", "event data", 60, PRIVATE));
-
-    API_COMPILE(Particle.publish("public event name", PRIVATE));
-
-    API_COMPILE(Particle.publish("public event name", "event data", PRIVATE));
-
-    API_COMPILE(Particle.publish("public event name", PUBLIC));
-
-
-    API_COMPILE(Particle.publish(String("public event name")));
-
-    API_COMPILE(Particle.publish(String("public event name"), String("event data")));
-
-    API_COMPILE(Particle.publish(String("public event name"), String("event data")));
-
-    API_COMPILE(Particle.publish(String("public event name"), String("event data"), 60));
-
-    API_COMPILE(Particle.publish(String("public event name"), String("event data"), 60, PUBLIC));
-
-    API_COMPILE(Particle.publish(String("public event name"), String("event data"), 60, PRIVATE));
-
-    API_COMPILE(Particle.publish(String("public event name"), PRIVATE));
-
-    API_COMPILE(Particle.publish(String("public event name"), String("event data"), PRIVATE));
-
-    API_COMPILE(Particle.publish(String("public event name"), PUBLIC));
-
+    API_COMPILE(Particle.publish(String("event"), String("data"), 60));
+    API_COMPILE(Particle.publish(String("event"), String("data"), 60, PUBLIC));
+    API_COMPILE(Particle.publish(String("event"), String("data"), 60, PUBLIC, NO_ACK));
+    API_COMPILE(Particle.publish(String("event"), String("data"), 60, PUBLIC | NO_ACK));
 }
 
 test(api_spark_subscribe) {

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -29,9 +29,12 @@
 #include "spark_protocol_functions.h"
 #include "spark_wiring_system.h"
 #include "spark_wiring_watchdog.h"
+#include "spark_wiring_flags.h"
 #include "interrupts_hal.h"
 #include "system_mode.h"
 #include <functional>
+
+using particle::Flags;
 
 typedef std::function<user_function_int_str_t> user_std_function_int_str_t;
 typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
@@ -47,27 +50,14 @@ typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 #define	__XSTRING(x)	__STRING(x)	/* expand x, then stringify */
 #endif
 
-class PublishFlag
-{
-public:
-	typedef uint8_t flag_t;
-	PublishFlag(flag_t flag) : flag_(flag) {}
-
-	explicit operator flag_t() const { return flag_; }
-
-	flag_t flag() const { return flag_; }
-
-private:
-	flag_t flag_;
-
-
+enum PublishFlag: uint8_t {
+    PUBLIC = PUBLISH_EVENT_FLAG_PUBLIC,
+    PRIVATE = PUBLISH_EVENT_FLAG_PRIVATE,
+    NO_ACK = PUBLISH_EVENT_FLAG_NO_ACK,
+    WITH_ACK = PUBLISH_EVENT_FLAG_WITH_ACK
 };
 
-const PublishFlag PUBLIC(PUBLISH_EVENT_FLAG_PUBLIC);
-const PublishFlag PRIVATE(PUBLISH_EVENT_FLAG_PRIVATE);
-const PublishFlag NO_ACK(PUBLISH_EVENT_FLAG_NO_ACK);
-const PublishFlag WITH_ACK(PUBLISH_EVENT_FLAG_WITH_ACK);
-
+PARTICLE_DEFINE_FLAG_OPERATORS(PublishFlag)
 
 class CloudClass {
 
@@ -221,24 +211,19 @@ public:
       return _function(funcKey, std::bind(func, instance, _1));
     }
 
-    inline bool publish(const char *eventName, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, Flags<PublishFlag> flags1 = PUBLIC, Flags<PublishFlag> flags2 = Flags<PublishFlag>())
     {
-        return publish(eventName, NULL, 60, PublishFlag::flag_t(eventType));
+        return publish(eventName, NULL, flags1, flags2);
     }
 
-    inline bool publish(const char *eventName, const char *eventData, PublishFlag eventType=PUBLIC)
+    inline bool publish(const char *eventName, const char *eventData, Flags<PublishFlag> flags1 = PUBLIC, Flags<PublishFlag> flags2 = Flags<PublishFlag>())
     {
-        return publish(eventName, eventData, 60, PublishFlag::flag_t(eventType));
+        return publish(eventName, eventData, 60, flags1, flags2);
     }
 
-    inline bool publish(const char *eventName, const char *eventData, PublishFlag f1, PublishFlag f2)
+    inline bool publish(const char *eventName, const char *eventData, int ttl, Flags<PublishFlag> flags1 = PUBLIC, Flags<PublishFlag> flags2 = Flags<PublishFlag>())
     {
-        return publish(eventName, eventData, 60, f1.flag()+f2.flag());
-    }
-
-    inline bool publish(const char *eventName, const char *eventData, int ttl, PublishFlag eventType=PUBLIC)
-    {
-        return publish(eventName, eventData, ttl, PublishFlag::flag_t(eventType));
+        return publish_event(eventName, eventData, ttl, flags1 | flags2);
     }
 
     inline bool subscribe(const char *eventName, EventHandler handler, Spark_Subscription_Scope_TypeDef scope=ALL_DEVICES)
@@ -349,7 +334,7 @@ private:
 
     static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
 
-    static bool publish(const char *eventName, const char *eventData, int ttl, uint32_t flags);
+    static bool publish_event(const char *eventName, const char *eventData, int ttl, Flags<PublishFlag> flags);
 
     static ProtocolFacade* sp()
     {

--- a/wiring/inc/spark_wiring_flags.h
+++ b/wiring/inc/spark_wiring_flags.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2017 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SPARK_WIRING_FLAGS_H
+#define SPARK_WIRING_FLAGS_H
+
+#include <type_traits>
+
+// Helper macro defining global operators for a specified enum type T
+#define PARTICLE_DEFINE_FLAG_OPERATORS(T) \
+        inline __attribute__((unused)) ::particle::Flags<T> operator|(T flag1, T flag2) { \
+            return ::particle::Flags<T>(flag1) | flag2; \
+        } \
+        inline __attribute__((unused)) ::particle::Flags<T> operator|(T flag, ::particle::Flags<T> flags) { \
+            return flags | flag; \
+        } \
+        inline __attribute__((unused)) ::particle::Flags<T> operator&(T flag, ::particle::Flags<T> flags) { \
+            return flags & flag; \
+        } \
+        inline __attribute__((unused)) ::particle::Flags<T> operator^(T flag, ::particle::Flags<T> flags) { \
+            return flags ^ flag; \
+        }
+
+namespace particle {
+
+// Class storing or-combinations of enum values in a type-safe way
+template<typename T>
+class Flags {
+public:
+    typedef T EnumType;
+    typedef typename std::underlying_type<T>::type ValueType;
+
+    explicit Flags(ValueType val = 0);
+    Flags(T flag);
+
+    Flags<T> operator|(T flag) const;
+    Flags<T> operator|(Flags<T> flags) const;
+    Flags<T>& operator|=(T flag);
+    Flags<T>& operator|=(Flags<T> flags);
+
+    Flags<T> operator&(T flag) const;
+    Flags<T> operator&(Flags<T> flags) const;
+    Flags<T>& operator&=(T flag);
+    Flags<T>& operator&=(Flags<T> flags);
+
+    Flags<T> operator^(T flag) const;
+    Flags<T> operator^(Flags<T> flags) const;
+    Flags<T>& operator^=(T flag);
+    Flags<T>& operator^=(Flags<T> flags);
+
+    Flags<T> operator~() const;
+
+    Flags<T>& operator=(ValueType val);
+
+    operator ValueType() const;
+    bool operator!() const;
+
+    ValueType value() const;
+
+private:
+    ValueType val_;
+};
+
+} // namespace particle
+
+template<typename T>
+inline particle::Flags<T>::Flags(ValueType val) :
+        val_(val) {
+}
+
+template<typename T>
+inline particle::Flags<T>::Flags(T flag) :
+        val_((ValueType)flag) {
+}
+
+template<typename T>
+inline particle::Flags<T> particle::Flags<T>::operator|(T flag) const {
+    return Flags<T>(val_ | (ValueType)flag);
+}
+
+template<typename T>
+inline particle::Flags<T> particle::Flags<T>::operator|(Flags<T> flags) const {
+    return Flags<T>(val_ | flags.val_);
+}
+
+template<typename T>
+inline particle::Flags<T>& particle::Flags<T>::operator|=(T flag) {
+    val_ |= (ValueType)flag;
+    return *this;
+}
+
+template<typename T>
+inline particle::Flags<T>& particle::Flags<T>::operator|=(Flags<T> flags) {
+    val_ |= flags.val_;
+    return *this;
+}
+
+template<typename T>
+inline particle::Flags<T> particle::Flags<T>::operator&(T flag) const {
+    return Flags<T>(val_ & (ValueType)flag);
+}
+
+template<typename T>
+inline particle::Flags<T> particle::Flags<T>::operator&(Flags<T> flags) const {
+    return Flags<T>(val_ & flags.val_);
+}
+
+template<typename T>
+inline particle::Flags<T>& particle::Flags<T>::operator&=(T flag) {
+    val_ &= (ValueType)flag;
+    return *this;
+}
+
+template<typename T>
+inline particle::Flags<T>& particle::Flags<T>::operator&=(Flags<T> flags) {
+    val_ &= flags.val_;
+    return *this;
+}
+
+template<typename T>
+inline particle::Flags<T> particle::Flags<T>::operator^(T flag) const {
+    return Flags<T>(val_ ^ (ValueType)flag);
+}
+
+template<typename T>
+inline particle::Flags<T> particle::Flags<T>::operator^(Flags<T> flags) const {
+    return Flags<T>(val_ ^ flags.val_);
+}
+
+template<typename T>
+inline particle::Flags<T>& particle::Flags<T>::operator^=(T flag) {
+    val_ ^= (ValueType)flag;
+    return *this;
+}
+
+template<typename T>
+inline particle::Flags<T>& particle::Flags<T>::operator^=(Flags<T> flags) {
+    val_ ^= flags.val_;
+    return *this;
+}
+
+template<typename T>
+inline particle::Flags<T> particle::Flags<T>::operator~() const {
+    return Flags<T>(~val_);
+}
+
+template<typename T>
+inline particle::Flags<T>& particle::Flags<T>::operator=(ValueType val) {
+    val_ = val;
+    return *this;
+}
+
+template<typename T>
+inline particle::Flags<T>::operator ValueType() const {
+    return val_;
+}
+
+template<typename T>
+inline bool particle::Flags<T>::operator!() const {
+    return !val_;
+}
+
+template<typename T>
+inline typename particle::Flags<T>::ValueType particle::Flags<T>::value() const {
+    return val_;
+}
+
+#endif // SPARK_WIRING_FLAGS_H

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -32,7 +32,7 @@ bool CloudClass::register_function(cloud_function_t fn, void* data, const char* 
     return spark_function(NULL, (user_function_int_str_t*)&desc, NULL);
 }
 
-bool CloudClass::publish(const char *eventName, const char *eventData, int ttl, uint32_t flags) {
+bool CloudClass::publish_event(const char *eventName, const char *eventData, int ttl, Flags<PublishFlag> flags) {
 #ifndef SPARK_NO_CLOUD
     spark_send_event_data d = { sizeof(spark_send_event_data) };
 


### PR DESCRIPTION
This PR sanitizes `Particle.publish()` overloads, making it possible to specify one or two flags for any variant of this method. The PR also implements a generic type-safe wrapper for enum-based flags, aka `particle::Flags<T>`, which enables regular syntax for ORed flag combinations as an option:

```cpp
Particle.publish("event", "data", PRIVATE | NO_ACK);
```

Fixes #1201 and #1194.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bug fixes

[[PR #1236]](https://github.com/spark/firmware/pull/1236) [[Fixes #1201]](https://github.com/spark/firmware/issues/1201) [[Fixes #1194]](https://github.com/spark/firmware/issues/1194) Sanitized `Particle.publish()` overloads.

### Enhancements

[[PR #1236]](https://github.com/spark/firmware/pull/1236) [[Fixes #1201]](https://github.com/spark/firmware/issues/1201) [[Fixes #1194]](https://github.com/spark/firmware/issues/1194) Added type-safe wrapper for enum-based flags for `Particle.publish()` which enables logical OR'ed flag combinations `PRIVATE | WITH_ACK`