### PR TITLE
RGB LED fixes [ch1742]

### DIFF
--- a/services/inc/led_service.h
+++ b/services/inc/led_service.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 // Pattern type
-typedef enum {
+typedef enum LEDPattern {
     LED_PATTERN_INVALID = 0,
     LED_PATTERN_SOLID = 1,
     LED_PATTERN_BLINK = 2,
@@ -38,7 +38,7 @@ typedef enum {
 } LEDPattern;
 
 // Status flags
-typedef enum {
+typedef enum LEDStatusFlag {
     LED_STATUS_FLAG_ACTIVE = 0x01, // LED status is active (do not modify this flag directly)
     LED_STATUS_FLAG_OFF = 0x02 // LED is turned off
 } LEDStatusFlag;

--- a/system/inc/system_led_signal.h
+++ b/system/inc/system_led_signal.h
@@ -50,7 +50,7 @@ extern "C" {
 
 // System LED signals.
 // Note: When adding new signals, make sure LED_SIGNAL_COUNT is updated accordingly
-typedef enum {
+typedef enum LEDSignal {
     LED_SIGNAL_NETWORK_OFF = 0,
     LED_SIGNAL_NETWORK_ON = 1,
     LED_SIGNAL_NETWORK_CONNECTING = 2,
@@ -67,7 +67,7 @@ typedef enum {
 } LEDSignal;
 
 // LED signal source
-typedef enum {
+typedef enum LEDSource {
     LED_SOURCE_APPLICATION = 1,
     LED_SOURCE_SYSTEM = 2,
 #ifdef PARTICLE_USER_MODULE
@@ -78,7 +78,7 @@ typedef enum {
 } LEDSource;
 
 // LED signal priority
-typedef enum {
+typedef enum LEDPriority {
     LED_PRIORITY_BACKGROUND = 10,
     LED_PRIORITY_NORMAL = 20,
     LED_PRIORITY_IMPORTANT = 30,
@@ -86,19 +86,19 @@ typedef enum {
 } LEDPriority;
 
 // Predefined LED pattern speed
-typedef enum {
+typedef enum LEDSpeed {
     LED_SPEED_SLOW = 10,
     LED_SPEED_NORMAL = 20,
     LED_SPEED_FAST = 30
 } LEDSpeed;
 
-typedef enum {
+typedef enum LEDSignalFlag {
     LED_SIGNAL_FLAG_SAVE_THEME = 0x01, // Save theme to persistent storage
     LED_SIGNAL_FLAG_DEFAULT_THEME = 0x02, // Initialize theme with factory default settings
     LED_SIGNAL_FLAG_ALL_SIGNALS = 0x04 // Stop all signals
 } LEDSignalFlag;
 
-typedef struct {
+typedef struct LEDSignalThemeData_v1 {
     uint32_t version; // ABI version number. Should be initialized to LED_SIGNAL_THEME_VERSION
     struct { // Signal settings (in order of LEDSignal enum elements)
         uint32_t color; // Color (0x00RRGGBB)

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -28,6 +28,7 @@
 #include "system_cloud_internal.h"
 #include "system_network.h"
 #include "system_threading.h"
+#include "system_mode.h"
 
 using namespace particle;
 
@@ -191,7 +192,14 @@ protected:
         bool wlanStarted = SPARK_WLAN_STARTED;
 
         cloud_disconnect();
-        LED_SIGNAL_START(LISTENING_MODE, NORMAL); // TODO: Use BACKGROUND priority if threading is enabled?
+
+        if (system_thread_get_state(nullptr) == spark::feature::ENABLED) {
+            LED_SIGNAL_START(LISTENING_MODE, NORMAL);
+        } else {
+            // Using critical priority here, since in a single-threaded configuration the listening
+            // mode blocks an application code from running
+            LED_SIGNAL_START(LISTENING_MODE, CRITICAL);
+        }
 
         on_start_listening();
         start_listening_timer_create();

--- a/user/tests/unit/led_service.cpp
+++ b/user/tests/unit/led_service.cpp
@@ -64,10 +64,6 @@ public:
                 std::abs(b() - color.b()) <= d);
     }
 
-    static Color random() {
-        return Color(test::randomInt(0, 0x00ffffff));
-    }
-
     operator uint32_t() const {
         return rgb();
     }
@@ -562,7 +558,7 @@ TEST_CASE("LEDSystemTheme") {
         LEDSystemTheme t2;
         for (int i = 0; i < LED_SIGNAL_COUNT; ++i) {
             const LEDSignal s = (LEDSignal)i;
-            t2.setColor(s, Color::random());
+            t2.setColor(s, Color(i * 10, i * 10, i * 10));
             t2.setPattern(s, test::anyOf(LED_PATTERN_SOLID, LED_PATTERN_BLINK, LED_PATTERN_FADE));
             t2.setPeriod(s, test::randomInt(0, 10000));
         }

--- a/user/tests/wiring/no_fixture/led.cpp
+++ b/user/tests/wiring/no_fixture/led.cpp
@@ -69,6 +69,10 @@ uint8_t ledAdjust(uint8_t value, uint8_t brightness=255) {
 }
 
 test(LED_01_Updated) {
+    // Force the LED to show a breathing pattern for this test
+    LEDStatus status(LED_PATTERN_FADE, LED_PRIORITY_IMPORTANT);
+    status.setActive();
+
     RGB.control(false);
     RGB.onChange(onChangeRGBLED);
     uint32_t start = rgbNotifyCount;
@@ -131,6 +135,8 @@ test(LED_05_StaticWhenControlled) {
 
     for (int i=0; i<3; i++)
         assertEqual(rgbInitial[i], rgbNotify[i]);
+
+    RGB.onChange(NULL);
 }
 
 test(LED_06_SettingRGBAfterOverrideShouldChangeLED) {
@@ -207,6 +213,8 @@ test(LED_10_ChangeHandlerCalled) {
 
     // then
     assertChangeHandlerCalledWith(ledAdjust(10),ledAdjust(20),ledAdjust(30));
+
+    RGB.onChange(NULL);
 }
 
 static void assertRgbLedMirrorPinsColor(const pin_t pins[3], uint16_t r, uint16_t g, uint16_t b)

--- a/wiring/inc/spark_wiring_rgb.h
+++ b/wiring/inc/spark_wiring_rgb.h
@@ -1,6 +1,6 @@
 /**
  ******************************************************************************
- * @file    spark_wiring_system.h
+ * @file    spark_wiring_rgb.h
  * @author  Satish Nair, Zachary Crockett, Matthew McGowan
  ******************************************************************************
   Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
@@ -20,8 +20,12 @@
   ******************************************************************************
  */
 
-#include <stdint.h>
+#ifndef SPARK_WIRING_RGB_H
+#define SPARK_WIRING_RGB_H
+
 #include <functional>
+#include <cstdint>
+
 #include "pinmap_hal.h"
 #include "rgbled.h"
 
@@ -30,31 +34,31 @@ typedef std::function<raw_rgb_change_handler_t> wiring_rgb_change_handler_t;
 
 class RGBClass {
 public:
-	static bool controlled(void);
-	static void control(bool);
-	static void color(int, int, int);
-	static void color(uint32_t rgb);
-	static void brightness(uint8_t, bool update=true);
+    static bool controlled(void);
+    static void control(bool);
+    static void color(int, int, int);
+    static void color(uint32_t rgb);
+    static void brightness(uint8_t, bool update=true);
+    static uint8_t brightness();
 
-	static uint8_t brightness() {
-		return Get_LED_Brightness();
-	}
-
-	static void onChange(wiring_rgb_change_handler_t handler);
-	static void onChange(raw_rgb_change_handler_t *handler);
+    void onChange(wiring_rgb_change_handler_t handler);
+    void onChange(raw_rgb_change_handler_t* handler);
 
     template <typename T>
-    static void onChange(void (T::*handler)(uint8_t, uint8_t, uint8_t), T *instance) {
-      using namespace std::placeholders;
-      onChange(std::bind(handler, instance, _1, _2, _3));
+    void onChange(void (T::*handler)(uint8_t, uint8_t, uint8_t), T *instance) {
+        using namespace std::placeholders;
+        onChange(std::bind(handler, instance, _1, _2, _3));
     }
 
-  static void mirrorTo(pin_t rpin, pin_t gpin, pin_t bpin, bool invert=false, bool bootloader=false);
-  static void mirrorDisable(bool bootloader=true);
+    static void mirrorTo(pin_t rpin, pin_t gpin, pin_t bpin, bool invert=false, bool bootloader=false);
+    static void mirrorDisable(bool bootloader=true);
 
 private:
-	static void call_raw_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);
-	static void call_std_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);
+    wiring_rgb_change_handler_t changeHandler_;
+
+    static void ledChangeHandler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved);
 };
 
 extern RGBClass RGB;
+
+#endif // SPARK_WIRING_RGB_H

--- a/wiring/src/spark_wiring_rgb.cpp
+++ b/wiring/src/spark_wiring_rgb.cpp
@@ -17,11 +17,12 @@
   ******************************************************************************
  */
 
-
-
 #include "spark_wiring_rgb.h"
+#include "spark_wiring_interrupts.h"
+
 #include "core_hal.h"
-#include "rgbled.h"
+
+RGBClass RGB;
 
 bool RGBClass::controlled(void)
 {
@@ -30,12 +31,13 @@ bool RGBClass::controlled(void)
 
 void RGBClass::control(bool override)
 {
-    if(override == controlled())
-            return;
-    else if (override)
-            LED_Signaling_Start();
-    else
-            LED_Signaling_Stop();
+    if (override == controlled()) {
+        return;
+    } else if (override) {
+        LED_Signaling_Start();
+    } else {
+        LED_Signaling_Stop();
+    }
 }
 
 void RGBClass::color(uint32_t rgb) {
@@ -44,9 +46,9 @@ void RGBClass::color(uint32_t rgb) {
 
 void RGBClass::color(int red, int green, int blue)
 {
-    if (!controlled())
-            return;
-
+    if (!controlled()) {
+        return;
+    }
     LED_SetSignalingColor(red << 16 | green << 8 | blue);
     LED_On(LED_RGB);
 }
@@ -54,49 +56,53 @@ void RGBClass::color(int red, int green, int blue)
 void RGBClass::brightness(uint8_t brightness, bool update)
 {
     LED_SetBrightness(brightness);
-    if (controlled() && update)
+    if (controlled() && update) {
         LED_On(LED_RGB);
-}
-
-void RGBClass::onChange(wiring_rgb_change_handler_t handler) {
-  if(handler) {
-    auto wrapper = new wiring_rgb_change_handler_t(handler);
-    if(wrapper) {
-      LED_RGB_SetChangeHandler(call_std_change_handler, wrapper);
     }
-  }
-  else {
-      // FIXME: This currently causes a memory leak
-      LED_RGB_SetChangeHandler(NULL, NULL);
-  }
 }
 
-void RGBClass::onChange(raw_rgb_change_handler_t *handler) {
-    LED_RGB_SetChangeHandler(handler ? call_raw_change_handler : NULL, (void*)handler);
-}
-
-void RGBClass::call_raw_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved)
+uint8_t RGBClass::brightness()
 {
-    auto fn = (raw_rgb_change_handler_t*)(data);
-    (*fn)(r, g, b);
+    return Get_LED_Brightness();
 }
 
-void RGBClass::call_std_change_handler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved)
+void RGBClass::onChange(wiring_rgb_change_handler_t handler)
 {
-    auto fn = (wiring_rgb_change_handler_t*)(data);
-    (*fn)(r, g, b);
+    // User callback for LED changes can be called from an ISR, so we're masking interrupts before
+    // changing current callback function
+    ATOMIC_BLOCK() {
+        changeHandler_ = std::move(handler);
+        if (changeHandler_) {
+            LED_RGB_SetChangeHandler(ledChangeHandler, this);
+        } else {
+            LED_RGB_SetChangeHandler(nullptr, nullptr);
+        }
+    }
+}
+
+void RGBClass::onChange(raw_rgb_change_handler_t* handler)
+{
+    onChange(wiring_rgb_change_handler_t(handler));
 }
 
 void RGBClass::mirrorTo(pin_t rpin, pin_t gpin, pin_t bpin, bool invert, bool bootloader)
 {
-  HAL_Core_Led_Mirror_Pin(LED_RED + LED_MIRROR_OFFSET, rpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
-  HAL_Core_Led_Mirror_Pin(LED_GREEN + LED_MIRROR_OFFSET, gpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
-  HAL_Core_Led_Mirror_Pin(LED_BLUE + LED_MIRROR_OFFSET, bpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin(LED_RED + LED_MIRROR_OFFSET, rpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin(LED_GREEN + LED_MIRROR_OFFSET, gpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin(LED_BLUE + LED_MIRROR_OFFSET, bpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
 }
 
 void RGBClass::mirrorDisable(bool bootloader)
 {
-  HAL_Core_Led_Mirror_Pin_Disable(LED_RED + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
-  HAL_Core_Led_Mirror_Pin_Disable(LED_GREEN + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
-  HAL_Core_Led_Mirror_Pin_Disable(LED_BLUE + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin_Disable(LED_RED + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin_Disable(LED_GREEN + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin_Disable(LED_BLUE + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
+}
+
+void RGBClass::ledChangeHandler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved)
+{
+    RGBClass* const d = static_cast<RGBClass*>(data);
+    if (d->changeHandler_) {
+        d->changeHandler_(r, g, b);
+    }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Fixes potential memory leak and race condition issues in `RGB.onChange()` method.
- Fixes `unit/led_service.cpp` and `wiring/no_fixture/led.cpp` tests that are currently failing intermittently (CH story 1742).
- Raises priority of the listening mode LED indication in single-threaded mode.

_TODO: Update firmware reference_

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bug fixes

- [[PR #1237]](https://github.com/spark/firmware/pull/1237) Fixes potential memory leak and race condition issues in `RGB.onChange()` function.

### Enhancements

- [[PR #1237]](https://github.com/spark/firmware/pull/1237) Added `uint8_t val = RGB.brightness();` getter function.