### PR TITLE
Fix for attachInterrupt() on the Core

### DIFF
--- a/hal/src/core/interrupts_hal.c
+++ b/hal/src/core/interrupts_hal.c
@@ -153,6 +153,7 @@ void HAL_Interrupts_Attach(uint16_t pin, HAL_InterruptHandler handler, void* dat
   {
     //configure NVIC
     //select NVIC channel to configure
+    NVIC_InitStructure.NVIC_IRQChannel = GPIO_IRQn[GPIO_PinSource];
     if (config == NULL) {
       if(GPIO_PinSource > 4)
         NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 14;


### PR DESCRIPTION
This PR fixes #1136 by reverting what I believe was an accidental change introduced by this PR: https://github.com/spark/firmware/pull/1076.

I don't have a Core device personally, but I've managed to reproduce symptoms of the issue on the Photon, so any help with testing is appreciated.

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)