### PR TITLE
Process USB vendor requests in system thread

### DIFF
--- a/hal/src/stm32f2xx/usb_hal.c
+++ b/hal/src/stm32f2xx/usb_hal.c
@@ -115,8 +115,9 @@ uint8_t HAL_USB_Handle_Vendor_Request(USB_SETUP_REQ* req, uint8_t dataStage)
                         // Don't use user buffer if wLength <= USBD_EP0_MAX_PACKET_SIZE
                         // and copy into internal buffer
                         memcpy(USB_SetupRequest_Data, USB_SetupRequest.data, USB_SetupRequest.wLength);
+                        USB_SetupRequest.data = USB_SetupRequest_Data;
                     }
-                    USBD_CtlSendData (&USB_OTG_dev, USB_SetupRequest_Data, USB_SetupRequest.wLength);
+                    USBD_CtlSendData (&USB_OTG_dev, USB_SetupRequest.data, USB_SetupRequest.wLength);
                 } else {
                     ret = USBD_FAIL;
                 }

--- a/services/inc/appender.h
+++ b/services/inc/appender.h
@@ -62,12 +62,14 @@ inline bool append_instance(void* appender, const uint8_t* data, size_t length) 
 class BufferAppender : public Appender {
     uint8_t* buffer;
     uint8_t* end;
+    uint8_t* start;
 
 public:
 
     BufferAppender(uint8_t* start, size_t length) {
         this->buffer = start;
         this->end = start + length;
+        this->start = start;
     }
 
     bool append(const uint8_t* data, size_t length) {
@@ -85,7 +87,9 @@ public:
     bool append(char c) {
         return Appender::append(c);
     }
-
+    size_t size() {
+        return (buffer - start);
+    }
 
     const uint8_t* next() { return buffer; }
 };

--- a/system/inc/system_control.h
+++ b/system/inc/system_control.h
@@ -55,7 +55,8 @@ typedef enum USBRequestType {
   USB_REQUEST_DFU_MODE = 50,
   USB_REQUEST_SAFE_MODE = 60,
   USB_REQUEST_LISTENING_MODE = 70,
-  USB_REQUEST_LOG_CONFIG = 80
+  USB_REQUEST_LOG_CONFIG = 80,
+  USB_REQUEST_MODULE_INFO = 90
 } USBRequestType;
 
 typedef enum USBRequestResult {
@@ -66,6 +67,7 @@ typedef enum USBRequestResult {
 typedef struct USBRequest {
   size_t size; // Structure size
   int type; // Request type (as defined by USBRequestType enum)
+  uint16_t value; // wValue field
   char* data; // Data buffer
   size_t request_size; // Request size
   size_t reply_size; // Reply size (initialized to 0)

--- a/system/inc/system_control.h
+++ b/system/inc/system_control.h
@@ -67,11 +67,11 @@ typedef enum USBRequestResult {
 typedef struct USBRequest {
   size_t size; // Structure size
   int type; // Request type (as defined by USBRequestType enum)
-  uint16_t value; // wValue field
   char* data; // Data buffer
   size_t request_size; // Request size
   size_t reply_size; // Reply size (initialized to 0)
   int format; // Data format (as defined by DataFormat enum)
+  uint16_t value; // wValue field
 } USBRequest;
 
 // Callback invoked for USB requests that should be processed at application side

--- a/system/src/system_control.cpp
+++ b/system/src/system_control.cpp
@@ -31,8 +31,7 @@
 #include "system_threading.h"
 
 #include "spark_wiring_system.h"
-#include "spark_wiring_wifi.h"
-#include "spark_wiring_cellular.h"
+#include "system_network_internal.h"
 #include "bytes2hexbuf.h"
 #include "system_update.h"
 
@@ -299,13 +298,7 @@ void SystemControlInterface::processSystemRequest(void* data) {
   }
 
   case USB_REQUEST_LISTENING_MODE: {
-#if Wiring_WiFi
-    spark::WiFi.listen(req->value);
-#elif Wiring_Cellular
-    spark::Cellular.listen(req->value);
-#else
-    result = USB_REQUEST_RESULT_ERROR;
-#endif
+    network.listen(req->value);
     break;
   }
 

--- a/system/src/system_control.cpp
+++ b/system/src/system_control.cpp
@@ -31,6 +31,10 @@
 #include "system_threading.h"
 
 #include "spark_wiring_system.h"
+#include "spark_wiring_wifi.h"
+#include "spark_wiring_cellular.h"
+#include "bytes2hexbuf.h"
+#include "system_update.h"
 
 #ifdef USB_VENDOR_REQUEST_ENABLE
 
@@ -125,28 +129,13 @@ uint8_t SystemControlInterface::handleVendorRequest(HAL_USB_SetupRequest* req) {
   if (req->bmRequestTypeDirection == 0) {
     // Host -> Device
     switch (req->wIndex) {
-      case USB_REQUEST_RESET: {
-        // FIXME: We probably shouldn't reset from an ISR.
-        // The host will probably get an error that control request has timed out since we
-        // didn't respond to it.
-        System.reset(req->wValue);
-        break;
-      }
-
-      case USB_REQUEST_DFU_MODE: {
-        // FIXME: We probably shouldn't enter DFU mode from an ISR.
-        // The host will probably get an error that control request has timed out since we
-        // didn't respond to it.
-        System.dfu(false);
-        break;
-      }
-
-      case USB_REQUEST_LISTENING_MODE: {
-        // FIXME: We probably shouldn't enter listening mode from an ISR.
-        // The host will probably get an error that control request has timed out since we
-        // didn't respond to it.
-        system_set_flag(SYSTEM_FLAG_STARTUP_SAFE_LISTEN_MODE, 1, nullptr);
-        System.enterSafeMode();
+      // Process these requests on system thread
+      case USB_REQUEST_RESET:
+      case USB_REQUEST_DFU_MODE:
+      case USB_REQUEST_LISTENING_MODE:
+      case USB_REQUEST_SAFE_MODE:
+      case USB_REQUEST_MODULE_INFO: {
+        return enqueueRequest(req);
         break;
       }
 
@@ -181,10 +170,13 @@ uint8_t SystemControlInterface::handleVendorRequest(HAL_USB_SetupRequest* req) {
         } else {
           // Return as string
           String id = System.deviceID();
-          if (req->wLength < (id.length() + 1))
+          uint8_t deviceId[16];
+          int sz = HAL_device_ID(deviceId, sizeof(deviceId));
+          if (req->wLength < (sz * 2 + 1))
             return 1;
-          strncpy((char*)req->data, id.c_str(), req->wLength);
-          req->wLength = id.length() + 1;
+          bytes2hexbuf(deviceId, sz, (char*)req->data);
+          req->data[sz * 2] = '\0';
+          req->wLength = sz * 2 + 1;
         }
         break;
       }
@@ -200,6 +192,7 @@ uint8_t SystemControlInterface::handleVendorRequest(HAL_USB_SetupRequest* req) {
         break;
       }
 
+      case USB_REQUEST_MODULE_INFO:
       case USB_REQUEST_LOG_CONFIG:
       case USB_REQUEST_CUSTOM: {
         return fetchRequestResult(req);
@@ -242,6 +235,7 @@ uint8_t SystemControlInterface::enqueueRequest(HAL_USB_SetupRequest* req, DataFo
     return 1;
   }
   usbReq_.req.type = (USBRequestType)req->wIndex;
+  usbReq_.req.value = req->wValue;
   usbReq_.req.request_size = req->wLength;
   usbReq_.req.reply_size = 0;
   usbReq_.req.format = fmt;
@@ -292,15 +286,51 @@ void SystemControlInterface::setRequestResult(USBRequest* req, USBRequestResult 
 
 void SystemControlInterface::processSystemRequest(void* data) {
   USBRequest* req = static_cast<USBRequest*>(data);
+  USBRequestResult result = USB_REQUEST_RESULT_OK;
   switch (req->type) {
   // Handle requests that should be processed by the system modules here
+  case USB_REQUEST_RESET: {
+    System.reset(req->value);
+    break;
+  }
+
+  case USB_REQUEST_DFU_MODE: {
+    System.dfu(false);
+    break;
+  }
+
+  case USB_REQUEST_LISTENING_MODE: {
+    setRequestResult(req, result);
+#if Wiring_WiFi
+    spark::WiFi.listen(req->value);
+#elif Wiring_Cellular
+    spark::Cellular.listen(req->value);
+#endif
+    return;
+  }
+
+  case USB_REQUEST_SAFE_MODE: {
+    System.enterSafeMode();
+    break;
+  }
+
+  case USB_REQUEST_MODULE_INFO: {
+    BufferAppender appender((uint8_t*)req->data, USB_REQUEST_BUFFER_SIZE);
+    system_module_info(append_instance, &appender);
+    req->reply_size = appender.size();
+    break;
+  }
+
   default:
     if (usbReqAppHandler) {
       processAppRequest(data); // Forward request to the application thread
     } else {
       setRequestResult(req, USB_REQUEST_RESULT_ERROR);
     }
+    return;
   }
+
+  setRequestResult(req, result);
 }
 
 void SystemControlInterface::processAppRequest(void* data) {

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -279,6 +279,7 @@ protected:
                 console.loop();
             }
 #if PLATFORM_THREADING
+            SystemISRTaskQueue.process();
             if (!APPLICATION_THREAD_CURRENT()) {
                 SystemThread.process();
             }


### PR DESCRIPTION
### Problem

Most of the currently supported vendor requests should be executed on system thread instead of being processed in ISR.

### Solution

Utilize `SystemISRTaskQueue` for vendor requests.

### Steps to Test

N/A

### Example App

N/A

### References


---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
