### PR TITLE
fix crash in tcp_server_t due to incorrect tcp_server_t::clients[]

### DIFF
--- a/hal/src/photon/socket_hal.cpp
+++ b/hal/src/photon/socket_hal.cpp
@@ -289,6 +289,12 @@ struct tcp_server_t : public wiced_tcp_server_t
      */
     wiced_result_t disconnect(wiced_tcp_socket_t* socket) {
         wiced_tcp_disconnect(socket);
+        // remove from client array as this socket is getting closed and
+        // subsequently destroyed
+	    int idx = index(socket);
+	    if (idx >= 0) {
+		  clients[idx] = NULL;
+	    }
         wiced_result_t result = wiced_tcp_server_disconnect_socket(this, socket);
         return result;
     }


### PR DESCRIPTION
Fixes a crash related to memory corruption. I think it is the reason for the problem mentioned here:
https://community.particle.io/t/active-tcpserver-client-appears-to-crash-photon-when-wifi-disconnects/27130

The crash shows when following event sequence occurs
1. TCPServer is started
2. TCPClient is created for connection
3. TCPClient connection is closed gracefully
4. TCPServer is destroyed

Bug:
The client list of TCPServer is not updated correctly when a client disconnects. Subsequently, on destruction of TCPServer, an already destroyed client object is accessed. 

I confirmed the events with the debugger, but unfortunately do not have the stack traces at hand anymore.

Fix:
In TCPServer::disconnect, set correct pointer in clients[] to NULL. The object itself is destroyed in socket_t::dispose()

---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)