### PR TITLE
WiFi.RSSI() shouldn't report positive values. Constrain RSSI to -1dBm max

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -363,6 +363,10 @@ int wlan_connected_rssi()
     int32_t rssi = 0;
     if (wwd_wifi_get_rssi( &rssi ))
         rssi = 0;
+    else if (rssi > 0) {
+        // Constrain RSSI to -1dBm maximum
+        rssi = -1;
+    }
     return rssi;
 }
 


### PR DESCRIPTION
A simple fix for #1180

---

Doneness:

- [X] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [x] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)