### PR TITLE
Support for Twilio SIMs by default in system firmware [ch1537]

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -26,21 +26,11 @@
 #include "net_hal.h"
 #include "inet_hal.h"
 #include "system_tick_hal.h"
+#include "cellular_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct __attribute__((__packed__))  _CellularConfig_t {
-    uint16_t size;
-    NetworkConfig nw;
-} CellularConfig;
-
-typedef int cellular_result_t;
-
-typedef int (*_CALLBACKPTR_MDM)(int type, const char* buf, int len, void* param);
-
-typedef void (*_CELLULAR_SMS_CB_MDM)(void* data, int index);
 
 /**
  * Power on and initialize the cellular module,
@@ -54,25 +44,6 @@ cellular_result_t  cellular_init(void* reserved);
  * Power off the cellular module.
  */
 cellular_result_t  cellular_off(void* reserved);
-
-#ifdef __cplusplus
-// Todo - is storing raw string pointers correct here? These will only be valid
-// If they are stored as constants in the application.
-struct CellularCredentials
-{
-    uint16_t size;
-    const char* apn = "";
-    const char* username = "";
-    const char* password = "";
-
-    CellularCredentials()
-    {
-        size = sizeof(*this);
-    }
-};
-#else
-typedef struct CellularCredentials CellularCredentials;
-#endif
 
 /**
  * Wait for the cellular module to register on the GSM network.
@@ -104,23 +75,6 @@ cellular_result_t  cellular_gprs_detach(void* reserved);
  */
 cellular_result_t  cellular_fetch_ipconfig(CellularConfig* config, void* reserved);
 
-#ifdef __cplusplus
-struct CellularDevice
-{
-    uint16_t size;
-    char iccid[21];
-    char imei[16];
-
-    CellularDevice()
-    {
-        memset(this, 0, sizeof(*this));
-        size = sizeof(*this);
-    }
-};
-#else
-typedef struct CellularDevice CellularDevice;
-#endif
-
 /**
  * Retrieve cellular module info, must be initialized first.
  */
@@ -148,16 +102,6 @@ bool cellular_sim_ready(void* reserved);
  */
 void cellular_cancel(bool cancel, bool calledFromISR, void* reserved);
 
-#ifdef __cplusplus
-struct CellularSignalHal
-{
-    int rssi = 0;
-    int qual = 0;
-};
-#else
-typedef struct CellularSignalHal CellularSignalHal;
-#endif
-
 /**
  * Retrieve cellular signal strength info
  */
@@ -168,30 +112,6 @@ cellular_result_t cellular_signal(CellularSignalHal &signal, void* reserved);
  */
 cellular_result_t cellular_command(_CALLBACKPTR_MDM cb, void* param,
                          system_tick_t timeout_ms, const char* format, ...);
-
-#ifdef __cplusplus
-struct CellularDataHal {
-    uint16_t size;
-    int cid;
-    int tx_session_offset;
-    int rx_session_offset;
-    int tx_total_offset;
-    int rx_total_offset;
-    int tx_session;
-    int rx_session;
-    int tx_total;
-    int rx_total;
-
-    CellularDataHal()
-    {
-        memset(this, 0, sizeof(*this));
-        cid = -1;
-        size = sizeof(*this);
-    }
-};
-#else
-typedef struct CellularDataHal CellularDataHal;
-#endif
 
 /**
  * Set cellular data usage info
@@ -222,6 +142,16 @@ cellular_result_t cellular_pause(void* reserved);
  * Resumes cellular modem serial communication
  */
 cellular_result_t cellular_resume(void* reserved);
+
+/**
+ * Set the cellular network provider based on the IMSI of the SIM card inserted
+ */
+cellular_result_t cellular_imsi_to_network_provider(void* reserved);
+
+/**
+ * Function for getting the cellular network provider currently set
+ */
+CellularNetProv cellular_network_provider_get(void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -149,9 +149,9 @@ cellular_result_t cellular_resume(void* reserved);
 cellular_result_t cellular_imsi_to_network_provider(void* reserved);
 
 /**
- * Function for getting the cellular network provider currently set
+ * Function for getting the cellular network provider data currently set
  */
-CellularNetProv cellular_network_provider_get(void* reserved);
+const CellularNetProvData cellular_network_provider_data_get(void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -26,7 +26,7 @@
 #include "net_hal.h"
 #include "inet_hal.h"
 #include "system_tick_hal.h"
-#include "cellular_internal.h"
+#include "cellular_hal_constants.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/inc/cellular_hal_constants.h
+++ b/hal/inc/cellular_hal_constants.h
@@ -1,0 +1,126 @@
+/*
+ ******************************************************************************
+  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+  ******************************************************************************
+ */
+
+#ifndef CELLULAR_HAL_CONSTANTS_H
+#define CELLULAR_HAL_CONSTANTS_H
+
+#include "inet_hal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct __attribute__((__packed__))  _CellularConfig_t {
+    uint16_t size;
+    NetworkConfig nw;
+} CellularConfig;
+
+typedef int cellular_result_t;
+
+typedef int (*_CALLBACKPTR_MDM)(int type, const char* buf, int len, void* param);
+
+typedef void (*_CELLULAR_SMS_CB_MDM)(void* data, int index);
+
+typedef enum { CELLULAR_NETPROV_TELEFONICA =   0,
+               CELLULAR_NETPROV_TWILIO     =   1,
+               CELLULAR_NETPROV_UNKNOWN    = 999 } CellularNetProv;
+
+// Network APNs
+#define CELLULAR_NETAPN_TELEFONICA              "spark.telefonica.com"
+#define CELLULAR_NETAPN_TWILIO                  "wireless.twilio.com"
+
+// Network Provider Keep Alive (seconds)
+#define CELLULAR_NETPROV_TELEFONICA_KEEPALIVE   (23*60)
+#define CELLULAR_NETPROV_TWILIO_KEEPALIVE       (23*60)
+
+#ifdef __cplusplus
+// Todo - is storing raw string pointers correct here? These will only be valid
+// If they are stored as constants in the application.
+struct CellularCredentials
+{
+    uint16_t size;
+    const char* apn = "";
+    const char* username = "";
+    const char* password = "";
+
+    CellularCredentials()
+    {
+        size = sizeof(*this);
+    }
+};
+#else
+typedef struct CellularCredentials CellularCredentials;
+#endif
+
+#ifdef __cplusplus
+struct CellularDevice
+{
+    uint16_t size;
+    char iccid[21];
+    char imei[16];
+
+    CellularDevice()
+    {
+        memset(this, 0, sizeof(*this));
+        size = sizeof(*this);
+    }
+};
+#else
+typedef struct CellularDevice CellularDevice;
+#endif
+
+#ifdef __cplusplus
+struct CellularSignalHal
+{
+    int rssi = 0;
+    int qual = 0;
+};
+#else
+typedef struct CellularSignalHal CellularSignalHal;
+#endif
+
+#ifdef __cplusplus
+struct CellularDataHal {
+    uint16_t size;
+    int cid;
+    int tx_session_offset;
+    int rx_session_offset;
+    int tx_total_offset;
+    int rx_total_offset;
+    int tx_session;
+    int rx_session;
+    int tx_total;
+    int rx_total;
+
+    CellularDataHal()
+    {
+        memset(this, 0, sizeof(*this));
+        cid = -1;
+        size = sizeof(*this);
+    }
+};
+#else
+typedef struct CellularDataHal CellularDataHal;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* CELLULAR_HAL_CONSTANTS_H */

--- a/hal/inc/cellular_hal_constants.h
+++ b/hal/inc/cellular_hal_constants.h
@@ -62,9 +62,6 @@ struct CellularNetProvData {
 typedef struct CellularNetProvData CellularNetProvData;
 #endif
 
-// CELLULAR_NET_PROVIDER_DATA[CELLULAR_NETPROV_MAX - 1] is the last provider record
-const CellularNetProvData CELLULAR_NET_PROVIDER_DATA[] = { DEFINE_NET_PROVIDER_DATA };
-
 #ifdef __cplusplus
 // Todo - is storing raw string pointers correct here? These will only be valid
 // If they are stored as constants in the application.

--- a/hal/inc/cellular_hal_constants.h
+++ b/hal/inc/cellular_hal_constants.h
@@ -37,17 +37,33 @@ typedef int (*_CALLBACKPTR_MDM)(int type, const char* buf, int len, void* param)
 
 typedef void (*_CELLULAR_SMS_CB_MDM)(void* data, int index);
 
-typedef enum { CELLULAR_NETPROV_TELEFONICA =   0,
-               CELLULAR_NETPROV_TWILIO     =   1,
-               CELLULAR_NETPROV_UNKNOWN    = 999 } CellularNetProv;
+#define DEFINE_NET_PROVIDER_DATA \
+    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_TELEFONICA, "spark.telefonica.com", (23*60), (5684) ),  \
+    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_TWILIO, "wireless.twilio.com", (23*60), (4500) ),  \
+    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_MAX, "", (0), (0) )
 
-// Network APNs
-#define CELLULAR_NETAPN_TELEFONICA              "spark.telefonica.com"
-#define CELLULAR_NETAPN_TWILIO                  "wireless.twilio.com"
+#define DEFINE_NET_PROVIDER( idx, apn, keepalive, port )  idx
+#ifdef __cplusplus
+enum CellularNetProv { DEFINE_NET_PROVIDER_DATA };
+#else
+typedef enum CellularNetProv CellularNetProv;
+#endif
 
-// Network Provider Keep Alive (seconds)
-#define CELLULAR_NETPROV_TELEFONICA_KEEPALIVE   (23*60)
-#define CELLULAR_NETPROV_TWILIO_KEEPALIVE       (23*60)
+#undef DEFINE_NET_PROVIDER
+#define DEFINE_NET_PROVIDER( idx, apn, keepalive, port )  { apn, keepalive, port }
+
+#ifdef __cplusplus
+struct CellularNetProvData {
+    const char* apn;
+    int keepalive;
+    uint16_t port;
+};
+#else
+typedef struct CellularNetProvData CellularNetProvData;
+#endif
+
+// CELLULAR_NET_PROVIDER_DATA[CELLULAR_NETPROV_MAX - 1] is the last provider record
+const CellularNetProvData CELLULAR_NET_PROVIDER_DATA[] = { DEFINE_NET_PROVIDER_DATA };
 
 #ifdef __cplusplus
 // Todo - is storing raw string pointers correct here? These will only be valid

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -67,7 +67,7 @@ DYNALIB_FN(26, hal_cellular, HAL_NET_SetCallbacks, void(const HAL_NET_Callbacks*
 DYNALIB_FN(27, hal_cellular, cellular_pause, cellular_result_t(void*))
 DYNALIB_FN(28, hal_cellular, cellular_resume, cellular_result_t(void*))
 DYNALIB_FN(29, hal_cellular, cellular_imsi_to_network_provider, cellular_result_t(void*))
-DYNALIB_FN(30, hal_cellular, cellular_network_provider_get, CellularNetProv(void*))
+DYNALIB_FN(30, hal_cellular, cellular_network_provider_data_get, const CellularNetProvData(void*))
 DYNALIB_END(hal_cellular)
 
 #endif  // PLATFORM_ID == 10

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -66,6 +66,8 @@ DYNALIB_FN(25, hal_cellular, HAL_USART3_Handler_Impl, void(void*))
 DYNALIB_FN(26, hal_cellular, HAL_NET_SetCallbacks, void(const HAL_NET_Callbacks*, void*))
 DYNALIB_FN(27, hal_cellular, cellular_pause, cellular_result_t(void*))
 DYNALIB_FN(28, hal_cellular, cellular_resume, cellular_result_t(void*))
+DYNALIB_FN(29, hal_cellular, cellular_imsi_to_network_provider, cellular_result_t(void*))
+DYNALIB_FN(30, hal_cellular, cellular_network_provider_get, CellularNetProv(void*))
 DYNALIB_END(hal_cellular)
 
 #endif  // PLATFORM_ID == 10

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -10,6 +10,9 @@ static CellularCredentials cellularCredentials;
 
 static CellularNetProv cellularNetProv = CELLULAR_NETPROV_TELEFONICA;
 
+// CELLULAR_NET_PROVIDER_DATA[CELLULAR_NETPROV_MAX - 1] is the last provider record
+const CellularNetProvData CELLULAR_NET_PROVIDER_DATA[] = { DEFINE_NET_PROVIDER_DATA };
+
 static HAL_NET_Callbacks netCallbacks = { 0 };
 
 void HAL_NET_notify_connected()

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -86,14 +86,8 @@ cellular_result_t  cellular_gprs_attach(CellularCredentials* connect, void* rese
     if (strcmp(connect->apn,"") != 0 || strcmp(connect->username,"") != 0 || strcmp(connect->password,"") != 0 ) {
         CHECK_SUCCESS(electronMDM.join(connect->apn, connect->username, connect->password));
     }
-    else if (cellularNetProv == CELLULAR_NETPROV_TELEFONICA) {
-        CHECK_SUCCESS(electronMDM.join(CELLULAR_NETAPN_TELEFONICA, NULL, NULL));
-    }
-    else if (cellularNetProv == CELLULAR_NETPROV_TWILIO) {
-        CHECK_SUCCESS(electronMDM.join(CELLULAR_NETAPN_TWILIO, NULL, NULL));
-    }
     else {
-        CHECK_SUCCESS(electronMDM.join());
+        CHECK_SUCCESS(electronMDM.join(CELLULAR_NET_PROVIDER_DATA[cellularNetProv].apn, NULL, NULL));
     }
     return 0;
 }
@@ -305,9 +299,9 @@ cellular_result_t cellular_imsi_to_network_provider(void* reserved)
     return 0;
 }
 
-CellularNetProv cellular_network_provider_get(void* reserved)
+const CellularNetProvData cellular_network_provider_data_get(void* reserved)
 {
-    return cellularNetProv;
+    return CELLULAR_NET_PROVIDER_DATA[cellularNetProv];
 }
 
 #endif // !defined(HAL_CELLULAR_EXCLUDE)

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -2,6 +2,7 @@
 
 #include "modem/mdm_hal.h"
 #include "cellular_hal.h"
+#include "cellular_internal.h"
 
 #define CHECK_SUCCESS(x) { if (!(x)) return -1; }
 

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -1,12 +1,13 @@
 #ifndef HAL_CELLULAR_EXCLUDE
 
-#include "cellular_hal.h"
-#include "cellular_internal.h"
 #include "modem/mdm_hal.h"
+#include "cellular_hal.h"
 
 #define CHECK_SUCCESS(x) { if (!(x)) return -1; }
 
 static CellularCredentials cellularCredentials;
+
+static CellularNetProv cellularNetProv = CELLULAR_NETPROV_TELEFONICA;
 
 static HAL_NET_Callbacks netCallbacks = { 0 };
 
@@ -83,6 +84,12 @@ cellular_result_t  cellular_gprs_attach(CellularCredentials* connect, void* rese
 {
     if (strcmp(connect->apn,"") != 0 || strcmp(connect->username,"") != 0 || strcmp(connect->password,"") != 0 ) {
         CHECK_SUCCESS(electronMDM.join(connect->apn, connect->username, connect->password));
+    }
+    else if (cellularNetProv == CELLULAR_NETPROV_TELEFONICA) {
+        CHECK_SUCCESS(electronMDM.join(CELLULAR_NETAPN_TELEFONICA, NULL, NULL));
+    }
+    else if (cellularNetProv == CELLULAR_NETPROV_TWILIO) {
+        CHECK_SUCCESS(electronMDM.join(CELLULAR_NETAPN_TWILIO, NULL, NULL));
     }
     else {
         CHECK_SUCCESS(electronMDM.join());
@@ -288,6 +295,18 @@ cellular_result_t cellular_resume(void* reserved)
 {
     electronMDM.resume();
     return 0;
+}
+
+cellular_result_t cellular_imsi_to_network_provider(void* reserved)
+{
+    const DevStatus* status = electronMDM.getDevStatus();
+    cellularNetProv = detail::_cellular_imsi_to_network_provider(status->imsi);
+    return 0;
+}
+
+CellularNetProv cellular_network_provider_get(void* reserved)
+{
+    return cellularNetProv;
 }
 
 #endif // !defined(HAL_CELLULAR_EXCLUDE)

--- a/hal/src/electron/cellular_internal.cpp
+++ b/hal/src/electron/cellular_internal.cpp
@@ -1,0 +1,26 @@
+#ifndef HAL_CELLULAR_EXCLUDE
+
+#include "logging.h"
+#include "cellular_hal.h"
+#include "cellular_internal.h"
+#include <stdlib.h>
+
+namespace detail {
+    CellularNetProv _cellular_imsi_to_network_provider(const char* imsi) {
+        if (imsi && strlen(imsi) > 0) {
+            // convert to unsigned long long (imsi can be 15 digits)
+            unsigned long long imsi64 = strtoull(imsi, NULL, 10);
+            // LOG(INFO,"IMSI: %s %lu%lu", imsi, (uint32_t)(imsi64/100000000), (uint32_t)(imsi64-310260800000000));
+            // set network provider based on IMSI range
+            if (imsi64 >= 310260859000000 && imsi64 <= 310260859999999) {
+                return CELLULAR_NETPROV_TWILIO;
+            }
+            else {
+                return CELLULAR_NETPROV_TELEFONICA;
+            }
+        }
+        return CELLULAR_NETPROV_TELEFONICA; // default to telefonica
+    }
+} // namespace detail
+
+#endif // !defined(HAL_CELLULAR_EXCLUDE)

--- a/hal/src/electron/cellular_internal.h
+++ b/hal/src/electron/cellular_internal.h
@@ -17,106 +17,14 @@
   ******************************************************************************
  */
 
-#ifndef CELLULAR_HAL_MDM_H
-#define	CELLULAR_HAL_MDM_H
+#ifndef CELLULAR_INTERNAL_H
+#define	CELLULAR_INTERNAL_H
 
 #include "modem/enums_hal.h"
+#include "cellular_hal_constants.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-typedef struct __attribute__((__packed__))  _CellularConfig_t {
-    uint16_t size;
-    NetworkConfig nw;
-} CellularConfig;
-
-typedef int cellular_result_t;
-
-typedef int (*_CALLBACKPTR_MDM)(int type, const char* buf, int len, void* param);
-
-typedef void (*_CELLULAR_SMS_CB_MDM)(void* data, int index);
-
-typedef enum { CELLULAR_NETPROV_TELEFONICA =   0,
-               CELLULAR_NETPROV_TWILIO     =   1,
-               CELLULAR_NETPROV_UNKNOWN    = 999 } CellularNetProv;
-
-// Network APNs
-#define CELLULAR_NETAPN_TELEFONICA              "spark.telefonica.com"
-#define CELLULAR_NETAPN_TWILIO                  "wireless.twilio.com"
-
-// Network Provider Keep Alive (seconds)
-#define CELLULAR_NETPROV_TELEFONICA_KEEPALIVE   (23*60)
-#define CELLULAR_NETPROV_TWILIO_KEEPALIVE       (23*60)
-
-#ifdef __cplusplus
-// Todo - is storing raw string pointers correct here? These will only be valid
-// If they are stored as constants in the application.
-struct CellularCredentials
-{
-    uint16_t size;
-    const char* apn = "";
-    const char* username = "";
-    const char* password = "";
-
-    CellularCredentials()
-    {
-        size = sizeof(*this);
-    }
-};
-#else
-typedef struct CellularCredentials CellularCredentials;
-#endif
-
-#ifdef __cplusplus
-struct CellularDevice
-{
-    uint16_t size;
-    char iccid[21];
-    char imei[16];
-
-    CellularDevice()
-    {
-        memset(this, 0, sizeof(*this));
-        size = sizeof(*this);
-    }
-};
-#else
-typedef struct CellularDevice CellularDevice;
-#endif
-
-#ifdef __cplusplus
-struct CellularSignalHal
-{
-    int rssi = 0;
-    int qual = 0;
-};
-#else
-typedef struct CellularSignalHal CellularSignalHal;
-#endif
-
-#ifdef __cplusplus
-struct CellularDataHal {
-    uint16_t size;
-    int cid;
-    int tx_session_offset;
-    int rx_session_offset;
-    int tx_total_offset;
-    int rx_total_offset;
-    int tx_session;
-    int rx_session;
-    int tx_total;
-    int rx_total;
-
-    CellularDataHal()
-    {
-        memset(this, 0, sizeof(*this));
-        cid = -1;
-        size = sizeof(*this);
-    }
-};
-#else
-typedef struct CellularDataHal CellularDataHal;
 #endif
 
 /**
@@ -157,5 +65,5 @@ cellular_result_t cellular_band_available_get(MDM_BandSelect* bands, void* reser
 }
 #endif
 
-#endif	/* CELLULAR_HAL_MDM_H */
+#endif	/* CELLULAR_INTERNAL_H */
 

--- a/hal/src/electron/cellular_internal.h
+++ b/hal/src/electron/cellular_internal.h
@@ -26,6 +26,99 @@
 extern "C" {
 #endif
 
+typedef struct __attribute__((__packed__))  _CellularConfig_t {
+    uint16_t size;
+    NetworkConfig nw;
+} CellularConfig;
+
+typedef int cellular_result_t;
+
+typedef int (*_CALLBACKPTR_MDM)(int type, const char* buf, int len, void* param);
+
+typedef void (*_CELLULAR_SMS_CB_MDM)(void* data, int index);
+
+typedef enum { CELLULAR_NETPROV_TELEFONICA =   0,
+               CELLULAR_NETPROV_TWILIO     =   1,
+               CELLULAR_NETPROV_UNKNOWN    = 999 } CellularNetProv;
+
+// Network APNs
+#define CELLULAR_NETAPN_TELEFONICA              "spark.telefonica.com"
+#define CELLULAR_NETAPN_TWILIO                  "wireless.twilio.com"
+
+// Network Provider Keep Alive (seconds)
+#define CELLULAR_NETPROV_TELEFONICA_KEEPALIVE   (23*60)
+#define CELLULAR_NETPROV_TWILIO_KEEPALIVE       (23*60)
+
+#ifdef __cplusplus
+// Todo - is storing raw string pointers correct here? These will only be valid
+// If they are stored as constants in the application.
+struct CellularCredentials
+{
+    uint16_t size;
+    const char* apn = "";
+    const char* username = "";
+    const char* password = "";
+
+    CellularCredentials()
+    {
+        size = sizeof(*this);
+    }
+};
+#else
+typedef struct CellularCredentials CellularCredentials;
+#endif
+
+#ifdef __cplusplus
+struct CellularDevice
+{
+    uint16_t size;
+    char iccid[21];
+    char imei[16];
+
+    CellularDevice()
+    {
+        memset(this, 0, sizeof(*this));
+        size = sizeof(*this);
+    }
+};
+#else
+typedef struct CellularDevice CellularDevice;
+#endif
+
+#ifdef __cplusplus
+struct CellularSignalHal
+{
+    int rssi = 0;
+    int qual = 0;
+};
+#else
+typedef struct CellularSignalHal CellularSignalHal;
+#endif
+
+#ifdef __cplusplus
+struct CellularDataHal {
+    uint16_t size;
+    int cid;
+    int tx_session_offset;
+    int rx_session_offset;
+    int tx_total_offset;
+    int rx_total_offset;
+    int tx_session;
+    int rx_session;
+    int tx_total;
+    int rx_total;
+
+    CellularDataHal()
+    {
+        memset(this, 0, sizeof(*this));
+        cid = -1;
+        size = sizeof(*this);
+    }
+};
+#else
+typedef struct CellularDataHal CellularDataHal;
+#endif
+
 /**
  * Function for processing Set cellular data usage info, broken out for unit tests
  */
@@ -35,6 +128,14 @@ cellular_result_t _cellular_data_usage_set(CellularDataHal &data, const MDM_Data
  * Function for processing Get cellular data usage info, broken out for unit tests
  */
 cellular_result_t _cellular_data_usage_set(CellularDataHal &data, const MDM_DataUsage &data_usage, bool ret);
+
+/* detail functions defined for unit tests */
+namespace detail {
+    /**
+     * Function for setting the cellular network provider based on the IMSI of the SIM card inserted, broken out for unit tests
+     */
+    CellularNetProv _cellular_imsi_to_network_provider(const char* imsi);
+} // namespace detail
 
 /**
  * Set cellular band select
@@ -50,6 +151,7 @@ cellular_result_t cellular_band_select_get(MDM_BandSelect* bands, void* reserved
  * Get cellular band available
  */
 cellular_result_t cellular_band_available_get(MDM_BandSelect* bands, void* reserved);
+
 
 #ifdef __cplusplus
 }

--- a/hal/src/electron/modem/enums_hal.h
+++ b/hal/src/electron/modem/enums_hal.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string.h>
+#include <stdint.h>
 
 // ----------------------------------------------------------------
 // Types

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -61,7 +61,7 @@ public:
         \return true if successful, false otherwise
     */
     bool connect(const char* simpin = NULL,
-            const char* apn = "spark.telefonica.com", const char* username = NULL,
+            const char* apn = NULL, const char* username = NULL,
             const char* password = NULL, Auth auth = AUTH_DETECT);
 
     /**
@@ -144,7 +144,7 @@ public:
 
     /** Setup the PDP context
     */
-    bool pdp(const char* apn = "spark.telefonica.com");
+    bool pdp(const char* apn = NULL);
 
     // ----------------------------------------------------------------
     // Data Connection (GPRS)
@@ -157,7 +157,7 @@ public:
         \param auth is the authentication mode (CHAP,PAP,NONE or DETECT)
         \return the ip that is assigned
     */
-    MDM_IP join(const char* apn = "spark.telefonica.com", const char* username = NULL,
+    MDM_IP join(const char* apn = NULL, const char* username = NULL,
                        const char* password = NULL, Auth auth = AUTH_DETECT);
 
     /** deregister (detach) the MT from the GPRS service.

--- a/modules/electron/system-part1/src/cellular_hal.cpp
+++ b/modules/electron/system-part1/src/cellular_hal.cpp
@@ -2,5 +2,6 @@
 #include "../src/electron/modem/mdm_hal.cpp"
 #include "../src/electron/parser.cpp"
 #include "../src/electron/cellular_hal.cpp"
+#include "../src/electron/cellular_internal.cpp"
 #include "../src/electron/inet_hal_new.cpp"
 #include "../src/electron/socket_hal.cpp"

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -185,7 +185,6 @@ int spark_set_connection_property(unsigned property_id, unsigned data, void* dat
 //#define SPARK_SERVER_IP             "54.235.79.249"
 #define SPARK_SERVER_PORT             5683
 #define PORT_COAPS                    (5684)
-#define PORT_COAPS_TWILIO             4500
 #define SPARK_LOOP_DELAY_MILLIS       1000    //1sec
 #define SPARK_RECEIVE_DELAY_MILLIS    10      //10ms
 

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -180,29 +180,30 @@ ProtocolFacade* system_cloud_protocol_instance(void);
 int spark_set_connection_property(unsigned property_id, unsigned data, void* datap, void* reserved);
 
 
-#define SPARK_BUF_LEN			        600
+#define SPARK_BUF_LEN                 600
 
-//#define SPARK_SERVER_IP			        "54.235.79.249"
-#define SPARK_SERVER_PORT		        5683
-#define PORT_COAPS						(5684)
-#define SPARK_LOOP_DELAY_MILLIS		        1000    //1sec
-#define SPARK_RECEIVE_DELAY_MILLIS              10      //10ms
+//#define SPARK_SERVER_IP             "54.235.79.249"
+#define SPARK_SERVER_PORT             5683
+#define PORT_COAPS                    (5684)
+#define PORT_COAPS_TWILIO             4500
+#define SPARK_LOOP_DELAY_MILLIS       1000    //1sec
+#define SPARK_RECEIVE_DELAY_MILLIS    10      //10ms
 
 #if PLATFORM_ID==10
-#define TIMING_FLASH_UPDATE_TIMEOUT             90000   //90sec
+#define TIMING_FLASH_UPDATE_TIMEOUT   90000   //90sec
 #else
-#define TIMING_FLASH_UPDATE_TIMEOUT             30000   //30sec
+#define TIMING_FLASH_UPDATE_TIMEOUT   30000   //30sec
 #endif
 
-#define USER_VAR_MAX_COUNT		        10
-#define USER_VAR_KEY_LENGTH		        12
+#define USER_VAR_MAX_COUNT            10
+#define USER_VAR_KEY_LENGTH           12
 
-#define USER_FUNC_MAX_COUNT		        4
-#define USER_FUNC_KEY_LENGTH		        12
-#define USER_FUNC_ARG_LENGTH		        64
+#define USER_FUNC_MAX_COUNT           4
+#define USER_FUNC_KEY_LENGTH          12
+#define USER_FUNC_ARG_LENGTH          64
 
-#define USER_EVENT_NAME_LENGTH		        64
-#define USER_EVENT_DATA_LENGTH		        64
+#define USER_EVENT_NAME_LENGTH        64
+#define USER_EVENT_DATA_LENGTH        64
 
 #ifdef __cplusplus
 }

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -29,6 +29,7 @@
 
 int Internet_Test(void);
 
+void spark_cloud_udp_port_set(uint16_t port);
 int spark_cloud_socket_connect(void);
 int spark_cloud_socket_disconnect(void);
 

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -61,6 +61,9 @@ protected:
         result = cellular_pdp_activate(savedCreds, NULL);
         if (result) { return; }
 
+        result = cellular_imsi_to_network_provider(NULL);
+        if (result) { return; }
+
         //DEBUG_D("savedCreds = %s %s %s\r\n", savedCreds->apn, savedCreds->username, savedCreds->password);
         result = cellular_gprs_attach(savedCreds, NULL);
         if (result) { return; }

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -342,8 +342,8 @@ public:
 
     void connect(bool listen_enabled=true) override
     {
-        INFO("ready(): %d; connecting(): %d; listening(): %d; WLAN_SMART_CONFIG_START: %d", (int)ready(), (int)connecting(),
-                (int)listening(), (int)WLAN_SMART_CONFIG_START);
+        // INFO("ready(): %d; connecting(): %d; listening(): %d; WLAN_SMART_CONFIG_START: %d", (int)ready(), (int)connecting(),
+        //        (int)listening(), (int)WLAN_SMART_CONFIG_START);
         if (!ready() && !connecting() && !listening() && !WLAN_SMART_CONFIG_START) // Don't try to connect if listening mode is active or pending
         {
             bool was_sleeping = SPARK_WLAN_SLEEP;

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -37,7 +37,6 @@
 #include "rgbled.h"
 #include "service_debug.h"
 #include "cellular_hal.h"
-#include "cellular_internal.h"
 
 #include "spark_wiring_network.h"
 #include "spark_wiring_constants.h"

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -290,7 +290,6 @@ void establish_cloud_connection()
 #if PLATFORM_ID==PLATFORM_ELECTRON_PRODUCTION
         uint16_t electron_udp_port = PORT_COAPS;
         int electron_udp_keepalive = CELLULAR_NETPROV_TELEFONICA_KEEPALIVE;
-        DEBUG("NETPROV:%s", (cellular_network_provider_get(NULL)==CELLULAR_NETPROV_TWILIO)?"Twilio":"Telefonica");
         if (cellular_network_provider_get(NULL) == CELLULAR_NETPROV_TWILIO) {
             electron_udp_port = PORT_COAPS_TWILIO;
             electron_udp_keepalive = CELLULAR_NETPROV_TWILIO_KEEPALIVE;

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -287,14 +287,9 @@ void establish_cloud_connection()
         }
 
 #if PLATFORM_ID==PLATFORM_ELECTRON_PRODUCTION
-        uint16_t electron_udp_port = PORT_COAPS;
-        int electron_udp_keepalive = CELLULAR_NETPROV_TELEFONICA_KEEPALIVE;
-        if (cellular_network_provider_get(NULL) == CELLULAR_NETPROV_TWILIO) {
-            electron_udp_port = PORT_COAPS_TWILIO;
-            electron_udp_keepalive = CELLULAR_NETPROV_TWILIO_KEEPALIVE;
-        }
-        CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, electron_udp_keepalive * 1000, nullptr, nullptr), (void)0);
-        spark_cloud_udp_port_set(electron_udp_port);
+        const CellularNetProvData provider_data = cellular_network_provider_data_get(NULL);
+        CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, (provider_data.keepalive * 1000), nullptr, nullptr), (void)0);
+        spark_cloud_udp_port_set(provider_data.port);
 #endif
         INFO("Cloud: connecting");
         system_notify_event(cloud_status, cloud_status_connecting);

--- a/user/tests/unit/cellular.cpp
+++ b/user/tests/unit/cellular.cpp
@@ -17,7 +17,7 @@
  ******************************************************************************
  */
 
-#include "cellular_hal.h"
+#include "cellular_internal.h"
 
 #undef WARN
 #undef INFO

--- a/user/tests/unit/cellular.cpp
+++ b/user/tests/unit/cellular.cpp
@@ -1,0 +1,38 @@
+/**
+ ******************************************************************************
+  Copyright (c) 2013-2016 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#include "cellular_hal.h"
+
+#undef WARN
+#undef INFO
+#include "catch.hpp"
+
+using namespace detail;
+
+SCENARIO("IMSI range should default to Telefonica as Network Provider", "[cellular]") {
+    REQUIRE(_cellular_imsi_to_network_provider(NULL) == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("") == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("123456789012345") == CELLULAR_NETPROV_TELEFONICA);
+}
+
+SCENARIO("IMSI range should set Twilio as Network Provider", "[cellular]") {
+    REQUIRE(_cellular_imsi_to_network_provider("310260859000000") == CELLULAR_NETPROV_TWILIO);
+    REQUIRE(_cellular_imsi_to_network_provider("310260859500000") == CELLULAR_NETPROV_TWILIO);
+    REQUIRE(_cellular_imsi_to_network_provider("310260859999999") == CELLULAR_NETPROV_TWILIO);
+}

--- a/user/tests/unit/makefile
+++ b/user/tests/unit/makefile
@@ -56,6 +56,7 @@ CPPSRC += $(call target_files,$(SYSTEM)src/,system_string_interpolate.cpp)
 CPPSRC += $(call target_files,$(SYSTEM)src/,system_led_signal.cpp)
 CPPSRC += $(call target_files,$(HAL)src/gcc,timer_hal.cpp)
 CPPSRC += $(call target_files,$(HAL)src/gcc,rgbled_hal.cpp)
+CPPSRC += $(call target_files,$(HAL)src/electron,cellular_internal.cpp)
 
 # Paths to dependent projects, referenced from root of this project
 LIB_SERVICES = services/
@@ -76,6 +77,7 @@ INCLUDE_DIRS += $(WIRING)inc
 INCLUDE_DIRS += $(SYSTEM)inc
 INCLUDE_DIRS += $(HAL)shared
 INCLUDE_DIRS += $(HAL)inc
+INCLUDE_DIRS += $(HAL)src/electron
 INCLUDE_DIRS += $(COMMUNICATION)src
 INCLUDE_DIRS += dynalib/inc
 


### PR DESCRIPTION
Supersedes PR #1288 so we can release in 0.6.2-rc.2 instead of 0.7.0-rc.1.

---

### Feature

[[PR#1311]](https://github.com/spark/firmware/pull/1311) `[Implements CH1537] [Electron]` Added support for Twilio SIMs by default in system firmware.