### PR TITLE
math.h fix

### DIFF
--- a/user/inc/Arduino.h
+++ b/user/inc/Arduino.h
@@ -16,11 +16,12 @@
 #define ARDUINO 10800
 #endif
 
-#ifndef __cplusplus
-#include <math.h>
-#else
-#include <cmath>
-#endif // __cplusplus
+#include "math.h"
+
+#ifndef isnan
+#error isnan is not defined please ensure this header is included before any STL headers
+#endif
+
 
 #include "avr/pgmspace.h"
 #include "spark_wiring_arduino_constants.h"

--- a/wiring/inc/spark_wiring_arduino.h
+++ b/wiring/inc/spark_wiring_arduino.h
@@ -72,10 +72,4 @@
 #define pgm_read_word_near(x) ((uint16_t)(*(x)))
 #endif
 
-#include "math.h"
-
-#ifndef isnan
-#error isnan is not defined
-#endif
-
 #endif	/* SPARK_WIRING_ARDUINO_H */


### PR DESCRIPTION
removed extraneous include of math.h in spark_wiring_arduino.h - we only want to include it when Arduino compatibility is enabled (via Arduino.h)

### Problem

math.h was being included, plus a check for isnan being a defined symbol. This will fail if `<algrithm>` has already been included before the header.  

### Solution

Only include math.h when Arduino compatibility is requested. (math.h was not included in 0.6.0).

### Steps to Test

Run the firmware library compile script to validate all libraries that compiled with 0.6.0 continue to compile with this PR.  (this has been done.)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- N/A Run unit/integration/application tests on device
- N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Bug fix

- [[PR #1310]](https://github.com/spark/firmware/pull/1310) Fixes a error when `<algorithm>` has already been included before the `math.h` header. Now we only include `math.h` when Arduino compatibility is requested. (math.h was not included in 0.6.0).