### PR TITLE
Compilation fixes for GCC platform

### DIFF
--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -446,6 +446,14 @@ void HAL_Core_Button_Mirror_Pin(uint16_t pin, InterruptMode mode, uint8_t bootlo
 {
 }
 
+void HAL_Core_Led_Mirror_Pin(uint8_t led, pin_t pin, uint32_t flags, uint8_t bootloader, void* reserved)
+{
+}
+
+void HAL_Core_Led_Mirror_Pin_Disable(uint8_t led, uint8_t bootloader, void* reserved)
+{
+}
+
 static HAL_Event_Callback eventCallback = nullptr;
 
 void HAL_Set_Event_Callback(HAL_Event_Callback callback, void* reserved) {

--- a/hal/src/gcc/socket_hal.cpp
+++ b/hal/src/gcc/socket_hal.cpp
@@ -140,8 +140,6 @@ bool is_valid(ip::udp::socket& handle) {
 
 class TCPServer
 {
-	uint16_t _port;
-
 	ip::tcp::acceptor acceptor;
 
 	void accept_handler(const boost::system::error_code& error)
@@ -166,8 +164,7 @@ class TCPServer
 
 public:
 	TCPServer(uint16_t port)
-		: _port(port),
-		  acceptor(device_io_service, ip::tcp::endpoint(ip::tcp::v4(), port))
+		: acceptor(device_io_service, ip::tcp::endpoint(ip::tcp::v4(), port))
 	{
 		acceptor.non_blocking(true);
 	}

--- a/system/src/system_network_wifi.h
+++ b/system/src/system_network_wifi.h
@@ -26,8 +26,6 @@
 
 class WiFiNetworkInterface : public ManagedIPNetworkInterface<WLanConfig, WiFiNetworkInterface>
 {
-    WLanConfig ip_config;
-
     static int wifi_add_profile_callback(void* data, const char *ssid, const char *password,
         unsigned long security_type, unsigned long cipher, bool dry_run)
     {


### PR DESCRIPTION
### Problem

Compilation of the firmware currently fails on Mac OS.

### Solution

Remove unused member variables, add missing functions to the gcc platform's HAL.

### Steps to Test

firmware/main$ make -s clean all PLATFORM=gcc

---

### Completeness

- [x] User is totes amazing for contributing!
- [X] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [X] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
