### PR TITLE
Fix LED indication when clearing network credentials

### DIFF
--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -244,7 +244,7 @@ protected:
             {
                 // Get base color used for the listening mode indication
                 const LEDStatusData* status = led_signal_status(LED_SIGNAL_LISTENING_MODE, nullptr);
-                LEDStatus led(status ? status->color : RGB_COLOR_BLUE, LED_PRIORITY_IMPORTANT);
+                LEDStatus led(status ? status->color : RGB_COLOR_BLUE, LED_PRIORITY_CRITICAL);
                 led.setActive();
                 int toggle = 25;
                 while (toggle--)


### PR DESCRIPTION
### Problem

The LED doesn't blink rapidly when clearing network credentials.

_Note:_ This regression doesn't present in any of the releases, so there's no need to update the change log.

### Solution

Use higher priority for the LED indication.

### Steps to Test

Ensure the device has some network credentials configured, then hold SETUP button for ~10 seconds.

### Example App

N/A

### References

https://docs.particle.io/guide/getting-started/modes/photon/#wi-fi-network-reset

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)