### PR TITLE
TCP server fixes

### DIFF
--- a/hal/src/photon/socket_hal.cpp
+++ b/hal/src/photon/socket_hal.cpp
@@ -289,6 +289,12 @@ struct tcp_server_t : public wiced_tcp_server_t
      */
     wiced_result_t disconnect(wiced_tcp_socket_t* socket) {
         wiced_tcp_disconnect(socket);
+        // remove from client array as this socket is getting closed and
+        // subsequently destroyed
+	    int idx = index(socket);
+	    if (idx >= 0) {
+		  clients[idx] = NULL;
+	    }
         wiced_result_t result = wiced_tcp_server_disconnect_socket(this, socket);
         return result;
     }

--- a/system/src/system_control.cpp
+++ b/system/src/system_control.cpp
@@ -279,8 +279,7 @@ uint8_t SystemControlInterface::fetchRequestResult(HAL_USB_SetupRequest* req) {
     req->wLength = usbReq_.req.reply_size;
   }
   usbReq_.active = false;
-  // FIXME: Don't invalidate reply data for now (simplifies testing with usbtool)
-  // usbReq_.ready = false;
+  usbReq_.ready = false;
   return 0;
 }
 

--- a/user/tests/accept/tools/send_usb_req
+++ b/user/tests/accept/tools/send_usb_req
@@ -134,7 +134,7 @@ if [ $req_type == reqrep ] || [ $req_type == in ]; then
 
   if [ "$data" ]; then
     # "0x61 0x62 0x63" -> "616263"
-    data=$(printf "$data" | sed 's/ //g;s/0x//g')
+    data=$(printf "$data" | tr -d ' \n' | sed 's/0x//g')
     if [ ! $hex_flag ]; then
       # "616263" -> "abc"
       data=$(printf "$data" | xxd -r -p)

--- a/user/tests/accept/tools/send_usb_req
+++ b/user/tests/accept/tools/send_usb_req
@@ -39,11 +39,7 @@ send_out_req() {
 
 # Sends device-to-host request
 send_in_req() {
-  size_arg="-n $max_size"
-  if [ $1 ]; then
-    size_arg="-n $1"
-  fi
-  usbtool -v 0x$USB_VENDOR_ID -p 0x$USB_PRODUCT_ID $size_arg control in vendor device $usb_req $usb_val $usb_index
+  usbtool -v 0x$USB_VENDOR_ID -p 0x$USB_PRODUCT_ID -n $max_size control in vendor device $usb_req $usb_val $usb_index
 }
 
 # Prints current UNIX time with nanosecond precision
@@ -121,10 +117,6 @@ if [ $req_type == reqrep ] || [ $req_type == in ]; then
     while : ; do
       sleep 0.1
       data=$(send_in_req 2>/dev/null) && break
-      if [ $max_size != 0 ]; then
-        # Empty reply data seems to require some special handling
-        data=$(send_in_req 0 2>/dev/null) && break
-      fi
       less_than $(timestamp) $time_end || error "Request timeout"
     done
   else

--- a/user/tests/app/tcp_server/README.md
+++ b/user/tests/app/tcp_server/README.md
@@ -1,0 +1,10 @@
+Flash server application to the device:
+$ cd ~/firmware/modules
+$ make -s all program-dfu PLATFORM=photon TEST=app/tcp_server
+
+Install client dependencies:
+$ cd ~/firmware/user/tests/app/tcp_server/client
+$ npm install
+
+Run client:
+$ ./client

--- a/user/tests/app/tcp_server/client/client
+++ b/user/tests/app/tcp_server/client/client
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+if [ ! $PLATFORM ]; then
+  echo 'PLATFORM is not defined, assuming Photon'
+  export PLATFORM=photon
+fi
+
+this_dir=$(cd $(dirname "$0") && pwd)
+test_dir=$(cd "$this_dir/../../../accept" && pwd)
+
+PATH="$test_dir/tools:$PATH"
+source "$test_dir/init_env"
+
+node "$this_dir/main.js"

--- a/user/tests/app/tcp_server/client/lib/client.js
+++ b/user/tests/app/tcp_server/client/lib/client.js
@@ -1,0 +1,215 @@
+const randomstring = require('randomstring');
+const net = require('net');
+const _ = require('lodash');
+
+const EventEmitter = require('events');
+const Promise = require('bluebird');
+
+const DEFAULT_TIMEOUT = 30000;
+
+const State = {
+  NEW: 1,
+  CONNECTING: 2,
+  CONNECTED: 3,
+  READING: 4,
+  WRITING: 5,
+  CLOSING: 6,
+  CLOSED: 7
+};
+
+// Promise-based TCP client for testing purposes
+class Client extends EventEmitter {
+  constructor(host, port) {
+    super();
+    this._host = host;
+    this._port = port;
+    this._data = '';
+    this._readSize = 0;
+    this._resolve = null;
+    this._reject = null;
+    this._timer = null;
+    this._timeout = DEFAULT_TIMEOUT;
+    this._sock = this._newSocket();
+    this._state = State.NEW;
+  }
+
+  connect() {
+    return this._setState(State.NEW, State.CONNECTING, () => {
+      this._sock.connect({ host: this._host, port: this._port });
+    });
+  }
+
+  disconnect() {
+    return this._setState(State.CONNECTED, State.CLOSING, () => {
+      this._sock.end();
+    });
+  }
+
+  read(size) {
+    return this._setState(State.CONNECTED, State.READING, () => {
+      this._readSize = size;
+      this._read();
+    });
+  }
+
+  write(data) {
+    return this._setState(State.CONNECTED, State.WRITING, () => {
+      this._sock.write(data, null, () => {
+        this._resolveState(State.WRITING, State.CONNECTED);
+      });
+    });
+  }
+
+  waitUntilClosed() {
+    return this._setState(State.CONNECTED, State.CLOSING);
+  }
+
+  // Closes connection synchronously
+  close() {
+    this._state = State.CLOSED;
+    this._sock.destroy();
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null
+    }
+    if (this._reject) {
+      this._reject(new Error('Operation has been aborted'));
+      this._reject = null;
+    }
+    this._resolve = null;
+    this._data = '';
+  }
+
+  get connecting() {
+    return this._state == State.CONNECTING;
+  }
+
+  get connected() {
+    return this._state == State.CONNECTED || this._state == State.READING || this._state == State.WRITING;
+  }
+
+  get closing() {
+    return this._state == State.CLOSING;
+  }
+
+  get closed() {
+    return this._state == State.CLOSED;
+  }
+
+  get host() {
+    return this._host;
+  }
+
+  get port() {
+    return this._port;
+  }
+
+  get timeout() {
+    return this._timeout;
+  }
+
+  set timeout(timeout) {
+    this._timeout = timeout;
+  }
+
+  _setState(curState, newState, func) {
+    return new Promise((resolve, reject) => {
+      if (this._state != curState) {
+        throw new Error('Invalid object state');
+      }
+      this._state = newState;
+      this._resolve = resolve;
+      this._reject = reject;
+      this._timer = setTimeout(() => {
+        this._error(new Error('Operation has timed out'));
+      }, this._timeout);
+      if (func) {
+        func();
+      }
+    });
+  }
+
+  _resolveState(curState, newState, data) {
+    if (this._state == curState) {
+      this._state = newState;
+      if (this._timer) {
+        clearTimeout(this._timer);
+        this._timer = null;
+      }
+      if (this._resolve) {
+        this._resolve(data);
+        this._resolve = null;
+      }
+      this._reject = null;
+    }
+  }
+
+  _error(err) {
+    if (this._reject) {
+      this._reject(err);
+      this._reject = null;
+    }
+    this.close();
+  }
+
+  _read() {
+    if (this._state == State.READING && this._data.length >= this._readSize) {
+      const d = this._data.substr(0, this._readSize);
+      this._data = this._data.substr(this._readSize);
+      this._resolveState(State.READING, State.CONNECTED, d);
+    }
+  }
+
+  _newSocket() {
+    const sock = new net.Socket();
+    sock.setEncoding('utf8');
+    sock.on('connect', () => {
+      this._resolveState(State.CONNECTING, State.CONNECTED);
+      this.emit('connect');
+    });
+    sock.on('close', () => {
+      if (this._state == State.CLOSING) {
+        this._resolveState(State.CLOSING, State.CLOSED);
+      } else {
+        this._error(new Error('Connection has been closed'));
+      }
+      this.close();
+      this.emit('close');
+    });
+    sock.on('data', (data) => {
+      this._data += data;
+      this._read();
+    });
+    sock.on('error', (err) => {
+      this._error(err);
+    });
+    return sock;
+  }
+}
+
+class EchoClient extends Client {
+  echo(strOrLength) {
+    let str = strOrLength;
+    if (_.isNumber(strOrLength)) {
+      str = randomstring.generate(strOrLength);
+    } else if (_.isUndefined(strOrLength)) {
+      const len = Math.floor(Math.random() * 125 + 4); // 4 to 128 characters
+      str = randomstring.generate(len);
+    }
+    return this.write(str)
+      .then(() => {
+        return this.read(str.length)
+      })
+      .then((reply) => {
+        if (reply != str) {
+          throw new Error('Unexpected reply from server');
+        }
+      });
+  }
+}
+
+module.exports = {
+  DEFAULT_TIMEOUT: DEFAULT_TIMEOUT,
+  Client: Client,
+  EchoClient: EchoClient
+};

--- a/user/tests/app/tcp_server/client/lib/device.js
+++ b/user/tests/app/tcp_server/client/lib/device.js
@@ -1,0 +1,105 @@
+const exec = require('child_process').exec;
+const util = require('util');
+const _ = require('lodash');
+
+const Promise = require('bluebird');
+
+const DEFAULT_TIMEOUT = 5000;
+
+let commands = [];
+
+// Device control interface
+class DeviceControl {
+  static startServer(id, type, port, timeout) {
+    return this.command('startServer', { id: id, type: type, port: port }, timeout);
+  }
+
+  static stopServer(id, timeout) {
+    return this.command('stopServer', { id: id }, timeout);
+  }
+
+  static stopServers(timeout) {
+    return this.command('stopServers', timeout);
+  }
+
+  static connectToNetwork(timeout) {
+    return this.command('connectToNetwork', timeout).then((rep) => {
+      return rep.address;
+    });
+  }
+
+  static disconnectFromNetwork(timeout) {
+    return this.command('disconnectFromNetwork', timeout);
+  }
+
+  static getNetworkStatus(timeout) {
+    return this.command('getNetworkStatus', timeout);
+  }
+
+  static getFreeMemory(timeout) {
+    return this.command('getFreeMemory', timeout).then((rep) => {
+      return rep.bytes;
+    });
+  }
+
+  static command(cmd, paramsOrTimeout, timeout) {
+    let p = {}; // Parameters
+    let t = DEFAULT_TIMEOUT; // Timeout
+    if (_.isNumber(paramsOrTimeout)) {
+      t = paramsOrTimeout;
+    } else if (!_.isUndefined(paramsOrTimeout)) {
+      p = paramsOrTimeout;
+      if (_.isNumber(timeout)) {
+        t = timeout;
+      }
+    }
+    return new Promise((resolve, reject) => {
+      // Put device command into the queue
+      commands.push({
+        name: cmd,
+        params: p,
+        resolve: resolve,
+        reject: reject,
+        timeout: t
+      });
+      // Start processing commands if the queue was empty
+      if (commands.length == 1) {
+        this._nextCommand();
+      }
+    });
+  }
+
+  static _nextCommand() {
+    if (commands.length > 0) {
+      const cmd = commands[0]; // Get next command
+      const req = cmd.params || {}; // Request object
+      req.cmd = cmd.name;
+      const json = JSON.stringify(req); // Request JSON data
+      const hex = Buffer.from(json, 'utf8').toString('hex');
+      // Request: 80 ('P'); value: 0; index: 10 (USB_REQUEST_CUSTOM)
+      exec(util.format('send_usb_req -t %d -r 80 -v 0 -i 10 -x %s', cmd.timeout, hex), (err, stdout, stderr) => {
+        try {
+          if (err) {
+            throw err;
+          }
+          const json = Buffer.from(stdout.trim(), 'hex').toString('utf8'); // Reply JSON data
+          const rep = JSON.parse(json); // Reply object
+          if (_.has(rep, 'error')) {
+            throw new Error(rep.error);
+          }
+          cmd.resolve(rep);
+        } catch (err) {
+          cmd.reject(err);
+        } finally {
+          commands.shift(); // Remove current command from the queue
+          this._nextCommand(); // Process next command
+        }
+      });
+    }
+  }
+}
+
+module.exports = {
+  DEFAULT_TIMEOUT: DEFAULT_TIMEOUT,
+  DeviceControl: DeviceControl
+};

--- a/user/tests/app/tcp_server/client/lib/test.js
+++ b/user/tests/app/tcp_server/client/lib/test.js
@@ -1,6 +1,5 @@
 const client = require('./client');
 const device = require('./device');
-const async = require('async');
 const util = require('./util');
 const _ = require('lodash');
 

--- a/user/tests/app/tcp_server/client/lib/test.js
+++ b/user/tests/app/tcp_server/client/lib/test.js
@@ -1,0 +1,212 @@
+const client = require('./client');
+const device = require('./device');
+const async = require('async');
+const util = require('./util');
+const _ = require('lodash');
+
+const Client = client.Client;
+const EchoClient = client.EchoClient;
+const DeviceControl = device.DeviceControl;
+const Promise = require('bluebird');
+
+const DEFAULT_PORT = 1234;
+const MEMORY_USAGE_THRESH = 0.025;
+
+class TestError extends Error {
+  constructor(msg, stack) {
+    super(msg);
+    this.name = this.constructor.name;
+    if (stack) {
+      this.stack = stack;
+    } else {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+
+class Test {
+  constructor(name, func) {
+    this._name = name;
+    this._func = func;
+    this._devAddr = 'localhost';
+    this._clients = {};
+    this._servers = new Set();
+    this._nextClientId = 1;
+    this._nextServerId = 1;
+    this._verbose = true;
+  }
+
+  run() {
+    let memBefore = 0;
+    return util.mapAll([
+      // Ensure device is connected to network
+      () => {
+        return this.connectToNetwork();
+      },
+      // Get device's free memory before test
+      () => {
+        return DeviceControl.getFreeMemory()
+          .then((freeMem) => {
+            memBefore = freeMem;
+          })
+      },
+      // Run test
+      () => {
+        return this._func(this)
+          .catch((err) => {
+            if (!(err instanceof TestError)) {
+              err = new TestError(err.message, err.stack);
+            }
+            throw err;
+          });
+      },
+      // Close all client connections
+      () => {
+        if (_.isEmpty(this._clients)) {
+          return Promise.resolve();
+        }
+        return util.mapAll(_.values(this._clients), (client) => {
+          return client.disconnect(); // Disconnect gracefully
+        })
+        .catch((err) => {
+          _.forEach(this._clients, (client) => {
+            client.close(); // Close connection synchronously
+          });
+          throw err;
+        });
+      },
+      // Stop all servers
+      () => {
+        return this.stopServers();
+      },
+      // Check device's free memory after test
+      () => {
+        return DeviceControl.getFreeMemory()
+          .then((memAfter) => {
+            if (memAfter < memBefore && (memBefore - memAfter) >= memBefore * MEMORY_USAGE_THRESH) {
+              throw new Error('Memory check failed');
+            }
+          })
+      }],
+      (func) => {
+        return func();
+      }
+    );
+  }
+
+  newClient(classOrPort, port) {
+    let cls = Client;
+    let p = DEFAULT_PORT;
+    if (_.isNumber(classOrPort)) {
+      p = classOrPort;
+    } else if (!_.isUndefined(classOrPort)) {
+      cls = classOrPort;
+      if (_.isNumber(port)) {
+        p = port;
+      }
+    }
+    const id = this._nextClientId++;
+    const client = new cls(this._devAddr, p);
+    client.on('connect', () => {
+      if (this._verbose) {
+        console.log('Connected to %s:%d', client.host, client.port);
+      }
+      this._clients[id] = client;
+    });
+    client.on('close', () => {
+      if (this._verbose) {
+        console.log('Disconnected from %s', client.host);
+      }
+      delete this._clients[id];
+    });
+    return client;
+  }
+
+  startServer(type, idOrPort, port) {
+    let id = util.format('server%d', this._nextServerId++);
+    let p = DEFAULT_PORT;
+    if (_.isNumber(idOrPort)) {
+      p = idOrPort;
+    } else if (!_.isUndefined(idOrPort)) {
+      id = idOrPort;
+      if (_.isNumber(port)) {
+        p = port;
+      }
+    }
+    return DeviceControl.startServer(id, type, p)
+      .then(() => {
+        if (this._verbose) {
+          console.log('Started server: %s, port: %d (%s)', id, p, type);
+        }
+        this._servers.add(id);
+      })
+  }
+
+  stopServer(id) {
+    return DeviceControl.stopServer(id)
+      .then(() => {
+        if (this._verbose) {
+          console.log('Stopped server: %s', id);
+        }
+        this._servers.delete(id);
+      });
+  }
+
+  stopServers() {
+    if (_.isEmpty(this._servers)) {
+      return Promise.resolve();
+    }
+    return DeviceControl.stopServers()
+      .then(() => {
+        if (this._verbose) {
+          console.log('Stopped all servers');
+        }
+        this._servers.clear();
+      });
+  }
+
+  connectToNetwork() {
+    return DeviceControl.getNetworkStatus()
+      .then((stat) => {
+        if (!stat.connected) {
+          return DeviceControl.connectToNetwork(45000)
+            .then((addr) => {
+              this._devAddr = addr;
+              if (this._verbose) {
+                console.log('Connected to network, device address: %s', addr);
+              }
+            });
+        } else {
+          this._devAddr = stat.address;
+        }
+      });
+  }
+
+  disconnectFromNetwork() {
+    return DeviceControl.getNetworkStatus()
+      .then((stat) => {
+        if (stat.connected) {
+          return DeviceControl.disconnectFromNetwork()
+            .then(() => {
+              if (this._verbose) {
+                console.log('Disconnected from network');
+              }
+            });
+        }
+      });
+  }
+
+  set verbose(enabled) {
+    this._verbose = enabled;
+  }
+
+  get name() {
+    return this._name;
+  }
+}
+
+module.exports = {
+  DEFAULT_PORT: DEFAULT_PORT,
+  TestError: TestError,
+  Test: Test
+};

--- a/user/tests/app/tcp_server/client/lib/util.js
+++ b/user/tests/app/tcp_server/client/lib/util.js
@@ -1,0 +1,26 @@
+const util = require('util');
+const _ = require('lodash');
+
+const Promise = require('bluebird');
+
+// Variant of Promise.mapSeries() that doesn't stop on errors
+exports.mapAll = (input, func) => {
+  return new Promise((resolve, reject) => {
+    let error = null;
+    Promise.mapSeries(input, (val) => {
+      return func(val)
+        .catch((err) => {
+          error = error || err;
+        });
+    })
+    .finally(() => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+};
+
+_.extend(exports, util);

--- a/user/tests/app/tcp_server/client/main.js
+++ b/user/tests/app/tcp_server/client/main.js
@@ -1,0 +1,39 @@
+const tests = require('./tests');
+const test = require('./lib/test');
+const util = require('./lib/util');
+const _ = require('lodash');
+
+const DeviceControl = require('./lib/device').DeviceControl;
+const Test = test.Test;
+const TestError = test.TestError;
+
+let passedCount = 0;
+
+// Wrap all test functions into instances of the Test class
+const allTests = _.map(tests, (func, name) => {
+  return new Test(name, func);
+});
+
+// Run all tests
+return util.mapAll(allTests, (test) => {
+  console.log('\nRunning %s...', test.name);
+  return test.run()
+    .then(() => {
+      console.log('PASSED');
+      ++passedCount;
+    })
+    .catch((err) => {
+      console.error('FAILED: %s', err.message);
+      throw err;
+    });
+})
+.then(() => {
+  console.log('\nPASSED: All %d tests passed', allTests.length);
+})
+.catch((err) => {
+  if (!(err instanceof TestError)) {
+    console.error(err.message);
+  }
+  console.error('\nFAILED: %d of %d tests failed', allTests.length - passedCount, allTests.length);
+  process.exit(1);
+});

--- a/user/tests/app/tcp_server/client/package.json
+++ b/user/tests/app/tcp_server/client/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "client",
+  "version": "1.0.0",
+  "private": true,
+  "main": "main.js",
+  "dependencies": {
+    "randomstring": "^1.1.5",
+    "bluebird": "^3.5.0",
+    "lodash": "^4.17.4"
+  }
+}

--- a/user/tests/app/tcp_server/client/tests.js
+++ b/user/tests/app/tcp_server/client/tests.js
@@ -1,0 +1,293 @@
+const client = require('./lib/client');
+const test = require('./lib/test');
+const _ = require('lodash');
+
+const Client = client.Client;
+const EchoClient = client.EchoClient;
+const Promise = require('bluebird');
+
+const DEFAULT_PORT = test.DEFAULT_PORT;
+
+// Maximum number of TCP connections supported by the device (as defined by LwIP's MEMP_NUM_TCP_PCB option)
+const MAX_CONNECTIONS = 5;
+// Maxumum number of TCP servers supported by the device (as defined by WICED_MAXIMUM_NUMBER_OF_SERVERS macro)
+const MAX_SERVERS = 5;
+
+exports.EchoTest = (test) => {
+  const client = test.newClient(EchoClient);
+  // Start server
+  return test.startServer('EchoServer')
+  // Connect to server
+  .then(() => {
+    return client.connect();
+  })
+  // Send random message and receive it back
+  .then(() => {
+    return client.echo();
+  });
+};
+
+exports.MaxConnectionsTest = (test) => {
+  let clients = [];
+  // Start server
+  return test.startServer('EchoServer')
+  // Establish maximum number of connections
+  .then(() => {
+    for (let i = 0; i < MAX_CONNECTIONS; ++i) {
+      clients.push(test.newClient(EchoClient));
+    }
+    return Promise.each(clients, (client) => {
+      return client.connect();
+    });
+  })
+  // Try to establish one more connection
+  .then(() => {
+    const client = test.newClient(EchoClient);
+    client.timeout = 1000; // Use shorter timeout
+    return client.connect()
+      .then(() => {
+        throw new Error('Extra connection has been established unexpectedly');
+      }, () => {
+        // Ignore error silently
+      });
+  })
+  // Check that all connections work as expected
+  .then(() => {
+    return Promise.each(clients, (client) => {
+      return client.echo();
+    });
+  })
+}
+
+exports.ExtraConnectionTest = (test) => {
+  let clients = [];
+  let extraClient = null;
+  let extraClientPromise = null;
+  // Start server
+  return test.startServer('EchoServer')
+  // Establish maximum number of connections
+  .then(() => {
+    for (let i = 0; i < MAX_CONNECTIONS; ++i) {
+      clients.push(test.newClient(EchoClient));
+    }
+    return Promise.each(clients, (client) => {
+      return client.connect();
+    });
+  })
+  // Try to establish one more connection
+  .then(() => {
+    extraClient = test.newClient(EchoClient);
+    extraClientPromise = extraClient.connect();
+  })
+  .delay(1000)
+  // Close one of the previously established connections
+  .then(() => {
+    if (extraClient.connected) {
+      throw new Error('Extra connection has been established unexpectedly');
+    }
+    let client = clients.shift();
+    return client.disconnect();
+  })
+  // Pending extra connection should now succeed
+  .then(() => {
+    return extraClientPromise;
+  })
+  .then(() => {
+    // Check that all connections work as expected
+    clients.push(extraClient);
+    return Promise.each(clients, (client) => {
+      return client.echo();
+    });
+  });
+};
+
+exports.MaxServersTest = (test) => {
+  // Start maximum number of servers
+  let serverPromises = [];
+  for (let i = 0; i < MAX_SERVERS; ++i) {
+    serverPromises.push(test.startServer('EchoServer', DEFAULT_PORT + i));
+  }
+  return Promise.all(serverPromises)
+  // Try to start one more server
+  .then(() => {
+    return test.startServer('EchoServer', DEFAULT_PORT + MAX_SERVERS)
+      .then(() => {
+        throw new Error('Extra server instance has been started unexpectedly');
+      }, () => {
+        // Ignore error silently
+      });
+  })
+  // Check that all servers work as expected
+  .then(() => {
+    var clients = [];
+    for (let i = 0; i < MAX_SERVERS; ++i) {
+      clients.push(test.newClient(EchoClient, DEFAULT_PORT + i));
+    }
+    return Promise.each(clients, (client) => {
+      return client.connect().then(() => {
+          return client.echo();
+      });
+    })
+  })
+};
+
+// FIXME: This test may crash the device since there's a bug in socket HAL, which destroys all
+// sockets on network disconnection, leaving invalid socket handles at the application side
+exports.NoServerSocketLeakOnNetworkDisconnectTest = (test) => {
+  // Start maximum number of servers
+  let serverPromises = [];
+  for (let i = 0; i < MAX_SERVERS; ++i) {
+    serverPromises.push(test.startServer('SimpleServer', DEFAULT_PORT + i));
+  }
+  return Promise.all(serverPromises)
+  // Disconnect from network
+  .then(() => {
+    return test.disconnectFromNetwork();
+  })
+  .delay(1000)
+  // Stop all servers
+  .then(() => {
+    return test.stopServers();
+  })
+  // Connect to network
+  .then(() => {
+    return test.connectToNetwork();
+  })
+  // Try to start servers again
+  .then(() => {
+    serverPromises = [];
+    for (let i = 0; i < MAX_SERVERS; ++i) {
+      serverPromises.push(test.startServer('SimpleServer', DEFAULT_PORT + i));
+    }
+    return Promise.all(serverPromises);
+  })
+};
+
+exports.StoppedServerDoesntAffectOtherServersTest = (test) => {
+  const PORT1 = DEFAULT_PORT;
+  const PORT2 = DEFAULT_PORT + 1;
+  const checkServer = (port) => {
+    const client = test.newClient(EchoClient, port);
+    return client.connect()
+      .then(() => {
+        return client.echo();
+      })
+      .then(() => {
+        return client.disconnect();
+      });
+  };
+  // Start 1st server
+  return test.startServer('EchoServer', 'server1', PORT1)
+  // Start 2nd server
+  .then(() => {
+    return test.startServer('EchoServer', 'server2', PORT2);
+  })
+  // Check that both servers work as expected
+  .then(() => {
+    return checkServer(PORT1);
+  })
+  .then(() => {
+    return checkServer(PORT2);
+  })
+  // Stop 1st server
+  .then(() => {
+    return test.stopServer('server1');
+  })
+  // Check that 2nd server still works normally
+  .then(() => {
+    return checkServer(PORT2);
+  })
+};
+
+exports.StoppingServerWithActiveConnectionsTest = (test) => {
+  let clients = [];
+  let clientPromises = [];
+  for (let i = 0; i < MAX_CONNECTIONS; ++i) {
+    clients.push(test.newClient(EchoClient));
+  }
+  // Start server
+  return test.startServer('SimpleServer', 'server1')
+  // Make several connections
+  .then(() => {
+    return Promise.each(clients, (client) => {
+      return client.connect();
+    });
+  })
+  // Stop server
+  .then(() => {
+    clientPromises = _.map(clients, (client) => {
+      return client.waitUntilClosed();
+    });
+    return test.stopServer('server1');
+  })
+  // All connections should have been closed by the server
+  .then(() => {
+    return Promise.all(clientPromises);
+  });
+};
+
+exports.TcpClientClosesOnDestructionTest = (test) => {
+  const client = test.newClient();
+  let clientPromise = null;
+  // Start server
+  return test.startServer('TcpClientClosesOnDestructionTestServer')
+  // Connect to server
+  .then(() => {
+    return client.connect();
+  })
+  // Internally, TCPServer holds a reference to last accepted client connection, so here we make
+  // another connection to ensure that the TCPClient instance representing first connection gets
+  // destroyed
+  .then(() => {
+    clientPromise = client.waitUntilClosed();
+    return test.newClient().connect();
+  })
+  // Wait until first connection is closed
+  .then(() => {
+    return clientPromise;
+  });
+};
+
+exports.StressTest = (test) => {
+  const TOTAL_CONNS = 500; // Total number of connections
+  const CONCURRENT_CONNS = MAX_CONNECTIONS; // Maximum number of concurrent connection attempts
+  const MAX_FAILED_CONNS = 6; // Maximum allowed number of failed connections
+  console.log('Total connections: %d', TOTAL_CONNS);
+  console.log('Concurrent connection attempts: %d', CONCURRENT_CONNS);
+  console.log('Allowed failed connections: %d', MAX_FAILED_CONNS);
+  console.log('Connecting...'); // This test may take some time
+  test.verbose = false; // Disable verbose logging
+  let clients = [];
+  for (let i = 0; i < TOTAL_CONNS; ++i) {
+    const client = test.newClient(EchoClient);
+    // Longer client timeout can be useful when number of concurrent connection attempts is greater
+    // than maximum number of simultaneous connections supported by the device
+    client.timeout = 60000;
+    clients.push(client);
+  }
+  let failedConns = 0;
+  // Start server
+  return test.startServer('EchoServer')
+  // Start connecting to the server
+  .then(() => {
+    return Promise.map(clients, (client) => {
+      return Promise.delay(Math.random() * 500)
+        .then(() => {
+          return client.connect()
+        })
+        .then(() => {
+          return client.echo();
+        })
+        .delay(Math.random() * 500)
+        .then(() => {
+          return client.disconnect();
+        })
+        .catch((err) => {
+          console.error('Connection failed: %s', err.message);
+          if (++failedConns >= MAX_FAILED_CONNS) {
+            throw err; // Fatal error
+          }
+        });
+    }, { concurrency: CONCURRENT_CONNS });
+  })
+};

--- a/user/tests/app/tcp_server/server.cpp
+++ b/user/tests/app/tcp_server/server.cpp
@@ -1,0 +1,515 @@
+#include "application.h"
+
+SYSTEM_MODE(MANUAL)
+
+// Assertion macro to use in Errorable classes
+#define CHECK(_expr) \
+        do { \
+            if (!(_expr)) { \
+                Errorable::setError("%s:%d: Assertion failed: %s", fileName(__FILE__), __LINE__, #_expr); \
+            } \
+        } while (false)
+
+// Registers server factory
+#define REGISTER_SERVER(_type) \
+        STARTUP(ServerManager::instance()->registerServer(#_type, [](const char* id, unsigned port) { \
+            return new _type(id, port); \
+        }));
+
+namespace {
+
+Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
+    { "app", LOG_LEVEL_ALL }
+});
+
+const char* fileName(const char *path);
+
+// Base class for everything that may fail
+class Errorable {
+public:
+    explicit Errorable(const char* name = nullptr) :
+            log(name ? name : "app"),
+            error_(Error::NONE) {
+    }
+
+    virtual ~Errorable() = default;
+
+    void setError(const char* fmt, ...) {
+        char msg[128];
+        va_list args;
+        va_start(args, fmt);
+        vsnprintf(msg, sizeof(msg), fmt, args);
+        va_end(args);
+        setError(Error(msg));
+    }
+
+    void setError(Error error) {
+        error_ = std::move(error);
+        log.error(error_.message());
+    }
+
+    void resetError() {
+        error_ = Error::NONE;
+    }
+
+    const Error& error() const {
+        return error_;
+    }
+
+    bool hasError() const {
+        return (error_ != Error::NONE);
+    }
+
+protected:
+    Logger log;
+
+private:
+    Error error_;
+};
+
+// Base class for test servers
+class Server: public Errorable {
+public:
+    Server(const char* id, unsigned port) :
+            Errorable("app.Server"),
+            id_(id),
+            port_(port) {
+        if (strlen(id) != 0 && id_.length() == 0) {
+            setError(Error::NO_MEMORY);
+        }
+    }
+
+    virtual ~Server() {
+        stop();
+    }
+
+    // Starts server
+    bool start() {
+        if (!server_) {
+            log.trace("%s: Starting server", (const char*)id_);
+            server_.reset(new TCPServer(port_));
+            if (!server_) {
+                setError(Error::NO_MEMORY);
+                return false;
+            }
+            if (!server_->begin()) {
+                setError("Unable to start server");
+                server_.reset();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Stops server
+    void stop() {
+        if (server_) {
+            log.trace("%s: Stopping server", (const char*)id_);
+            server_->stop();
+            server_.reset();
+        }
+    }
+
+    // Runs next server loop iteration
+    void run() {
+        if (server_) {
+            run(*server_);
+        }
+    }
+
+    const char* id() const {
+        return id_;
+    }
+
+    unsigned port() const {
+        return port_;
+    }
+
+protected:
+    virtual void run(TCPServer& server) {
+        // Default implementation accepts and closes client connections immediately
+        TCPClient client;
+        while (client = server.available()) {
+            client.stop();
+        }
+    }
+
+private:
+    const String id_;
+    const unsigned port_;
+
+    std::unique_ptr<TCPServer> server_;
+};
+
+class ServerManager: public Errorable {
+public:
+    typedef std::function<Server*(const char* id, unsigned port)> ServerFactoryFunction;
+
+    bool startServer(const char* id, const char* type, unsigned port) {
+        if (strlen(id) == 0) {
+            setError("Invalid server ID");
+            return false;
+        }
+        if (hasServer(id)) {
+            setError("Server is already running: %s", id);
+            return false;
+        }
+        log.info("Starting server: %s, port: %u (%s)", id, port, type);
+        std::unique_ptr<Server> server(createServer(id, type, port));
+        if (!server) {
+            // Error has been set by createServer() already
+            return false;
+        }
+        if (!server->start()) {
+            setError(server->error());
+            return false;
+        }
+        if (!servers_.append(std::move(server))) {
+            setError(Error::NO_MEMORY);
+            return false;
+        }
+        return true;
+    }
+
+    bool stopServer(const char* id) {
+        for (int i = 0; i < servers_.size(); ++i) {
+            if (strcmp(servers_.at(i)->id(), id) == 0) {
+                log.info("Stopping server: %s", id);
+                std::unique_ptr<Server> server(servers_.takeAt(i));
+                server->stop();
+                // Give WICED some time to complete any asynchronous cleanup, so that we could reuse the same
+                // server address later
+                delay(500);
+                if (server->hasError()) {
+                    setError(server->error()); // Server has finished with an error
+                    return false;
+                }
+                return true;
+            }
+        }
+        setError("Unknown server ID: %s", id);
+        return false;
+    }
+
+    bool stopServers() {
+        bool ok = true;
+        if (!servers_.isEmpty()) {
+            log.info("Stopping all servers");
+            for (auto& server: servers_) {
+                server->stop();
+                if (ok && server->hasError()) {
+                    setError(server->error()); // Server has finished with an error
+                    ok = false;
+                }
+            }
+            servers_.clear();
+            delay(500);
+        }
+        return ok;
+    }
+
+    bool hasServer(const char* id) const {
+        for (const auto& server: servers_) {
+            if (strcmp(server->id(), id) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool registerServer(const char* type, ServerFactoryFunction factory) {
+        if (strlen(type) == 0) {
+            setError("Invalid type name");
+            return false;
+        }
+        ServerType t;
+        t.name = type;
+        t.factory = std::move(factory);
+        if (t.name.length() == 0 || !serverTypes_.append(std::move(t))) {
+            setError(Error::NO_MEMORY);
+            return false;
+        }
+        return true;
+    }
+
+    void run() {
+        for (auto& server: servers_) {
+            server->run();
+        }
+    }
+
+    static ServerManager* instance() {
+        static ServerManager mgr;
+        return &mgr;
+    }
+
+private:
+    struct ServerType {
+        String name;
+        ServerFactoryFunction factory;
+    };
+
+    Vector<std::unique_ptr<Server>> servers_;
+    Vector<ServerType> serverTypes_;
+
+    ServerManager() :
+            Errorable("app.ServerManager") {
+    }
+
+    Server* createServer(const char* id, const char* type, unsigned port) {
+        for (const ServerType& t: serverTypes_) {
+            if (t.name == type) {
+                std::unique_ptr<Server> server(t.factory(id, port));
+                if (!server) {
+                    setError(Error::NO_MEMORY);
+                    return nullptr;
+                }
+                if (server->hasError()) {
+                    setError(server->error()); // Error while initializing server instance
+                    return nullptr;
+                }
+                return server.release();
+            }
+        }
+        setError("Unknown server type: %s", type);
+        return nullptr;
+    }
+};
+
+class NetworkManager: public Errorable {
+public:
+    bool connect() {
+        if (isConnected()) {
+            return true;
+        }
+        addr_ = IPAddress();
+        WiFi.connect();
+        if (!WiFi.ready()) {
+            setError("Unable to connect to network");
+            return false;
+        }
+        // Network address doesn't seem to be available right after WiFi.connect() returns
+        system_tick_t t = millis();
+        for (;;) {
+            addr_ = WiFi.localIP();
+            if (addr_ || millis() - t >= 5000) {
+                break;
+            }
+            Particle.process();
+        }
+        if (!addr_) {
+            WiFi.disconnect();
+            setError("Unable to get IP configuration");
+            return false;
+        }
+        log.info("Connected to network, device address: %s", (const char*)addr_.toString());
+        return true;
+    }
+
+    void disconnect() {
+        const bool wasConnected = WiFi.ready();
+        WiFi.disconnect();
+        addr_ = IPAddress();
+        if (wasConnected) {
+            log.info("Disconnected from network");
+        }
+    }
+
+    bool isConnected() const {
+        return (WiFi.ready() && addr_);
+    }
+
+    const IPAddress& address() const {
+        return addr_;
+    }
+
+    static NetworkManager* instance() {
+        static NetworkManager mgr;
+        return &mgr;
+    }
+
+private:
+    IPAddress addr_;
+
+    NetworkManager() :
+            Errorable("app.NetworkManager") {
+    }
+};
+
+// Server tracking client connections
+class SimpleServer: public Server {
+public:
+    explicit SimpleServer(const char* id, unsigned port) :
+            Server(id, port),
+            nextConnId_(1) {
+    }
+
+protected:
+    virtual void run(TCPServer& server) override {
+        // Process disconnected clients
+        int i = 0;
+        while (i < conns_.size()) {
+            if (!conns_.at(i).client.connected()) {
+                Connection conn = conns_.takeAt(i);
+                conn.client.stop();
+                log.trace("%s: Client disconnected (%d)", this->id(), conn.id);
+                disconnected(conn.id);
+            } else {
+                ++i;
+            }
+        }
+        // Process readable clients
+        for (Connection& conn: conns_) {
+            if (conn.client.available() > 0) {
+                readable(conn.client, conn.id);
+            }
+        }
+        // Process next pending connection
+        TCPClient client = server.available();
+        if (client) {
+            const int id = nextConnId_++;
+            log.trace("%s: Client connected: %s (%d)", this->id(), (const char*)client.remoteIP().toString(), id);
+            conns_.append(Connection(std::move(client), id));
+            connected(conns_.last().client, id);
+        }
+    }
+
+    virtual void connected(TCPClient& client, int id) {
+    }
+
+    virtual void disconnected(int id) {
+    }
+
+    virtual void readable(TCPClient& client, int id) {
+        while (client.available() > 0) {
+            client.read();
+        }
+    }
+
+private:
+    struct Connection {
+        TCPClient client;
+        int id;
+
+        Connection(TCPClient client, int id) :
+                client(std::move(client)),
+                id(id) {
+        }
+    };
+
+    Vector<Connection> conns_;
+    int nextConnId_;
+};
+
+REGISTER_SERVER(SimpleServer);
+
+class EchoServer: public SimpleServer {
+public:
+    using SimpleServer::SimpleServer;
+
+protected:
+    virtual void readable(TCPClient& client, int id) override {
+        int n = 0;
+        while ((n = client.available()) > 0) {
+            n = std::min(n, (int)sizeof(buf_));
+            CHECK((int)client.read((uint8_t*)buf_, n) == n);
+            CHECK((int)client.write((uint8_t*)buf_, n) == n);
+        }
+    }
+
+private:
+    char buf_[128];
+};
+
+REGISTER_SERVER(EchoServer);
+
+// Test-specific servers (see client/tests.js)
+class TcpClientClosesOnDestructionTestServer: public Server {
+public:
+    using Server::Server;
+
+protected:
+    virtual void run(TCPServer& server) override {
+        // Accept next connection and give up returned TCPClient instance
+        server.available();
+    }
+};
+
+REGISTER_SERVER(TcpClientClosesOnDestructionTestServer);
+
+const char* fileName(const char *path) {
+    const char *s = strrchr(path, '/');
+    if (s) {
+        return s + 1;
+    }
+    return path;
+}
+
+} // namespace
+
+bool usb_request_custom_handler(char* buf, size_t bufSize, size_t reqSize, size_t* repSize) {
+    // Parse JSON request
+    JSONString cmd, id, type;
+    unsigned port = 0;
+    JSONObjectIterator it(JSONValue::parse(buf, reqSize));
+    while (it.next()) {
+        const JSONString name = it.name();
+        if (name == "cmd") {
+            cmd = it.value().toString();
+        } else if (name == "id") {
+            id = it.value().toString();
+        } else if (name == "type") {
+            type = it.value().toString();
+        } else if (name == "port") {
+            port = it.value().toInt();
+        }
+    }
+    // Process request
+    ServerManager* serverManager = ServerManager::instance();
+    NetworkManager* networkManager = NetworkManager::instance();
+    Error error(Error::NONE);
+    JSONBufferWriter json(buf, bufSize); // Reply JSON data
+    json.beginObject();
+    if (cmd == "startServer") {
+        if (!serverManager->startServer((const char*)id, (const char*)type, port)) {
+            error = serverManager->error();
+        }
+    } else if (cmd == "stopServer") {
+        if (!serverManager->stopServer((const char*)id)) {
+            error = serverManager->error();
+        }
+    } else if (cmd == "stopServers") { // Stop all servers
+        if (!serverManager->stopServers()) {
+            error = serverManager->error();
+        }
+    } else if (cmd == "connectToNetwork") {
+        if (networkManager->connect()) {
+            json.name("address").value(networkManager->address().toString());
+        } else {
+            error = networkManager->error();
+        }
+    } else if (cmd == "disconnectFromNetwork") {
+        networkManager->disconnect();
+    } else if (cmd == "getNetworkStatus") {
+        json.name("connected").value(networkManager->isConnected());
+        if (networkManager->isConnected()) {
+            json.name("address").value(networkManager->address().toString());
+        }
+    } else if (cmd == "getFreeMemory") {
+        json.name("bytes").value((unsigned)System.freeMemory());
+    }
+    if (error) {
+        json.name("error").value(error.message());
+    }
+    json.endObject();
+    *repSize = json.dataSize();
+    return true;
+}
+
+void setup() {
+    WiFi.on();
+}
+
+void loop() {
+    ServerManager::instance()->run();
+}

--- a/wiring/inc/spark_wiring_error.h
+++ b/wiring/inc/spark_wiring_error.h
@@ -38,6 +38,7 @@ public:
 
     Error(Type type = UNKNOWN);
     Error(Type type, const char* msg);
+    explicit Error(const char* msg);
     Error(const Error& error);
     Error(Error&& error);
     ~Error();
@@ -51,6 +52,8 @@ public:
     bool operator!=(Type type) const;
 
     Error& operator=(Error error);
+
+    explicit operator bool() const;
 
 private:
     const char* msg_;
@@ -71,6 +74,10 @@ inline particle::Error::Error(Type type) :
 inline particle::Error::Error(Type type, const char* msg) :
         msg_(msg ? (const char*)strdup(msg) : nullptr),
         type_(type) {
+}
+
+inline particle::Error::Error(const char* msg) :
+        Error(UNKNOWN, msg) {
 }
 
 inline particle::Error::Error(const Error& error) :
@@ -113,6 +120,10 @@ inline bool particle::Error::operator!=(Type type) const {
 inline particle::Error& particle::Error::operator=(Error error) {
     swap(*this, error);
     return *this;
+}
+
+inline particle::Error::operator bool() const {
+    return type_ != NONE;
 }
 
 inline void particle::swap(Error& error1, Error& error2) {

--- a/wiring/inc/spark_wiring_ipaddress.h
+++ b/wiring/inc/spark_wiring_ipaddress.h
@@ -66,13 +66,19 @@ public:
     /**
      * @return true when this address is not zero.
      */
-    operator bool();
+    operator bool() const;
+
+    // For some reason, without this non-const overload GCC struggles to pick right operator
+    // for bool conversion of a non-const object
+    operator bool() {
+        return static_cast<const IPAddress*>(this)->operator bool();
+    }
 
     // Overloaded cast operator to allow IPAddress objects to be used where a pointer
     // to a four-byte uint8_t array, uint32_t or another IPAddress object is expected.
-    bool operator==(uint32_t address);
-    bool operator==(const uint8_t* address);
-    bool operator==(const IPAddress& address);
+    bool operator==(uint32_t address) const;
+    bool operator==(const uint8_t* address) const;
+    bool operator==(const IPAddress& address) const;
 
     // Overloaded index operator to allow getting and setting individual octets of the address
     uint8_t operator[](int index) const { return (((uint8_t*)(&address.ipv4))[3-index]); }

--- a/wiring/inc/spark_wiring_tcpclient.h
+++ b/wiring/inc/spark_wiring_tcpclient.h
@@ -32,6 +32,8 @@
 #include "spark_wiring_print.h"
 #include "socket_hal.h"
 
+#include <memory>
+
 #define TCPCLIENT_BUF_MAX_SIZE	128
 
 class TCPClient : public Client {
@@ -63,17 +65,32 @@ public:
 	using Print::write;
 
 protected:
-        inline sock_handle_t sock_handle() { return _sock; }
+        inline sock_handle_t sock_handle() { return d_->sock; }
 
 private:
-	static uint16_t _srcport;
-	sock_handle_t _sock;
-	uint8_t _buffer[TCPCLIENT_BUF_MAX_SIZE];
-	uint16_t _offset;
-	uint16_t _total;
-        IPAddress _remoteIP;
-	inline int bufferCount();
+    struct Data {
+        sock_handle_t sock;
+        uint8_t buffer[TCPCLIENT_BUF_MAX_SIZE];
+        uint16_t offset;
+        uint16_t total;
+        IPAddress remoteIP;
 
+        explicit Data(sock_handle_t sock) :
+                sock(sock),
+                offset(0),
+                total(0) {
+        }
+
+        ~Data() {
+            if (socket_handle_valid(sock)) {
+                socket_close(sock);
+            }
+        }
+    };
+
+    std::shared_ptr<Data> d_;
+
+	inline int bufferCount();
 };
 
 #endif

--- a/wiring/src/spark_wiring_ipaddress.cpp
+++ b/wiring/src/spark_wiring_ipaddress.cpp
@@ -55,7 +55,7 @@ IPAddress::IPAddress(const uint8_t* address)
     *this = address;
 }
 
-IPAddress::operator bool()
+IPAddress::operator bool() const
 {
 #if Wiring_IPv6
 #error handle me!
@@ -83,17 +83,17 @@ IPAddress& IPAddress::operator=(uint32_t ipv4)
     return *this;
 }
 
-bool IPAddress::operator==(uint32_t ipv4)
+bool IPAddress::operator==(uint32_t ipv4) const
 {
     return ipv4==address.ipv4;
 }
 
-bool IPAddress::operator==(const uint8_t* address)
+bool IPAddress::operator==(const uint8_t* address) const
 {
     return IPAddress(address)==*this;
 }
 
-bool IPAddress::operator==(const IPAddress& that)
+bool IPAddress::operator==(const IPAddress& that) const
 {
 #if 	HAL_IPv6
 	if (address.v!=that.address.v)

--- a/wiring/src/spark_wiring_tcpclient.cpp
+++ b/wiring/src/spark_wiring_tcpclient.cpp
@@ -45,7 +45,7 @@ TCPClient::TCPClient() : TCPClient(socket_handle_invalid())
 }
 
 TCPClient::TCPClient(sock_handle_t sock) :
-        d_(new Data(sock))
+        d_(std::make_shared<Data>(sock))
 {
   flush_buffer();
 }

--- a/wiring/src/spark_wiring_tcpclient.cpp
+++ b/wiring/src/spark_wiring_tcpclient.cpp
@@ -35,8 +35,6 @@
 
 using namespace spark;
 
-uint16_t TCPClient::_srcport = 1024;
-
 static bool inline isOpen(sock_handle_t sd)
 {
    return socket_handle_valid(sd);
@@ -46,7 +44,8 @@ TCPClient::TCPClient() : TCPClient(socket_handle_invalid())
 {
 }
 
-TCPClient::TCPClient(sock_handle_t sock) : _sock(sock)
+TCPClient::TCPClient(sock_handle_t sock) :
+        d_(new Data(sock))
 {
   flush_buffer();
 }
@@ -76,10 +75,10 @@ int TCPClient::connect(IPAddress ip, uint16_t port, network_interface_t nif)
         if(Network.from(nif).ready())
         {
           sockaddr_t tSocketAddr;
-          _sock = socket_create(AF_INET, SOCK_STREAM, IPPROTO_TCP, port, nif);
-          DEBUG("socket=%d",_sock);
+          d_->sock = socket_create(AF_INET, SOCK_STREAM, IPPROTO_TCP, port, nif);
+          DEBUG("socket=%d",d_->sock);
 
-          if (socket_handle_valid(_sock))
+          if (socket_handle_valid(d_->sock))
           {
             flush_buffer();
 
@@ -95,11 +94,11 @@ int TCPClient::connect(IPAddress ip, uint16_t port, network_interface_t nif)
 
 
             uint32_t ot = HAL_NET_SetNetWatchDog(S2M(MAX_SEC_WAIT_CONNECT));
-            DEBUG("_sock %d connect",_sock);
-            connected = (socket_connect(_sock, &tSocketAddr, sizeof(tSocketAddr)) == 0 ? 1 : 0);
-            DEBUG("_sock %d connected=%d",_sock, connected);
+            DEBUG("sock %d connect",d_->sock);
+            connected = (socket_connect(d_->sock, &tSocketAddr, sizeof(tSocketAddr)) == 0 ? 1 : 0);
+            DEBUG("sock %d connected=%d",d_->sock, connected);
             HAL_NET_SetNetWatchDog(ot);
-            _remoteIP = ip;
+            d_->remoteIP = ip;
             if(!connected)
             {
                 stop();
@@ -116,12 +115,12 @@ size_t TCPClient::write(uint8_t b)
 
 size_t TCPClient::write(const uint8_t *buffer, size_t size)
 {
-        return status() ? socket_send(_sock, buffer, size) : -1;
+        return status() ? socket_send(d_->sock, buffer, size) : -1;
 }
 
 int TCPClient::bufferCount()
 {
-  return _total - _offset;
+  return d_->total - d_->offset;
 }
 
 int TCPClient::available()
@@ -129,32 +128,32 @@ int TCPClient::available()
     int avail = 0;
 
     // At EOB => Flush it
-    if (_total && (_offset == _total))
+    if (d_->total && (d_->offset == d_->total))
     {
         flush_buffer();
     }
 
-    if(Network.from(nif).ready() && isOpen(_sock))
+    if(Network.from(nif).ready() && isOpen(d_->sock))
     {
         // Have room
-        if ( _total < arraySize(_buffer))
+        if ( d_->total < arraySize(d_->buffer))
         {
-            int ret = socket_receive(_sock, _buffer + _total , arraySize(_buffer)-_total, 0);
+            int ret = socket_receive(d_->sock, d_->buffer + d_->total , arraySize(d_->buffer)-d_->total, 0);
             if (ret > 0)
             {
                 DEBUG("recv(=%d)",ret);
-                if (_total == 0) _offset = 0;
-                _total += ret;
+                if (d_->total == 0) d_->offset = 0;
+                d_->total += ret;
             }
         } // Have Space
-    } // WiFi.ready() && isOpen(_sock)
+    } // WiFi.ready() && isOpen(d_->sock)
     avail = bufferCount();
     return avail;
 }
 
 int TCPClient::read()
 {
-  return (bufferCount() || available()) ? _buffer[_offset++] : -1;
+  return (bufferCount() || available()) ? d_->buffer[d_->offset++] : -1;
 }
 
 int TCPClient::read(uint8_t *buffer, size_t size)
@@ -163,21 +162,21 @@ int TCPClient::read(uint8_t *buffer, size_t size)
         if (bufferCount() || available())
         {
           read = (size > (size_t) bufferCount()) ? bufferCount() : size;
-          memcpy(buffer, &_buffer[_offset], read);
-          _offset += read;
+          memcpy(buffer, &d_->buffer[d_->offset], read);
+          d_->offset += read;
         }
         return read;
 }
 
 int TCPClient::peek()
 {
-  return  (bufferCount() || available()) ? _buffer[_offset] : -1;
+  return  (bufferCount() || available()) ? d_->buffer[d_->offset] : -1;
 }
 
 void TCPClient::flush_buffer()
 {
-  _offset = 0;
-  _total = 0;
+  d_->offset = 0;
+  d_->total = 0;
 }
 
 void TCPClient::flush()
@@ -187,12 +186,12 @@ void TCPClient::flush()
 
 void TCPClient::stop()
 {
-  DEBUG("_sock %d closesocket", _sock);
+  DEBUG("sock %d closesocket", d_->sock);
 
-  if (isOpen(_sock))
-      socket_close(_sock);
-  _sock = socket_handle_invalid();
-  _remoteIP.clear();
+  if (isOpen(d_->sock))
+      socket_close(d_->sock);
+  d_->sock = socket_handle_invalid();
+  d_->remoteIP.clear();
   flush_buffer();
 }
 
@@ -201,7 +200,7 @@ uint8_t TCPClient::connected()
   // Wlan up, open and not in CLOSE_WAIT or data still in the local buffer
   bool rv = (status() || bufferCount());
   // no data in the local buffer, Socket open but my be in CLOSE_WAIT yet the CC3000 may have data in its buffer
-  if(!rv && isOpen(_sock) && (SOCKET_STATUS_INACTIVE == socket_active_status(_sock)))
+  if(!rv && isOpen(d_->sock) && (SOCKET_STATUS_INACTIVE == socket_active_status(d_->sock)))
     {
       rv = available(); // Try CC3000
       if (!rv) {        // No more Data and CLOSE_WAIT
@@ -214,7 +213,7 @@ uint8_t TCPClient::connected()
 
 uint8_t TCPClient::status()
 {
-  return (isOpen(_sock) && Network.from(nif).ready() && (SOCKET_STATUS_ACTIVE == socket_active_status(_sock)));
+  return (isOpen(d_->sock) && Network.from(nif).ready() && (SOCKET_STATUS_ACTIVE == socket_active_status(d_->sock)));
 }
 
 TCPClient::operator bool()
@@ -224,5 +223,5 @@ TCPClient::operator bool()
 
 IPAddress TCPClient::remoteIP()
 {
-    return _remoteIP;
+    return d_->remoteIP;
 }

--- a/wiring/src/spark_wiring_tcpserver.cpp
+++ b/wiring/src/spark_wiring_tcpserver.cpp
@@ -73,6 +73,7 @@ bool TCPServer::begin()
 
 void TCPServer::stop()
 {
+    _client.stop();
     socket_close(_sock);
     _sock = socket_handle_invalid();
 }
@@ -102,7 +103,7 @@ TCPClient TCPServer::available()
     else
     {
         TCPServerClient client = TCPServerClient(sock);
-        client._remoteIP = client.remoteIP();      // fetch the peer IP ready for the copy operator
+        client.d_->remoteIP = client.remoteIP();      // fetch the peer IP ready for the copy operator
         _client = client;
 
     }


### PR DESCRIPTION
This PR accompanies [TCP server fixes in WICED](https://github.com/spark/photon-wiced/pull/6) and introduces the following changes to improve stability of the firmware's TCP server implementation:

- Update server's list of clients on a client destruction (thanks @tlangmo!).
- `TCPClient` now closes underlying socket on destruction.
- Test app for above fixes (including fixes in WICED).

### Testing
```
Flash server application to the device:
 $ cd ~/firmware/modules
 $ make -s all program-dfu PLATFORM=photon TEST=app/tcp_server
 
 Install client dependencies:
 $ cd ~/firmware/user/tests/app/tcp_server/client
 $ npm install
 
 Run client:
 $ ./client
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)