### PR TITLE
Use type-safe wrapper for flag values

### DIFF
--- a/user/tests/unit/flags.cpp
+++ b/user/tests/unit/flags.cpp
@@ -4,255 +4,208 @@
 
 #include <limits>
 
-namespace {
+TEST_CASE("particle::Flags<TagT, ValueT>") {
+    struct FlagType; // Tag type
+    typedef particle::Flags<FlagType> Flags; // Using default value type
 
-using namespace particle;
-
-enum FlagUint {
-    FLAG_1 = 0x01,
-    FLAG_2 = 0x02,
-    FLAG_NONE = 0x00,
-    FLAG_ALL = std::numeric_limits<unsigned>::max()
-};
-
-enum class FlagUint8: uint8_t {
-    FLAG_1 = 0x01,
-    FLAG_2 = 0x02,
-    FLAG_NONE = 0x00,
-    FLAG_ALL = 0xff
-};
-
-enum class FlagUint64: uint64_t {
-    FLAG_1 = 0x01,
-    FLAG_2 = 0x02,
-    FLAG_NONE = 0x00,
-    FLAG_ALL = 0xffffffffffffffffull
-};
-
-PARTICLE_DEFINE_FLAG_OPERATORS(FlagUint)
-PARTICLE_DEFINE_FLAG_OPERATORS(FlagUint8)
-PARTICLE_DEFINE_FLAG_OPERATORS(FlagUint64)
-
-template<typename FlagsT>
-void testFlags() {
-    using Flags = FlagsT;
-    using Enum = typename Flags::EnumType;
-    using Value = typename Flags::ValueType;
+    const Flags::FlagType FLAG_1(0x01);
+    const Flags::FlagType FLAG_2(0x02);
+    const Flags::FlagType FLAG_NONE(0x00);
+    const Flags::FlagType FLAG_ALL(std::numeric_limits<Flags::ValueType>::max());
 
     SECTION("Flags()") {
         // Flags()
         Flags f1;
         CHECK(f1.value() == 0x00);
-        // Flags(ValueType)
-        Flags f2(0x01);
+        // Flags(Flags::FlagType)
+        Flags f2(FLAG_1);
         CHECK(f2.value() == 0x01);
-        // Flags(T)
-        Flags f3(Enum::FLAG_1);
-        CHECK(f3.value() == 0x01);
-        // Flags(const Flags&)
-        Flags f4(f3);
-        CHECK(f4.value() == f3.value());
     }
 
     SECTION("operator|()") {
-        // operator|(T, T)
+        // operator|(Flags::FlagType, Flags::FlagType)
         Flags f1;
-        f1 = Enum::FLAG_NONE | Enum::FLAG_1;
+        f1 = FLAG_NONE | FLAG_1;
         CHECK(f1.value() == 0x01);
-        f1 = Enum::FLAG_1 | Enum::FLAG_1;
+        f1 = FLAG_1 | FLAG_1;
         CHECK(f1.value() == 0x01);
-        f1 = Enum::FLAG_1 | Enum::FLAG_2;
+        f1 = FLAG_1 | FLAG_2;
         CHECK(f1.value() == 0x03);
-        // operator|(T, Flags)
+        // operator|(Flags::FlagType, Flags)
         Flags f2;
-        f2 = Enum::FLAG_NONE | Flags(Enum::FLAG_1);
+        f2 = FLAG_NONE | Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 = Enum::FLAG_1 | Flags(Enum::FLAG_1);
+        f2 = FLAG_1 | Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 = Enum::FLAG_1 | Flags(Enum::FLAG_2);
+        f2 = FLAG_1 | Flags(FLAG_2);
         CHECK(f2.value() == 0x03);
-        // operator|(Flags, T)
+        // operator|(Flags, Flags::FlagType)
         Flags f3;
-        f3 = Flags(Enum::FLAG_NONE) | Enum::FLAG_1;
+        f3 = Flags(FLAG_NONE) | FLAG_1;
         CHECK(f3.value() == 0x01);
-        f3 = Flags(Enum::FLAG_1) | Enum::FLAG_1;
+        f3 = Flags(FLAG_1) | FLAG_1;
         CHECK(f3.value() == 0x01);
-        f3 = Flags(Enum::FLAG_1) | Enum::FLAG_2;
+        f3 = Flags(FLAG_1) | FLAG_2;
         CHECK(f3.value() == 0x03);
         // operator|(Flags, Flags)
         Flags f4;
-        f4 = Flags(Enum::FLAG_NONE) | Flags(Enum::FLAG_1);
+        f4 = Flags(FLAG_NONE) | Flags(FLAG_1);
         CHECK(f4.value() == 0x01);
-        f4 = Flags(Enum::FLAG_1) | Flags(Enum::FLAG_1);
+        f4 = Flags(FLAG_1) | Flags(FLAG_1);
         CHECK(f4.value() == 0x01);
-        f4 = Flags(Enum::FLAG_1) | Flags(Enum::FLAG_2);
+        f4 = Flags(FLAG_1) | Flags(FLAG_2);
         CHECK(f4.value() == 0x03);
     }
 
     SECTION("operator|=()") {
-        // operator|=(T)
+        // operator|=(Flags::FlagType)
         Flags f1;
-        f1 |= Enum::FLAG_1;
+        f1 |= FLAG_1;
         CHECK(f1.value() == 0x01);
-        f1 |= Enum::FLAG_1;
+        f1 |= FLAG_1;
         CHECK(f1.value() == 0x01);
-        f1 |= Enum::FLAG_2;
+        f1 |= FLAG_2;
         CHECK(f1.value() == 0x03);
         // operator|=(Flags)
         Flags f2;
-        f2 |= Flags(Enum::FLAG_1);
+        f2 |= Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 |= Flags(Enum::FLAG_1);
+        f2 |= Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 |= Flags(Enum::FLAG_2);
+        f2 |= Flags(FLAG_2);
         CHECK(f2.value() == 0x03);
     }
 
     SECTION("operator&()") {
-        // operator&(T, Flags)
+        // operator&(Flags::FlagType, Flags)
         Flags f1;
-        f1 = Enum::FLAG_NONE & Flags(Enum::FLAG_1);
+        f1 = FLAG_NONE & Flags(FLAG_1);
         CHECK(f1.value() == 0x00);
-        f1 = Enum::FLAG_1 & Flags(Enum::FLAG_1);
+        f1 = FLAG_1 & Flags(FLAG_1);
         CHECK(f1.value() == 0x01);
-        f1 = Enum::FLAG_1 & Flags(Enum::FLAG_2);
+        f1 = FLAG_1 & Flags(FLAG_2);
         CHECK(f1.value() == 0x00);
-        // operator&(Flags, T)
+        // operator&(Flags, Flags::FlagType)
         Flags f2;
-        f2 = Flags(Enum::FLAG_NONE) & Enum::FLAG_1;
+        f2 = Flags(FLAG_NONE) & FLAG_1;
         CHECK(f2.value() == 0x00);
-        f2 = Flags(Enum::FLAG_1) & Enum::FLAG_1;
+        f2 = Flags(FLAG_1) & FLAG_1;
         CHECK(f2.value() == 0x01);
-        f2 = Flags(Enum::FLAG_1) & Enum::FLAG_2;
+        f2 = Flags(FLAG_1) & FLAG_2;
         CHECK(f2.value() == 0x00);
         // operator&(Flags, Flags)
         Flags f3;
-        f3 = Flags(Enum::FLAG_NONE) & Flags(Enum::FLAG_1);
+        f3 = Flags(FLAG_NONE) & Flags(FLAG_1);
         CHECK(f3.value() == 0x00);
-        f3 = Flags(Enum::FLAG_1) & Flags(Enum::FLAG_1);
+        f3 = Flags(FLAG_1) & Flags(FLAG_1);
         CHECK(f3.value() == 0x01);
-        f3 = Flags(Enum::FLAG_1) & Flags(Enum::FLAG_2);
+        f3 = Flags(FLAG_1) & Flags(FLAG_2);
         CHECK(f3.value() == 0x00);
     }
 
     SECTION("operator&=()") {
-        // operator&=(T)
-        Flags f1(0x03);
-        f1 &= Enum::FLAG_1;
+        // operator&=(Flags::FlagType)
+        Flags f1(FLAG_1 | FLAG_2);
+        f1 &= FLAG_1;
         CHECK(f1.value() == 0x01);
-        f1 &= Enum::FLAG_1;
+        f1 &= FLAG_1;
         CHECK(f1.value() == 0x01);
-        f1 &= Enum::FLAG_2;
+        f1 &= FLAG_2;
         CHECK(f1.value() == 0x00);
         // operator&=(Flags)
-        Flags f2(0x03);
-        f2 &= Flags(Enum::FLAG_1);
+        Flags f2(FLAG_1 | FLAG_2);
+        f2 &= Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 &= Flags(Enum::FLAG_1);
+        f2 &= Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 &= Flags(Enum::FLAG_2);
+        f2 &= Flags(FLAG_2);
         CHECK(f2.value() == 0x00);
     }
 
     SECTION("operator^()") {
-        // operator^(T, Flags)
+        // operator^(Flags::FlagType, Flags)
         Flags f2;
-        f2 = Enum::FLAG_NONE ^ Flags(Enum::FLAG_1);
+        f2 = FLAG_NONE ^ Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 = Enum::FLAG_1 ^ Flags(Enum::FLAG_1);
+        f2 = FLAG_1 ^ Flags(FLAG_1);
         CHECK(f2.value() == 0x00);
-        f2 = Enum::FLAG_1 ^ Flags(Enum::FLAG_2);
+        f2 = FLAG_1 ^ Flags(FLAG_2);
         CHECK(f2.value() == 0x03);
-        // operator^(Flags, T)
+        // operator^(Flags, Flags::FlagType)
         Flags f3;
-        f3 = Flags(Enum::FLAG_NONE) ^ Enum::FLAG_1;
+        f3 = Flags(FLAG_NONE) ^ FLAG_1;
         CHECK(f3.value() == 0x01);
-        f3 = Flags(Enum::FLAG_1) ^ Enum::FLAG_1;
+        f3 = Flags(FLAG_1) ^ FLAG_1;
         CHECK(f3.value() == 0x00);
-        f3 = Flags(Enum::FLAG_1) ^ Enum::FLAG_2;
+        f3 = Flags(FLAG_1) ^ FLAG_2;
         CHECK(f3.value() == 0x03);
         // operator^(Flags, Flags)
         Flags f4;
-        f4 = Flags(Enum::FLAG_NONE) ^ Flags(Enum::FLAG_1);
+        f4 = Flags(FLAG_NONE) ^ Flags(FLAG_1);
         CHECK(f4.value() == 0x01);
-        f4 = Flags(Enum::FLAG_1) ^ Flags(Enum::FLAG_1);
+        f4 = Flags(FLAG_1) ^ Flags(FLAG_1);
         CHECK(f4.value() == 0x00);
-        f4 = Flags(Enum::FLAG_1) ^ Flags(Enum::FLAG_2);
+        f4 = Flags(FLAG_1) ^ Flags(FLAG_2);
         CHECK(f4.value() == 0x03);
     }
 
     SECTION("operator^=()") {
-        // operator^=(T)
+        // operator^=(Flags::FlagType)
         Flags f1;
-        f1 ^= Enum::FLAG_1;
+        f1 ^= FLAG_1;
         CHECK(f1.value() == 0x01);
-        f1 ^= Enum::FLAG_1;
+        f1 ^= FLAG_1;
         CHECK(f1.value() == 0x00);
-        f1 ^= Enum::FLAG_2;
+        f1 ^= FLAG_2;
         CHECK(f1.value() == 0x02);
         // operator^=(Flags)
         Flags f2;
-        f2 ^= Flags(Enum::FLAG_1);
+        f2 ^= Flags(FLAG_1);
         CHECK(f2.value() == 0x01);
-        f2 ^= Flags(Enum::FLAG_1);
+        f2 ^= Flags(FLAG_1);
         CHECK(f2.value() == 0x00);
-        f2 ^= Flags(Enum::FLAG_2);
+        f2 ^= Flags(FLAG_2);
         CHECK(f2.value() == 0x02);
     }
 
     SECTION("operator~()") {
-        Flags f1 = ~Flags(Enum::FLAG_NONE);
-        CHECK(f1.value() == (Value)Enum::FLAG_ALL);
-        Flags f2 = ~Flags(Enum::FLAG_ALL);
-        CHECK(f2.value() == (Value)Enum::FLAG_NONE);
+        Flags f1 = ~Flags(FLAG_NONE);
+        CHECK(f1.value() == (Flags::ValueType)FLAG_ALL);
+        Flags f2 = ~Flags(FLAG_ALL);
+        CHECK(f2.value() == (Flags::ValueType)FLAG_NONE);
     }
 
     SECTION("operator=()") {
-        // operator=(T)
+        // operator=(Flags::FlagType)
         Flags f1;
-        f1 = Enum::FLAG_1;
+        f1 = FLAG_1;
         CHECK(f1.value() == 0x01);
-        // operator=(Flags)
-        Flags f2;
-        f2 = Flags(Enum::FLAG_1);
-        CHECK(f2.value() == 0x01);
-        // operator=(ValueType)
-        Flags f3;
-        f3 = 0x01;
-        CHECK(f3.value() == 0x01);
     }
 
-    SECTION("operator ValueType()") {
-        Flags f1(0x01);
-        CHECK((Value)f1 == 0x01);
-        CHECK(f1); // acts as implicit operator bool()
+    SECTION("operator bool()") {
+        Flags f1(FLAG_1);
+        CHECK(f1);
         Flags f2;
-        CHECK((Value)f2 == 0x00);
         CHECK_FALSE(f2);
     }
 
     SECTION("operator!()") {
-        Flags f1(0x01);
+        Flags f1(FLAG_1);
         CHECK_FALSE(!f1);
         Flags f2;
         CHECK(!f2);
     }
 
-    SECTION("underlying type fits all flag values") {
-        Flags f1(Enum::FLAG_ALL);
-        CHECK(f1.value() == (Value)Enum::FLAG_ALL);
-        Flags f2((Value)Enum::FLAG_ALL);
-        CHECK(f2.value() == (Value)Enum::FLAG_ALL);
-        Flags f3;
-        f3 = (Value)Enum::FLAG_ALL;
-        CHECK(f3.value() == (Value)Enum::FLAG_ALL);
+    SECTION("flag cannot be implicitly converted to its value type") {
+        struct Test {
+            static bool func(Flags) {
+                return true;
+            }
+
+            static bool func(Flags::ValueType) {
+                return false;
+            }
+        };
+        CHECK(Test::func(FLAG_1));
     }
-}
-
-} // namespace
-
-TEST_CASE("Flags<T>") {
-    testFlags<Flags<FlagUint>>();
-    testFlags<Flags<FlagUint8>>();
-    testFlags<Flags<FlagUint64>>();
 }

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -35,8 +35,6 @@
 #include "system_mode.h"
 #include <functional>
 
-using particle::Flags;
-
 typedef std::function<user_function_int_str_t> user_std_function_int_str_t;
 typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 
@@ -51,14 +49,14 @@ typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 #define	__XSTRING(x)	__STRING(x)	/* expand x, then stringify */
 #endif
 
-enum PublishFlag: uint8_t {
-    PUBLIC = PUBLISH_EVENT_FLAG_PUBLIC,
-    PRIVATE = PUBLISH_EVENT_FLAG_PRIVATE,
-    NO_ACK = PUBLISH_EVENT_FLAG_NO_ACK,
-    WITH_ACK = PUBLISH_EVENT_FLAG_WITH_ACK
-};
+struct PublishFlagType; // Tag type for Particle.publish() flags
+typedef particle::Flags<PublishFlagType, uint8_t> PublishFlags;
+typedef PublishFlags::FlagType PublishFlag;
 
-PARTICLE_DEFINE_FLAG_OPERATORS(PublishFlag)
+const PublishFlag PUBLIC(PUBLISH_EVENT_FLAG_PUBLIC);
+const PublishFlag PRIVATE(PUBLISH_EVENT_FLAG_PRIVATE);
+const PublishFlag NO_ACK(PUBLISH_EVENT_FLAG_NO_ACK);
+const PublishFlag WITH_ACK(PUBLISH_EVENT_FLAG_WITH_ACK);
 
 class CloudClass {
 
@@ -212,17 +210,17 @@ public:
       return _function(funcKey, std::bind(func, instance, _1));
     }
 
-    inline particle::Future<bool> publish(const char *eventName, Flags<PublishFlag> flags1 = PUBLIC, Flags<PublishFlag> flags2 = Flags<PublishFlag>())
+    inline particle::Future<bool> publish(const char *eventName, PublishFlags flags1 = PUBLIC, PublishFlags flags2 = PublishFlags())
     {
         return publish(eventName, NULL, flags1, flags2);
     }
 
-    inline particle::Future<bool> publish(const char *eventName, const char *eventData, Flags<PublishFlag> flags1 = PUBLIC, Flags<PublishFlag> flags2 = Flags<PublishFlag>())
+    inline particle::Future<bool> publish(const char *eventName, const char *eventData, PublishFlags flags1 = PUBLIC, PublishFlags flags2 = PublishFlags())
     {
         return publish(eventName, eventData, 60, flags1, flags2);
     }
 
-    inline particle::Future<bool> publish(const char *eventName, const char *eventData, int ttl, Flags<PublishFlag> flags1 = PUBLIC, Flags<PublishFlag> flags2 = Flags<PublishFlag>())
+    inline particle::Future<bool> publish(const char *eventName, const char *eventData, int ttl, PublishFlags flags1 = PUBLIC, PublishFlags flags2 = PublishFlags())
     {
         return publish_event(eventName, eventData, ttl, flags1 | flags2);
     }
@@ -335,7 +333,7 @@ private:
 
     static void call_wiring_event_handler(const void* param, const char *event_name, const char *data);
 
-    static particle::Future<bool> publish_event(const char *eventName, const char *eventData, int ttl, Flags<PublishFlag> flags);
+    static particle::Future<bool> publish_event(const char *eventName, const char *eventData, int ttl, PublishFlags flags);
 
     static ProtocolFacade* sp()
     {

--- a/wiring/inc/spark_wiring_flags.h
+++ b/wiring/inc/spark_wiring_flags.h
@@ -18,164 +18,167 @@
 #ifndef SPARK_WIRING_FLAGS_H
 #define SPARK_WIRING_FLAGS_H
 
-#include <type_traits>
-
-// Helper macro defining global operators for a specified enum type T
-#define PARTICLE_DEFINE_FLAG_OPERATORS(T) \
-        inline __attribute__((unused)) ::particle::Flags<T> operator|(T flag1, T flag2) { \
-            return ::particle::Flags<T>(flag1) | flag2; \
-        } \
-        inline __attribute__((unused)) ::particle::Flags<T> operator|(T flag, ::particle::Flags<T> flags) { \
-            return flags | flag; \
-        } \
-        inline __attribute__((unused)) ::particle::Flags<T> operator&(T flag, ::particle::Flags<T> flags) { \
-            return flags & flag; \
-        } \
-        inline __attribute__((unused)) ::particle::Flags<T> operator^(T flag, ::particle::Flags<T> flags) { \
-            return flags ^ flag; \
-        }
-
 namespace particle {
 
-// Class storing or-combinations of enum values in a type-safe way
-template<typename T>
-class Flags {
+template<typename TagT, typename ValueT>
+class Flags;
+
+// Class storing a typed flag value
+template<typename TagT, typename ValueT = unsigned>
+class Flag {
 public:
-    typedef T EnumType;
-    typedef typename std::underlying_type<T>::type ValueType;
+    explicit Flag(ValueT val);
 
-    explicit Flags(ValueType val = 0);
-    Flags(T flag);
+    Flags<TagT, ValueT> operator|(Flag<TagT, ValueT> flag) const;
+    Flags<TagT, ValueT> operator|(Flags<TagT, ValueT> flags) const;
+    Flags<TagT, ValueT> operator&(Flags<TagT, ValueT> flags) const;
+    Flags<TagT, ValueT> operator^(Flags<TagT, ValueT> flags) const;
 
-    Flags<T> operator|(T flag) const;
-    Flags<T> operator|(Flags<T> flags) const;
-    Flags<T>& operator|=(T flag);
-    Flags<T>& operator|=(Flags<T> flags);
+    explicit operator ValueT() const;
 
-    Flags<T> operator&(T flag) const;
-    Flags<T> operator&(Flags<T> flags) const;
-    Flags<T>& operator&=(T flag);
-    Flags<T>& operator&=(Flags<T> flags);
-
-    Flags<T> operator^(T flag) const;
-    Flags<T> operator^(Flags<T> flags) const;
-    Flags<T>& operator^=(T flag);
-    Flags<T>& operator^=(Flags<T> flags);
-
-    Flags<T> operator~() const;
-
-    Flags<T>& operator=(ValueType val);
-
-    operator ValueType() const;
-    bool operator!() const;
-
-    ValueType value() const;
+    ValueT value() const;
 
 private:
-    ValueType val_;
+    ValueT val_;
+};
+
+// Class storing or-combinations of typed flag values
+template<typename TagT, typename ValueT = unsigned>
+class Flags {
+public:
+    typedef TagT TagType;
+    typedef ValueT ValueType;
+    typedef Flag<TagT, ValueT> FlagType;
+
+    Flags();
+    Flags(Flag<TagT, ValueT> flag);
+
+    Flags<TagT, ValueT> operator|(Flags<TagT, ValueT> flags) const;
+    Flags<TagT, ValueT>& operator|=(Flags<TagT, ValueT> flags);
+
+    Flags<TagT, ValueT> operator&(Flags<TagT, ValueT> flags) const;
+    Flags<TagT, ValueT>& operator&=(Flags<TagT, ValueT> flags);
+
+    Flags<TagT, ValueT> operator^(Flags<TagT, ValueT> flags) const;
+    Flags<TagT, ValueT>& operator^=(Flags<TagT, ValueT> flags);
+
+    Flags<TagT, ValueT> operator~() const;
+
+    explicit operator ValueT() const;
+    explicit operator bool() const;
+
+    ValueT value() const;
+
+private:
+    ValueT val_;
+
+    explicit Flags(ValueT val);
 };
 
 } // namespace particle
 
-template<typename T>
-inline particle::Flags<T>::Flags(ValueType val) :
+// particle::Flag<TagT, ValueT>
+template<typename TagT, typename ValueT>
+inline particle::Flag<TagT, ValueT>::Flag(ValueT val) :
         val_(val) {
 }
 
-template<typename T>
-inline particle::Flags<T>::Flags(T flag) :
-        val_((ValueType)flag) {
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flag<TagT, ValueT>::operator|(Flag<TagT, ValueT> flag) const {
+    return (Flags<TagT, ValueT>(*this) | flag);
 }
 
-template<typename T>
-inline particle::Flags<T> particle::Flags<T>::operator|(T flag) const {
-    return Flags<T>(val_ | (ValueType)flag);
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flag<TagT, ValueT>::operator|(Flags<TagT, ValueT> flags) const {
+    return (flags | *this);
 }
 
-template<typename T>
-inline particle::Flags<T> particle::Flags<T>::operator|(Flags<T> flags) const {
-    return Flags<T>(val_ | flags.val_);
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flag<TagT, ValueT>::operator&(Flags<TagT, ValueT> flags) const {
+    return (flags & *this);
 }
 
-template<typename T>
-inline particle::Flags<T>& particle::Flags<T>::operator|=(T flag) {
-    val_ |= (ValueType)flag;
-    return *this;
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flag<TagT, ValueT>::operator^(Flags<TagT, ValueT> flags) const {
+    return (flags ^ *this);
 }
 
-template<typename T>
-inline particle::Flags<T>& particle::Flags<T>::operator|=(Flags<T> flags) {
+template<typename TagT, typename ValueT>
+inline particle::Flag<TagT, ValueT>::operator ValueT() const {
+    return val_;
+}
+
+template<typename TagT, typename ValueT>
+inline ValueT particle::Flag<TagT, ValueT>::value() const {
+    return val_;
+}
+
+// particle::Flags<TagT, ValueT>
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>::Flags() :
+        val_(0) {
+}
+
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>::Flags(Flag<TagT, ValueT> flag) :
+        val_(flag.value()) {
+}
+
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>::Flags(ValueT val) :
+        val_(val) {
+}
+
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flags<TagT, ValueT>::operator|(Flags<TagT, ValueT> flags) const {
+    return Flags<TagT, ValueT>(val_ | flags.val_);
+}
+
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>& particle::Flags<TagT, ValueT>::operator|=(Flags<TagT, ValueT> flags) {
     val_ |= flags.val_;
     return *this;
 }
 
-template<typename T>
-inline particle::Flags<T> particle::Flags<T>::operator&(T flag) const {
-    return Flags<T>(val_ & (ValueType)flag);
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flags<TagT, ValueT>::operator&(Flags<TagT, ValueT> flags) const {
+    return Flags<TagT, ValueT>(val_ & flags.val_);
 }
 
-template<typename T>
-inline particle::Flags<T> particle::Flags<T>::operator&(Flags<T> flags) const {
-    return Flags<T>(val_ & flags.val_);
-}
-
-template<typename T>
-inline particle::Flags<T>& particle::Flags<T>::operator&=(T flag) {
-    val_ &= (ValueType)flag;
-    return *this;
-}
-
-template<typename T>
-inline particle::Flags<T>& particle::Flags<T>::operator&=(Flags<T> flags) {
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>& particle::Flags<TagT, ValueT>::operator&=(Flags<TagT, ValueT> flags) {
     val_ &= flags.val_;
     return *this;
 }
 
-template<typename T>
-inline particle::Flags<T> particle::Flags<T>::operator^(T flag) const {
-    return Flags<T>(val_ ^ (ValueType)flag);
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flags<TagT, ValueT>::operator^(Flags<TagT, ValueT> flags) const {
+    return Flags<TagT, ValueT>(val_ ^ flags.val_);
 }
 
-template<typename T>
-inline particle::Flags<T> particle::Flags<T>::operator^(Flags<T> flags) const {
-    return Flags<T>(val_ ^ flags.val_);
-}
-
-template<typename T>
-inline particle::Flags<T>& particle::Flags<T>::operator^=(T flag) {
-    val_ ^= (ValueType)flag;
-    return *this;
-}
-
-template<typename T>
-inline particle::Flags<T>& particle::Flags<T>::operator^=(Flags<T> flags) {
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>& particle::Flags<TagT, ValueT>::operator^=(Flags<TagT, ValueT> flags) {
     val_ ^= flags.val_;
     return *this;
 }
 
-template<typename T>
-inline particle::Flags<T> particle::Flags<T>::operator~() const {
-    return Flags<T>(~val_);
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT> particle::Flags<TagT, ValueT>::operator~() const {
+    return Flags<TagT, ValueT>(~val_);
 }
 
-template<typename T>
-inline particle::Flags<T>& particle::Flags<T>::operator=(ValueType val) {
-    val_ = val;
-    return *this;
-}
-
-template<typename T>
-inline particle::Flags<T>::operator ValueType() const {
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>::operator ValueT() const {
     return val_;
 }
 
-template<typename T>
-inline bool particle::Flags<T>::operator!() const {
-    return !val_;
+template<typename TagT, typename ValueT>
+inline particle::Flags<TagT, ValueT>::operator bool() const {
+    return val_;
 }
 
-template<typename T>
-inline typename particle::Flags<T>::ValueType particle::Flags<T>::value() const {
+template<typename TagT, typename ValueT>
+inline ValueT particle::Flags<TagT, ValueT>::value() const {
     return val_;
 }
 

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -46,7 +46,7 @@ bool CloudClass::register_function(cloud_function_t fn, void* data, const char* 
     return spark_function(NULL, (user_function_int_str_t*)&desc, NULL);
 }
 
-Future<bool> CloudClass::publish_event(const char *eventName, const char *eventData, int ttl, Flags<PublishFlag> flags) {
+Future<bool> CloudClass::publish_event(const char *eventName, const char *eventData, int ttl, PublishFlags flags) {
 #ifndef SPARK_NO_CLOUD
     spark_send_event_data d = { sizeof(spark_send_event_data) };
 
@@ -55,7 +55,7 @@ Future<bool> CloudClass::publish_event(const char *eventName, const char *eventD
     d.handler_callback = publishCompletionCallback;
     d.handler_data = p.dataPtr();
 
-    if (!spark_send_event(eventName, eventData, ttl, flags, &d) && !p.isDone()) {
+    if (!spark_send_event(eventName, eventData, ttl, flags.value(), &d) && !p.isDone()) {
         // Set generic error code in case completion callback wasn't invoked for some reason
         p.setError(Error::UNKNOWN);
         p.fromDataPtr(d.handler_data); // Free wrapper object


### PR DESCRIPTION
### Problem

This PR fixes a regression introduced into current `develop` by https://github.com/spark/firmware/pull/1236, which allowed `Particle.publish()` flags to be converted to `int` implicitly.

@technobly, thanks for finding out this!

### Solution

Use type-safe wrapper for individual flag values, similarly to how it was implemented in 0.6.1.

### Steps to Test

Run unit tests, compile wiring/api tests.

### Example App

```c
void setup() {
    // NO_ACK flag should disable acknowledgement of the event (previously it was changing event's TTL instead)
    Particle.publish("event", "data", NO_ACK);
}

void loop() {
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [X] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [X] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)