### PR TITLE
Fix for WiFi.connecting() returning false during DHCP configuration

### DIFF
--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -68,6 +68,29 @@ inline void CLR_WLAN_WD() {
     WAN_WD_DEBUG("WD Cleared, was %d",wlan_watchdog_duration);
 }
 
+#ifdef DEBUG_NETWORK_STATE
+class ManagedNetworkInterface;
+
+// Helper class dumping internal state of a ManagedNetworkInterface instance
+class NetworkStateLogger {
+public:
+    NetworkStateLogger(const ManagedNetworkInterface& nif, const char* func);
+    ~NetworkStateLogger();
+
+private:
+    const ManagedNetworkInterface& nif_;
+    const char* const func_;
+
+    void dump() const;
+};
+
+#define DUMP_NETWORK_STATE() \
+        const NetworkStateLogger PP_CAT(_networkStateLogger_, __COUNTER__)(*this, __PRETTY_FUNCTION__)
+
+#else
+#define DUMP_NETWORK_STATE()
+#endif
+
 /**
  * Internal network interface class to provide polymorphic behavior for each
  * network type.  This is not part of the dynalib so functions can freely evolve.
@@ -82,7 +105,6 @@ struct NetworkInterface
     virtual void off(bool disconnect_cloud=false)=0;
     virtual void connect(bool listen_enabled=true)=0;
     virtual bool connecting()=0;
-    virtual bool connected()=0;
     virtual void connect_cancel(bool cancel)=0;
     /**
      * Force a manual disconnct.
@@ -117,6 +139,7 @@ struct NetworkInterface
 
 class ManagedNetworkInterface : public NetworkInterface
 {
+private:
     volatile uint8_t WLAN_DISCONNECT;
     volatile uint8_t WLAN_DELETE_PROFILES;
     volatile uint8_t WLAN_SMART_CONFIG_START; // Set to 'true' when listening mode is pending
@@ -125,7 +148,7 @@ class ManagedNetworkInterface : public NetworkInterface
     volatile uint8_t WLAN_SMART_CONFIG_FINISHED;
     volatile uint8_t WLAN_CONNECTED;
     volatile uint8_t WLAN_CONNECTING;
-    volatile uint8_t WLAN_DHCP;
+    volatile uint8_t WLAN_DHCP_PENDING;
     volatile uint8_t WLAN_CAN_SHUTDOWN;
     volatile uint8_t WLAN_LISTEN_ON_FAILED_CONNECT;
 #if PLATFORM_ID == 10 // Electron
@@ -135,6 +158,10 @@ class ManagedNetworkInterface : public NetworkInterface
 #endif
     volatile uint32_t start_listening_timer_base;
     volatile uint32_t start_listening_timer_duration;
+
+#ifdef DEBUG_NETWORK_STATE
+    friend class NetworkStateLogger;
+#endif
 
 protected:
 
@@ -184,6 +211,7 @@ protected:
 
     template<typename T> void start_listening(SystemSetupConsole<T>& console)
     {
+        DUMP_NETWORK_STATE();
         WLAN_SMART_CONFIG_ACTIVE = 1;
         WLAN_SMART_CONFIG_FINISHED = 0;
         WLAN_SMART_CONFIG_STOP = 0;
@@ -305,13 +333,9 @@ public:
         WLAN_DISCONNECT = disconnect;
     }
 
-    bool connected() override
-    {
-        return WLAN_CONNECTED;
-    }
-
     void listen(bool stop=false) override
     {
+        DUMP_NETWORK_STATE();
         if (stop) {
             WLAN_LISTEN_ON_FAILED_CONNECT = 0;  // ensure a failed wifi connection attempt doesn't bring the device back to listening mode
             WLAN_SMART_CONFIG_START = 0; // Cancel pending transition to listening mode
@@ -342,6 +366,7 @@ public:
 
     void connect(bool listen_enabled=true) override
     {
+        DUMP_NETWORK_STATE();
         INFO("ready(): %d; connecting(): %d; listening(): %d; WLAN_SMART_CONFIG_START: %d", (int)ready(), (int)connecting(),
                 (int)listening(), (int)WLAN_SMART_CONFIG_START);
         if (!ready() && !connecting() && !listening() && !WLAN_SMART_CONFIG_START) // Don't try to connect if listening mode is active or pending
@@ -378,6 +403,7 @@ public:
 
     void disconnect() override
     {
+        DUMP_NETWORK_STATE();
         if (SPARK_WLAN_STARTED)
         {
             const bool was_connected = WLAN_CONNECTED;
@@ -385,7 +411,7 @@ public:
             WLAN_DISCONNECT = 1; //Do not ARM_WLAN_WD() in WLAN_Async_Callback()
             WLAN_CONNECTING = 0;
             WLAN_CONNECTED = 0;
-            WLAN_DHCP = 0;
+            WLAN_DHCP_PENDING = 0;
 
             cloud_disconnect();
             if (was_connected) {
@@ -405,7 +431,7 @@ public:
 
     bool ready() override
     {
-        return (SPARK_WLAN_STARTED && WLAN_DHCP);
+        return (SPARK_WLAN_STARTED && WLAN_CONNECTED);
     }
 
     bool connecting() override
@@ -415,6 +441,7 @@ public:
 
     void on() override
     {
+        DUMP_NETWORK_STATE();
         if (!SPARK_WLAN_STARTED)
         {
             system_notify_event(network_status, network_status_powering_on);
@@ -430,6 +457,7 @@ public:
 
     void off(bool disconnect_cloud=false) override
     {
+        DUMP_NETWORK_STATE();
         if (SPARK_WLAN_STARTED)
         {
             disconnect();
@@ -444,7 +472,7 @@ public:
             }
 #endif
             SPARK_WLAN_STARTED = 0;
-            WLAN_DHCP = 0;
+            WLAN_DHCP_PENDING = 0;
             WLAN_CONNECTED = 0;
             WLAN_CONNECTING = 0;
             WLAN_SERIAL_CONFIG_DONE = 1;
@@ -455,20 +483,20 @@ public:
 
     void notify_listening_complete()
     {
+        DUMP_NETWORK_STATE();
         WLAN_SMART_CONFIG_FINISHED = 1;
         WLAN_SMART_CONFIG_STOP = 1;
     }
 
     void notify_connected()
     {
-        WLAN_CONNECTED = 1;
-        WLAN_CONNECTING = 0;
-
+        DUMP_NETWORK_STATE();
         /* If DHCP has completed, don't re-arm WD due to spurious notify_connected()
          * from WICED on loss of internet and reconnect
          */
-        if (!WLAN_DISCONNECT && !WLAN_DHCP)
+        if (!WLAN_DISCONNECT && !WLAN_CONNECTED)
         {
+            WLAN_DHCP_PENDING = 1;
             INFO("ARM_WLAN_WD 2");
             ARM_WLAN_WD(CONNECT_TO_ADDRESS_MAX);
             LED_SIGNAL_START(NETWORK_DHCP, NORMAL);
@@ -477,49 +505,44 @@ public:
 
     void notify_disconnected()
     {
+        DUMP_NETWORK_STATE();
         cloud_disconnect(false); // don't close the socket on the callback since this causes a lockup on the Core
-        if (WLAN_CONNECTED)     /// unsolicited disconnect
-        {
-            //Breathe blue if established connection gets disconnected
-            if (!WLAN_DISCONNECT) {
-                //if WiFi.disconnect called, do not enable wlan watchdog
-                INFO("ARM_WLAN_WD 3");
-                ARM_WLAN_WD(DISCONNECT_TO_RECONNECT);
-            } else {
-                LED_SIGNAL_STOP(NETWORK_CONNECTING);
+        if (WLAN_CONNECTING || WLAN_CONNECTED) {
+            if (WLAN_CONNECTED) {
+                // "Disconnecting" event is generated only for a successfully established connection
+                system_notify_event(network_status, network_status_disconnecting);
             }
-            LED_SIGNAL_STOP(NETWORK_DHCP);
-            LED_SIGNAL_STOP(NETWORK_CONNECTED);
-
+            // "Connecting" event should be always followed by either "connected" or "disconnected" event
             system_notify_event(network_status, network_status_disconnected);
         }
-        else if (!WLAN_SMART_CONFIG_ACTIVE)
-        {
-            //Do not enter if smart config related disconnection happens
-            //Blink green if connection fails because of wrong password
-            if (!WLAN_DISCONNECT) {
-                INFO("ARM_WLAN_WD 4");
-                ARM_WLAN_WD(DISCONNECT_TO_RECONNECT);
-            } else {
-                LED_SIGNAL_STOP(NETWORK_CONNECTING);
-            }
-            LED_SIGNAL_STOP(NETWORK_DHCP);
-            LED_SIGNAL_STOP(NETWORK_CONNECTED);
+        // Do not enable WLAN watchdog if WiFi.disconnect() has been called or smart config is active
+        if (!WLAN_DISCONNECT && !WLAN_SMART_CONFIG_ACTIVE) {
+            INFO("ARM_WLAN_WD 3");
+            ARM_WLAN_WD(DISCONNECT_TO_RECONNECT);
+            // Keep blinking green if automatic reconnection is pending
+        } else {
+            LED_SIGNAL_STOP(NETWORK_CONNECTING);
         }
+
+        LED_SIGNAL_STOP(NETWORK_CONNECTED);
+        LED_SIGNAL_STOP(NETWORK_DHCP);
+
         WLAN_CONNECTED = 0;
         WLAN_CONNECTING = 0;
-        WLAN_DHCP = 0;
+        WLAN_DHCP_PENDING = 0;
     }
 
     void notify_dhcp(bool dhcp)
     {
+        DUMP_NETWORK_STATE();
         WLAN_CONNECTING = 0;
+        WLAN_DHCP_PENDING = 0;
         LED_SIGNAL_STOP(NETWORK_DHCP);
         if (dhcp)
         {
             INFO("CLR_WLAN_WD 1, DHCP success");
             CLR_WLAN_WD();
-            WLAN_DHCP = 1;
+            WLAN_CONNECTED = 1;
             WLAN_LISTEN_ON_FAILED_CONNECT = false;
             LED_SIGNAL_START(NETWORK_CONNECTED, BACKGROUND);
             LED_SIGNAL_STOP(NETWORK_CONNECTING);
@@ -531,7 +554,6 @@ public:
         else
         {
             config_clear();
-            WLAN_DHCP = 0;
             if (WLAN_LISTEN_ON_FAILED_CONNECT) {
                 LED_SIGNAL_STOP(NETWORK_CONNECTING);
                 listen();
@@ -540,7 +562,7 @@ public:
                 ARM_WLAN_WD(DISCONNECT_TO_RECONNECT);
             }
 
-            // "Connecting" event should be followed by either "connected" or "disconnected" event
+            // "Connecting" event should be always followed by either "connected" or "disconnected" event
             system_notify_event(network_status, network_status_disconnected);
         }
     }
@@ -569,18 +591,12 @@ public:
         // 2. CC3000 established AP connection
         // 3. DHCP IP is configured
         // then send mDNS packet to stop external SmartConfig application
-        if ((WLAN_SMART_CONFIG_STOP == 1) && (WLAN_DHCP == 1) && (WLAN_CONNECTED == 1))
+        if ((WLAN_SMART_CONFIG_STOP == 1) && (WLAN_CONNECTED == 1))
         {
             on_setup_cleanup();
             WLAN_SMART_CONFIG_STOP = 0;
         }
     }
-
-    inline bool hasDHCP()
-    {
-        return WLAN_DHCP && !SPARK_WLAN_SLEEP;
-    }
-
 };
 
 extern ManagedNetworkInterface& network;
@@ -602,7 +618,7 @@ public:
     {
         // todo - IPv6 may not set this field.
         bool fetched_config = ip_config.nw.aucIP.ipv4!=0;
-        if (hasDHCP() || force)
+        if (ready() || force)
         {
             if (!fetched_config || force)
             {
@@ -626,7 +642,46 @@ public:
 
 };
 
+#ifdef DEBUG_NETWORK_STATE
+#define NETWORK_STATE_PRINTF(...) \
+        do { \
+            LOG_PRINTF_C(TRACE, "system.network.state", ##__VA_ARGS__); \
+        } while (false)
 
+inline NetworkStateLogger::NetworkStateLogger(const ManagedNetworkInterface& nif, const char* func) :
+        nif_(nif),
+        func_(func) {
+    NETWORK_STATE_PRINTF("-> %s\r\n", func_);
+    dump();
+}
+
+inline NetworkStateLogger::~NetworkStateLogger() {
+    NETWORK_STATE_PRINTF("<- %s\r\n", func_);
+    dump();
+}
+
+inline void NetworkStateLogger::dump() const {
+    NETWORK_STATE_PRINTF("WLAN_DISCONNECT: %d\r\n", (int)nif_.WLAN_DISCONNECT);
+    NETWORK_STATE_PRINTF("WLAN_DELETE_PROFILES: %d\r\n", (int)nif_.WLAN_DELETE_PROFILES);
+    NETWORK_STATE_PRINTF("WLAN_SMART_CONFIG_START: %d\r\n", (int)nif_.WLAN_SMART_CONFIG_START);
+    NETWORK_STATE_PRINTF("WLAN_SMART_CONFIG_ACTIVE: %d\r\n", (int)nif_.WLAN_SMART_CONFIG_ACTIVE);
+    NETWORK_STATE_PRINTF("WLAN_SMART_CONFIG_STOP: %d\r\n", (int)nif_.WLAN_SMART_CONFIG_STOP);
+    NETWORK_STATE_PRINTF("WLAN_SMART_CONFIG_FINISHED: %d\r\n", (int)nif_.WLAN_SMART_CONFIG_FINISHED);
+    NETWORK_STATE_PRINTF("WLAN_CONNECTED: %d\r\n", (int)nif_.WLAN_CONNECTED);
+    NETWORK_STATE_PRINTF("WLAN_CONNECTING: %d\r\n", (int)nif_.WLAN_CONNECTING);
+    NETWORK_STATE_PRINTF("WLAN_DHCP_PENDING: %d\r\n", (int)nif_.WLAN_DHCP_PENDING);
+    NETWORK_STATE_PRINTF("WLAN_CAN_SHUTDOWN: %d\r\n", (int)nif_.WLAN_CAN_SHUTDOWN);
+    NETWORK_STATE_PRINTF("WLAN_LISTEN_ON_FAILED_CONNECT: %d\r\n", (int)nif_.WLAN_LISTEN_ON_FAILED_CONNECT);
+    // Global flags
+    NETWORK_STATE_PRINTF("SPARK_WLAN_RESET: %d\r\n", (int)SPARK_WLAN_RESET);
+    NETWORK_STATE_PRINTF("SPARK_WLAN_SLEEP: %d\r\n", (int)SPARK_WLAN_SLEEP);
+    NETWORK_STATE_PRINTF("SPARK_WLAN_STARTED: %d\r\n", (int)SPARK_WLAN_STARTED);
+    NETWORK_STATE_PRINTF("wlan_watchdog_duration: %d\r\n", (int)wlan_watchdog_duration);
+    NETWORK_STATE_PRINTF("--------------------------------\r\n");
+}
+
+#undef NETWORK_STATE_PRINTF
+
+#endif // DEBUG_NETWORK_STATE
 
 #endif  /* SYSTEM_NETWORK_INTERNAL_H */
-

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -121,9 +121,9 @@ void manage_network_connection()
     }
     else
     {
-        if (!SPARK_WLAN_STARTED || (spark_cloud_flag_auto_connect() && !network.connected()))
+        if (!SPARK_WLAN_STARTED || (spark_cloud_flag_auto_connect() && !network.ready()))
         {
-            INFO("Network Connect: %s", (!SPARK_WLAN_STARTED) ? "!SPARK_WLAN_STARTED" : "SPARK_CLOUD_CONNECT && !network.connected()");
+            INFO("Network Connect: %s", (!SPARK_WLAN_STARTED) ? "!SPARK_WLAN_STARTED" : "SPARK_CLOUD_CONNECT && !network.ready()");
             network.connect();
         }
     }


### PR DESCRIPTION
This PR fixes #1241 by making `WLAN_CONNECTING` and `WLAN_CONNECTED` flags span over the entire network connection process, including DHCP configuration phase.

I'm not sure how I can write a good test for this fix, so below is my usual test application which I play with to debug network/cloud connectivity problems. Make sure you build the system firmware with debugging enabled and `DEBUG_NETWORK_STATE` macro defined to get internal state of the `ManagedNetworkInterface` class logged.

Tested on Photon and Electron with static and dynamic IP configurations.

```cpp
#include "application.h"

SYSTEM_MODE(MANUAL)
// SYSTEM_THREAD(ENABLED)

#if PLATFORM_ID == 10
#define Network Cellular
#else
#define Network WiFi
#endif

namespace {

Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
    { "system.network.state", LOG_LEVEL_ALL },
    { "app", LOG_LEVEL_ALL }
});

void connectionStatusChanged(system_event_t event, int data) {
    switch (event) {
    case network_status: {
        switch (data) {
        case network_status_powering_off: Log.info("network_status_powering_off"); break;
        case network_status_off: Log.info("network_status_off"); break;
        case network_status_powering_on: Log.info("network_status_powering_on"); break;
        case network_status_on: Log.info("network_status_on"); break;
        case network_status_connecting: Log.info("network_status_connecting"); break;
        case network_status_connected: Log.info("network_status_connected"); break;
        case network_status_disconnecting: Log.info("network_status_disconnecting"); break;
        case network_status_disconnected: Log.info("network_status_disconnected"); break;
        }
        Log.info(PP_STR(Network) ".connecting() == %d", (int)Network.connecting());
        Log.info(PP_STR(Network) ".ready() == %d", (int)Network.ready());
        break;
    }
    case cloud_status: {
        switch (data) {
        case cloud_status_disconnected: Log.info("cloud_status_disconnected"); break;
        case cloud_status_connecting: Log.info("cloud_status_connecting"); break;
        case cloud_status_connected: Log.info("cloud_status_connected"); break;
        case cloud_status_disconnecting: Log.info("cloud_status_disconnecting"); break;
        }
        Log.info("Particle.connected() == %d", (int)Particle.connected());
        break;
    }
    default:
        break;
    }
}

uint32_t t = 0;
int step = 0;

} // namespace

STARTUP(System.on(network_status | cloud_status, connectionStatusChanged))

void setup() {
/*
    WiFi.on();

    // Use static IP configuration
    IPAddress addr(192,168,1,177);
    IPAddress mask(255,255,255,0);
    IPAddress gateway(192,168,1,1);
    IPAddress dns(192,168,1,1);
    WiFi.setStaticIP(addr, mask, gateway, dns);
    WiFi.useStaticIP();

    // Use dynamic IP configuration
    WiFi.useDynamicIP();
*/
}

void loop() {
    if (step && millis() - t < 6000) {
        // Particle.process();
        return;
    }
    switch (++step) {
    case 1: {
        Log.info("-> " PP_STR(Network) ".on()");
        Network.on();
        break;
    }
    case 2: {
        Log.info("-> " PP_STR(Network) ".connect()");
        Network.connect();
        break;
    }
    case 3: {
        Log.info("-> Particle.connect()");
        Particle.connect();
        break;
    }
    case 4: {
        Log.info("-> Particle.disconnect()");
        Particle.disconnect();
        break;
    }
    case 5: {
        Log.info("-> " PP_STR(Network) ".disconnect()");
        Network.disconnect();
        break;
    }
    case 6: {
        Log.info("-> " PP_STR(Network) ".off()");
        Network.off();
        break;
    }
    default:
        break;
    }
    t = millis();
}
```

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation (N/A)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)

### Bugfixes

- [[PR #1254]](https://github.com/spark/firmware/pull/1254) [[Fixes #1241]](https://github.com/spark/firmware/issues/1241) `WiFi.connecting()` was returning `false` while DHCP is resolving, will now remain `true`.