### PR TITLE
Interrupt cloud connection when entering listening mode or powering off the device via setup button

### DIFF
--- a/system/inc/system_task.h
+++ b/system/inc/system_task.h
@@ -90,6 +90,13 @@ uint8_t main_thread_current(void* reserved);
 
 uint8_t application_thread_invoke(void (*callback)(void* data), void* data, void* reserved);
 
+/**
+ * Cancels current network connection attempt and aborts cloud connection. This function can be
+ * called from an ISR and is used to unblock the system thread in order to perform some other
+ * operation immediately.
+ */
+void cancel_connection();
+
 #ifdef __cplusplus
 }
 #endif

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -41,6 +41,7 @@ void Spark_SetTime(unsigned long dateTime);
 void Spark_Process_Events();
 void Spark_Sleep();
 void Spark_Wake();
+void Spark_Abort();
 
 void system_set_time(time_t time, unsigned param, void* reserved);
 

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -408,7 +408,7 @@ static void process_isr_task_queue()
 }
 
 #if Wiring_SetupButtonUX
-extern void system_handle_button_click();
+extern void system_handle_button_clicks(bool isIsr);
 #endif
 
 void Spark_Idle_Events(bool force_events/*=false*/)
@@ -423,7 +423,7 @@ void Spark_Idle_Events(bool force_events/*=false*/)
     if (!SYSTEM_POWEROFF) {
 
 #if Wiring_SetupButtonUX
-        system_handle_button_click();
+        system_handle_button_clicks(false /* isIsr */);
 #endif
         manage_serial_flasher();
 
@@ -580,4 +580,12 @@ uint8_t application_thread_invoke(void (*callback)(void* data), void* data, void
     APPLICATION_THREAD_CONTEXT_ASYNC_RESULT(application_thread_invoke(callback, data, reserved), 0);
     callback(data);
     return 0;
+}
+
+void cancel_connection()
+{
+    // Cancel current network connection attempt
+    network.connect_cancel(true);
+    // Abort cloud connection
+    Spark_Abort();
 }


### PR DESCRIPTION
This PR fixes #1067 by introducing a flag that can be set from an ISR and cause read/write operations on the cloud socket to fail with a generic error, effectively breaking any busy loop within the comms library.



---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)