### PR TITLE
USART half-duplex enhancements

### DIFF
--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -102,6 +102,10 @@
 #define LIN_SLAVE_10B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_10B)
 #define LIN_SLAVE_11B  (uint32_t)(((uint32_t)SERIAL_8N1) | LIN_MODE_SLAVE  | LIN_BREAK_11B)
 
+// Half-duplex
+#define SERIAL_HALF_DUPLEX            ((uint32_t)0x1000)
+#define SERIAL_HALF_DUPLEX_NO_ECHO    ((uint32_t)0x3000)
+
 
 /* Exported types ------------------------------------------------------------*/
 typedef struct Ring_Buffer

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -106,6 +106,11 @@
 #define SERIAL_HALF_DUPLEX            ((uint32_t)0x1000)
 #define SERIAL_HALF_DUPLEX_NO_ECHO    ((uint32_t)0x3000)
 
+#define SERIAL_OPEN_DRAIN             ((uint32_t)0x4000)
+#define SERIAL_HALF_DUPLEX_OPEN_DRAIN (SERIAL_HALF_DUPLEX | SERIAL_OPEN_DRAIN)
+
+#define SERIAL_TX_PULL_UP             ((uint32_t)0x8000)
+
 
 /* Exported types ------------------------------------------------------------*/
 typedef struct Ring_Buffer

--- a/hal/src/core/usart_hal.c
+++ b/hal/src/core/usart_hal.c
@@ -114,6 +114,8 @@ inline void store_char(uint16_t c, Ring_Buffer *buffer)
 static uint8_t HAL_USART_Calculate_Word_Length(uint32_t config, uint8_t noparity);
 static uint32_t HAL_USART_Calculate_Data_Bits_Mask(uint32_t config);
 static uint8_t HAL_USART_Validate_Config(uint32_t config);
+static void HAL_USART_Configure_Transmit_Receive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive);
+static void HAL_USART_Configure_Pin_Modes(HAL_USART_Serial serial, uint32_t config);
 
 uint8_t HAL_USART_Calculate_Word_Length(uint32_t config, uint8_t noparity)
 {
@@ -157,6 +159,9 @@ uint8_t HAL_USART_Validate_Config(uint32_t config)
   if ((config & SERIAL_PARITY) == (SERIAL_PARITY_EVEN | SERIAL_PARITY_ODD))
     return 0;
 
+  if ((config & SERIAL_HALF_DUPLEX) && (config & LIN_MODE))
+    return 0;
+
   if (config & LIN_MODE)
   {
     // Either Master or Slave mode
@@ -175,6 +180,39 @@ uint8_t HAL_USART_Validate_Config(uint32_t config)
   }
 
   return 1;
+}
+
+void HAL_USART_Configure_Transmit_Receive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive)
+{
+  uint32_t toset = 0;
+  if (transmit) {
+    toset |= ((uint32_t)USART_CR1_TE);
+  }
+  if (receive) {
+    toset |= ((uint32_t)USART_CR1_RE);
+  }
+  uint32_t tmp = usartMap[serial]->usart_peripheral->CR1;
+  if ((tmp & ((uint32_t)(USART_CR1_TE | USART_CR1_RE))) != toset) {
+    tmp &= ~((uint32_t)(USART_CR1_TE | USART_CR1_RE));
+    tmp |= toset;
+    usartMap[serial]->usart_peripheral->CR1 = tmp;
+  }
+}
+
+void HAL_USART_Configure_Pin_Modes(HAL_USART_Serial serial, uint32_t config)
+{
+  // Configure USART Rx as input floating
+  HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
+  if ((config & SERIAL_HALF_DUPLEX) == 0) {
+    // Configure USART Tx as alternate function push-pull
+    HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
+  } else {
+    // Configure USART Tx as alternate function open drain
+    HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_DRAIN);
+  }
+
+  // Remap USARTn to alternate pins EG. USART1 to pins TX/PB6, RX/PB7
+  GPIO_PinRemapConfig(usartMap[serial]->usart_pin_remap, ENABLE);
 }
 
 void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
@@ -211,6 +249,8 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
     return;
   }
 
+  usartMap[serial]->usart_enabled = false;
+
   // AFIO clock enable
   RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
 
@@ -227,14 +267,7 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
 
   NVIC_Init(&NVIC_InitStructure);
 
-  // Configure USART Rx as input floating
-  HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
-
-  // Configure USART Tx as alternate function push-pull
-  HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
-
-  // Remap USARTn to alternate pins EG. USART1 to pins TX/PB6, RX/PB7
-  GPIO_PinRemapConfig(usartMap[serial]->usart_pin_remap, ENABLE);
+  HAL_USART_Configure_Pin_Modes(serial, config);
 
   // USART default configuration
   // USART configured as follow:
@@ -347,6 +380,12 @@ void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t conf
   // Enable USART Receive and Transmit interrupts
   USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, ENABLE);
   USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+
+  if (config & SERIAL_HALF_DUPLEX) {
+    HAL_USART_Half_Duplex(serial, ENABLE);
+  }
+
+  USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
 
   // Enable the USART
   USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
@@ -512,7 +551,23 @@ bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
 
 void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
 {
-    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, Enable ? ENABLE : DISABLE);
+  if (HAL_USART_Is_Enabled(serial)) {
+    USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
+  }
+  if (Enable) {
+    usartMap[serial]->usart_config |= SERIAL_HALF_DUPLEX;
+  } else {
+    usartMap[serial]->usart_config &= ~(SERIAL_HALF_DUPLEX);
+  }
+  HAL_USART_Configure_Pin_Modes(serial, usartMap[serial]->usart_config);
+  // These bits need to be cleared according to the reference manual
+  usartMap[serial]->usart_peripheral->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  usartMap[serial]->usart_peripheral->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
+  USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, Enable ? ENABLE : DISABLE);
+  if (HAL_USART_Is_Enabled(serial)) {
+    USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
+  }
+
 }
 
 void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
@@ -548,6 +603,15 @@ static void HAL_USART_Handler(HAL_USART_Serial serial)
     store_char(c, usartMap[serial]->usart_rx_buffer);
   }
 
+  uint8_t noecho = (usartMap[serial]->usart_config & (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO)) == (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
+
+  if(USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TC) != RESET) {
+    if (noecho) {
+      USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
+      HAL_USART_Configure_Transmit_Receive(serial, 0, 1);
+    }
+  }
+
   if(USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) != RESET)
   {
     // Write byte to the transmit data register
@@ -555,9 +619,16 @@ static void HAL_USART_Handler(HAL_USART_Serial serial)
     {
       // Buffer empty, so disable the USART Transmit interrupt
       USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
+      if (noecho) {
+        USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, ENABLE);
+      }
     }
     else
     {
+      if (noecho) {
+        HAL_USART_Configure_Transmit_Receive(serial, 1, 0);
+      }
+
       // There is more data in the output buffer. Send the next byte
       USART_SendData(usartMap[serial]->usart_peripheral,
         usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->tail++]);

--- a/user/tests/wiring/serial_halfduplex/application.cpp
+++ b/user/tests/wiring/serial_halfduplex/application.cpp
@@ -1,0 +1,6 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(MANUAL);
+
+UNIT_TEST_APP();

--- a/user/tests/wiring/serial_halfduplex/serial.cpp
+++ b/user/tests/wiring/serial_halfduplex/serial.cpp
@@ -1,0 +1,196 @@
+#include "application.h"
+#if (PLATFORM_ID == 6 || PLATFORM_ID == 8)
+#include "Serial2/Serial2.h"
+#define TESTSERIAL1 Serial1
+#define TESTSERIAL2 Serial2
+#define TX1 TX
+#elif (PLATFORM_ID == 10)
+#include "Serial4/Serial4.h"
+#include "Serial5/Serial5.h"
+#define TESTSERIAL1 Serial4
+#define TESTSERIAL2 Serial5
+#define TX1 C3
+#elif (PLATFORM_ID == 0)
+#include "Serial2/Serial2.h"
+#define TESTSERIAL1 Serial1
+#define TESTSERIAL2 Serial2
+#define TX1 TX
+#else
+#error Unsupported platform
+#endif
+#include "unit-test/unit-test.h"
+
+#define TEST_MESSAGE "All work and no play makes Jack a dull boy"
+
+void serialReadLineNoEcho(Stream *serialObj, char *dst, int max_len, system_tick_t timeout)
+{
+    char c = 0, i = 0;
+    system_tick_t last_millis = millis();
+
+    while (1)
+    {
+        if((timeout > 0) && ((millis()-last_millis) > timeout))
+        {
+            //Abort after a specified timeout
+            break;
+        }
+
+        if (0 < serialObj->available())
+        {
+            c = serialObj->read();
+
+            if (i == max_len || c == '\r' || c == '\n')
+            {
+                if (c == '\r' && (serialObj->available() > 0) && (serialObj->peek() == '\n')) {
+                    // consume it too
+                    (void)serialObj->read();
+                }
+                *dst = '\0';
+                break;
+            }
+
+            if (c == 8 || c == 127)
+            {
+                //for backspace or delete
+                if (i > 0)
+                {
+                    --dst;
+                    --i;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                *dst++ = c;
+                ++i;
+            }
+        }
+    }
+}
+
+
+void switchPinToAfOpenDrainWithPullUp(pin_t pin)
+{
+    STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
+    pin_t gpio_pin = PIN_MAP[pin].gpio_pin;
+    GPIO_TypeDef *gpio_port = PIN_MAP[pin].gpio_peripheral;
+    GPIO_InitTypeDef GPIO_InitStructure = {0};
+#if PLATFORM_ID != 0
+    GPIO_InitStructure.GPIO_Pin = gpio_pin;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+    GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+    GPIO_Init(gpio_port, &GPIO_InitStructure);
+#else
+    GPIO_InitStructure.GPIO_Pin = gpio_pin;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_OD;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init(gpio_port, &GPIO_InitStructure);
+#endif // PLATFORM_ID != 0
+}
+
+void consume(Stream& serial)
+{
+    while (serial.available() > 0) {
+        (void)serial.read();
+    }
+}
+
+test(SERIAL_01_serial_in_default_half_duplex_mode_works_normally_when_first_serial_transmits)
+{
+    char tmp[64] = {0};
+    TESTSERIAL1.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    TESTSERIAL2.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    switchPinToAfOpenDrainWithPullUp(TX1);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    TESTSERIAL1.println(TEST_MESSAGE);
+    delay(1000);
+
+    // By default echo is enabled, so both Serials under test should have received the transmitted buffer
+    assertEqual(TESTSERIAL2.available(), strlen(TEST_MESSAGE) + 2);
+    assertEqual(TESTSERIAL1.available(), strlen(TEST_MESSAGE) + 2);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL1, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL2, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+}
+
+test(SERIAL_01_serial_in_default_half_duplex_mode_works_normally_when_second_serial_transmits)
+{
+    char tmp[64] = {0};
+
+    TESTSERIAL1.end();
+    TESTSERIAL2.end();
+
+    TESTSERIAL1.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    TESTSERIAL2.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    switchPinToAfOpenDrainWithPullUp(TX1);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    consume(TESTSERIAL1);
+    consume(TESTSERIAL2);
+
+    TESTSERIAL2.println(TEST_MESSAGE);
+    delay(1000);
+
+    // By default echo is enabled, so both Serials under test should have received the transmitted buffer
+    assertEqual(TESTSERIAL1.available(), strlen(TEST_MESSAGE) + 2);
+    assertEqual(TESTSERIAL2.available(), strlen(TEST_MESSAGE) + 2);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL1, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL2, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+}
+
+
+test(SERIAL_03_serial_in_half_duplex_mode_with_echo_disabled_works_normally)
+{
+    char tmp[64] = {0};
+
+    TESTSERIAL1.end();
+    TESTSERIAL2.end();
+
+    TESTSERIAL1.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
+    TESTSERIAL2.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
+    switchPinToAfOpenDrainWithPullUp(TX1);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    consume(TESTSERIAL1);
+    consume(TESTSERIAL2);
+
+    TESTSERIAL1.println(TEST_MESSAGE);
+    delay(1000);
+
+    assertEqual(TESTSERIAL1.available(), 0);
+    assertEqual(TESTSERIAL2.available(), strlen(TEST_MESSAGE) + 2);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL2, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+
+    TESTSERIAL2.println(TEST_MESSAGE);
+    delay(1000);
+
+    assertEqual(TESTSERIAL1.available(), strlen(TEST_MESSAGE) + 2);
+    assertEqual(TESTSERIAL2.available(), 0);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL1, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+}

--- a/user/tests/wiring/serial_halfduplex/serial.cpp
+++ b/user/tests/wiring/serial_halfduplex/serial.cpp
@@ -4,23 +4,50 @@
 #define TESTSERIAL1 Serial1
 #define TESTSERIAL2 Serial2
 #define TX1 TX
+#define TX2 RGBG
 #elif (PLATFORM_ID == 10)
 #include "Serial4/Serial4.h"
 #include "Serial5/Serial5.h"
 #define TESTSERIAL1 Serial4
 #define TESTSERIAL2 Serial5
 #define TX1 C3
+#define TX2 C1
 #elif (PLATFORM_ID == 0)
 #include "Serial2/Serial2.h"
 #define TESTSERIAL1 Serial1
 #define TESTSERIAL2 Serial2
 #define TX1 TX
+#define TX2 D1
+#warning Core requires external pull-up resistor attached to TX or D1, as it doesn't support Open-Drain or Push-Pull mode with pull-up
 #else
 #error Unsupported platform
 #endif
 #include "unit-test/unit-test.h"
 
+#define BAUD_RATE 2400
 #define TEST_MESSAGE "All work and no play makes Jack a dull boy"
+
+
+/*
+ * TX1 and TX2 (for the actual pin names see the defines ^^) pins need to be jumpered for this test:
+ *            WIRE
+ * (TX1) --==========-- (TX2)
+ *
+ * NOTE: Core requires external pull-up resistor attached to TX or D1,
+ * as it doesn't support Open-Drain or Push-Pull mode with pull-up.
+ *
+ *            3V3
+ *           _____
+ *             |
+ *            +++
+ *            | | 4k7
+ *            | |
+ *            +++
+ *             |
+ *             |
+ * (TX) --=====+=====-- (D1)
+ *
+ */
 
 void serialReadLineNoEcho(Stream *serialObj, char *dst, int max_len, system_tick_t timeout)
 {
@@ -74,21 +101,16 @@ void serialReadLineNoEcho(Stream *serialObj, char *dst, int max_len, system_tick
 
 void switchPinToAfOpenDrainWithPullUp(pin_t pin)
 {
+#if PLATFORM_ID != 0
     STM32_Pin_Info* PIN_MAP = HAL_Pin_Map();
     pin_t gpio_pin = PIN_MAP[pin].gpio_pin;
     GPIO_TypeDef *gpio_port = PIN_MAP[pin].gpio_peripheral;
     GPIO_InitTypeDef GPIO_InitStructure = {0};
-#if PLATFORM_ID != 0
     GPIO_InitStructure.GPIO_Pin = gpio_pin;
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
-    GPIO_Init(gpio_port, &GPIO_InitStructure);
-#else
-    GPIO_InitStructure.GPIO_Pin = gpio_pin;
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_OD;
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_Init(gpio_port, &GPIO_InitStructure);
 #endif // PLATFORM_ID != 0
 }
@@ -100,14 +122,39 @@ void consume(Stream& serial)
     }
 }
 
-test(SERIAL_01_serial_in_default_half_duplex_mode_works_normally_when_first_serial_transmits)
+static bool pinIsFloating(const pin_t pin)
+{
+#if PLATFORM_ID != 0
+    PinMode mode = getPinMode(pin);
+    pinMode(pin, INPUT_PULLUP);
+    delay(1);
+    int32_t pup = digitalRead(pin);
+    pinMode(pin, INPUT_PULLDOWN);
+    delay(1);
+    int32_t pud = digitalRead(pin);
+
+    pinMode(pin, mode);
+
+    return (pup == HIGH && pud == LOW);
+#else
+    return true;
+#endif // PLATFORM_ID != 0
+}
+
+test(SERIAL_01_serial_in_half_duplex_mode_with_opendrain_tx_works_normally_when_first_serial_transmits)
 {
     char tmp[64] = {0};
-    TESTSERIAL1.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
-    TESTSERIAL2.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX_OPEN_DRAIN);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX_OPEN_DRAIN);
+    assertEqual(getPinMode(TX1), AF_OUTPUT_DRAIN);
+    assertEqual(getPinMode(TX2), AF_OUTPUT_DRAIN);
     switchPinToAfOpenDrainWithPullUp(TX1);
     assertEqual(TESTSERIAL1.isEnabled(), true);
     assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    consume(TESTSERIAL1);
+    consume(TESTSERIAL2);
 
     TESTSERIAL1.println(TEST_MESSAGE);
     delay(1000);
@@ -125,15 +172,17 @@ test(SERIAL_01_serial_in_default_half_duplex_mode_works_normally_when_first_seri
     assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
 }
 
-test(SERIAL_01_serial_in_default_half_duplex_mode_works_normally_when_second_serial_transmits)
+test(SERIAL_02_serial_in_half_duplex_mode_with_opendrain_tx_works_normally_when_second_serial_transmits)
 {
     char tmp[64] = {0};
 
     TESTSERIAL1.end();
     TESTSERIAL2.end();
 
-    TESTSERIAL1.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
-    TESTSERIAL2.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX_OPEN_DRAIN);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX_OPEN_DRAIN);
+    assertEqual(getPinMode(TX1), AF_OUTPUT_DRAIN);
+    assertEqual(getPinMode(TX2), AF_OUTPUT_DRAIN);
     switchPinToAfOpenDrainWithPullUp(TX1);
     assertEqual(TESTSERIAL1.isEnabled(), true);
     assertEqual(TESTSERIAL2.isEnabled(), true);
@@ -158,16 +207,147 @@ test(SERIAL_01_serial_in_default_half_duplex_mode_works_normally_when_second_ser
 }
 
 
-test(SERIAL_03_serial_in_half_duplex_mode_with_echo_disabled_works_normally)
+test(SERIAL_03_serial_in_half_duplex_mode_with_opendrain_tx_with_echo_disabled_works_normally)
 {
     char tmp[64] = {0};
 
     TESTSERIAL1.end();
     TESTSERIAL2.end();
 
-    TESTSERIAL1.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
-    TESTSERIAL2.begin(1200, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX_OPEN_DRAIN | SERIAL_HALF_DUPLEX_NO_ECHO);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX_OPEN_DRAIN | SERIAL_HALF_DUPLEX_NO_ECHO);
+    assertEqual(getPinMode(TX1), AF_OUTPUT_DRAIN);
+    assertEqual(getPinMode(TX2), AF_OUTPUT_DRAIN);
     switchPinToAfOpenDrainWithPullUp(TX1);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    consume(TESTSERIAL1);
+    consume(TESTSERIAL2);
+
+    TESTSERIAL1.println(TEST_MESSAGE);
+    delay(1000);
+
+    assertEqual(TESTSERIAL1.available(), 0);
+    assertEqual(TESTSERIAL2.available(), strlen(TEST_MESSAGE) + 2);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL2, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+
+    TESTSERIAL2.println(TEST_MESSAGE);
+    delay(1000);
+
+    assertEqual(TESTSERIAL1.available(), strlen(TEST_MESSAGE) + 2);
+    assertEqual(TESTSERIAL2.available(), 0);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL1, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+}
+
+test(SERIAL_04_serial_in_half_duplex_mode_with_pushpull_tx_works_normally_when_first_serial_transmits)
+{
+    char tmp[64] = {0};
+
+    TESTSERIAL1.end();
+    TESTSERIAL2.end();
+
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    // Both should be floating when not transmitting
+    assertTrue(pinIsFloating(TX1));
+    assertTrue(pinIsFloating(TX2));
+
+    // Reconfigure with one of USARTS pulling up to avoid noise
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_TX_PULL_UP);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    consume(TESTSERIAL1);
+    consume(TESTSERIAL2);
+
+    TESTSERIAL1.println(TEST_MESSAGE);
+    delay(1000);
+
+    // By default echo is enabled, so both Serials under test should have received the transmitted buffer
+    assertEqual(TESTSERIAL2.available(), strlen(TEST_MESSAGE) + 2);
+    assertEqual(TESTSERIAL1.available(), strlen(TEST_MESSAGE) + 2);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL1, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL2, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+}
+
+test(SERIAL_05_serial_in_half_duplex_mode_with_pushpull_tx_works_normally_when_second_serial_transmits)
+{
+    char tmp[64] = {0};
+
+    TESTSERIAL1.end();
+    TESTSERIAL2.end();
+
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    // Both should be floating when not transmitting
+    assertTrue(pinIsFloating(TX1));
+    assertTrue(pinIsFloating(TX2));
+
+    // Reconfigure with one of USARTS pulling up to avoid noise
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_TX_PULL_UP);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    consume(TESTSERIAL1);
+    consume(TESTSERIAL2);
+
+    TESTSERIAL2.println(TEST_MESSAGE);
+    delay(1000);
+
+    // By default echo is enabled, so both Serials under test should have received the transmitted buffer
+    assertEqual(TESTSERIAL1.available(), strlen(TEST_MESSAGE) + 2);
+    assertEqual(TESTSERIAL2.available(), strlen(TEST_MESSAGE) + 2);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL1, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+
+    memset(tmp, 0, sizeof(tmp));
+    serialReadLineNoEcho(&TESTSERIAL2, tmp, sizeof(tmp) - 1, 1000);
+    assertEqual(strcmp(tmp, TEST_MESSAGE), 0);
+}
+
+
+test(SERIAL_06_serial_in_half_duplex_mode_with_pushpull_tx_with_echo_disabled_works_normally)
+{
+    char tmp[64] = {0};
+
+    TESTSERIAL1.end();
+    TESTSERIAL2.end();
+
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
+    assertEqual(TESTSERIAL1.isEnabled(), true);
+    assertEqual(TESTSERIAL2.isEnabled(), true);
+
+    // Both should be floating when not transmitting
+    assertTrue(pinIsFloating(TX1));
+    assertTrue(pinIsFloating(TX2));
+
+    // Reconfigure with one of USARTS pulling up to avoid noise
+    TESTSERIAL1.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_TX_PULL_UP | SERIAL_HALF_DUPLEX_NO_ECHO);
+    TESTSERIAL2.begin(BAUD_RATE, SERIAL_8N1 | SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
     assertEqual(TESTSERIAL1.isEnabled(), true);
     assertEqual(TESTSERIAL2.isEnabled(), true);
 


### PR DESCRIPTION
### Problem

Original issue: #1276.

### Solution

- Adds `SERIAL_HALF_DUPLEX` configuration option to enable half-duplex mode in `begin()`
- Adds `SERIAL_HALF_DUPLEX_NO_ECHO` configuration option to disable echoing (receiver gets disabled while transmitting)
- default USART half-duplex mode set to push-pull
  - Adds SERIAL_OPEN_DRAIN, SERIAL_HALF_DUPLEX_OPEN_DRAIN and
  - SERIAL_TX_PULL_UP USART config options.

### Steps to Test

`wiring/serial_halfduplex`

### Example App

N/A

### References


---

### Completeness

- [x] User is totes amazing for contributing!
- [X] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [X] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation (required)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Enhancement

- [`[PR #1308]`](https://github.com/spark/firmware/pull/1308) New configuration options added for USART Half-Duplex mode, push-pull outputs are still default.  Adds: `SERIAL_OPEN_DRAIN`, `SERIAL_HALF_DUPLEX_OPEN_DRAIN`, `SERIAL_TX_PULL_UP`, `SERIAL_HALF_DUPLEX`, and `SERIAL_HALF_DUPLEX_NO_ECHO`.

### Bug fix

- [`[PR #1308]`](https://github.com/spark/firmware/pull/1308)  [`[Fixes #1276]`](https://github.com/spark/firmware/issues/1276) USART Half-Duplex not receiving data properly.