### PR TITLE
Verify the bootloader was flashed correctly and retry if not

### DIFF
--- a/hal/src/photon/core_hal.c
+++ b/hal/src/photon/core_hal.c
@@ -122,14 +122,14 @@ void HAL_Core_Setup_finalize(void)
     // in the eeprom region.
     const module_info_t* app_info = FLASH_ModuleInfo(FLASH_INTERNAL, app_backup);
     if (app_info->module_start_address==(void*)0x80A0000) {
-    		LED_SetRGBColor(RGB_COLOR_GREEN);
-    		uint32_t length = app_info->module_end_address-app_info->module_start_address+4;
-    		if (length < 80*1024 && FLASH_CopyMemory(FLASH_INTERNAL, app_backup, FLASH_INTERNAL, 0x80E0000, length, MODULE_FUNCTION_USER_PART, MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION)) {
-        		FLASH_CopyMemory(FLASH_INTERNAL, app_backup, FLASH_INTERNAL, 0x80A0000, length, MODULE_FUNCTION_USER_PART, MODULE_VERIFY_CRC|MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_FUNCTION);
-    			FLASH_EraseMemory(FLASH_INTERNAL, app_backup, length);
-    		}
-    		LED_SetRGBColor(RGB_COLOR_WHITE);
-    	}
+            LED_SetRGBColor(RGB_COLOR_GREEN);
+            uint32_t length = app_info->module_end_address-app_info->module_start_address+4;
+            if (length < 80*1024 && FLASH_CopyMemory(FLASH_INTERNAL, app_backup, FLASH_INTERNAL, 0x80E0000, length, MODULE_FUNCTION_USER_PART, MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION) == FLASH_ACCESS_RESULT_OK) {
+                FLASH_CopyMemory(FLASH_INTERNAL, app_backup, FLASH_INTERNAL, 0x80A0000, length, MODULE_FUNCTION_USER_PART, MODULE_VERIFY_CRC|MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_FUNCTION);
+                FLASH_EraseMemory(FLASH_INTERNAL, app_backup, length);
+            }
+            LED_SetRGBColor(RGB_COLOR_WHITE);
+        }
 #endif
 }
 

--- a/hal/src/stm32f2xx/bootloader.cpp
+++ b/hal/src/stm32f2xx/bootloader.cpp
@@ -7,19 +7,19 @@
 #include "bootloader_hal.h"
 
 #ifdef HAL_REPLACE_BOOTLOADER_OTA
-bool bootloader_update(const void* bootloader_image, unsigned length)
+int bootloader_update(const void* bootloader_image, unsigned length)
 {
     HAL_Bootloader_Lock(false);
-    bool result =  (FLASH_CopyMemory(FLASH_INTERNAL, (uint32_t)bootloader_image,
+    int result = (FLASH_CopyMemory(FLASH_INTERNAL, (uint32_t)bootloader_image,
         FLASH_INTERNAL, 0x8000000, length, MODULE_FUNCTION_BOOTLOADER,
         MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION));
     HAL_Bootloader_Lock(true);
     return result;
 }
 #else
-bool bootloader_update(const void*, unsigned)
+int bootloader_update(const void*, unsigned)
 {
-    return false;
+    return FLASH_ACCESS_RESULT_ERROR;
 }
 #endif // HAL_REPLACE_BOOTLOADER_OTA
 

--- a/hal/src/stm32f2xx/bootloader.h
+++ b/hal/src/stm32f2xx/bootloader.h
@@ -17,7 +17,7 @@ extern "C" {
 bool bootloader_requires_update(const uint8_t* bootloader_image, uint32_t length);
 bool bootloader_update_if_needed();
 
-bool bootloader_update(const void* bootloader_image, unsigned length);
+int bootloader_update(const void* bootloader_image, unsigned length);
 
 
 #ifdef __cplusplus

--- a/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
+++ b/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
@@ -38,6 +38,8 @@
 #include "service_debug.h"
 #include "spark_wiring_random.h"
 #include "delay_hal.h"
+// For ATOMIC_BLOCK
+#include "spark_wiring_interrupts.h"
 
 #define OTA_CHUNK_SIZE                 (512)
 #define BOOTLOADER_RANDOM_BACKOFF_MIN  (200)

--- a/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.h
+++ b/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.h
@@ -23,6 +23,7 @@
 extern const module_bounds_t* module_bounds[];
 extern const unsigned module_bounds_length;
 extern const module_bounds_t module_ota;
+extern const module_bounds_t module_bootloader;
 extern const module_bounds_t module_user;
 
 

--- a/platform/MCU/shared/STM32/inc/flash_access.h
+++ b/platform/MCU/shared/STM32/inc/flash_access.h
@@ -7,6 +7,11 @@
 extern "C" {
 #endif
 
+typedef enum {
+  FLASH_ACCESS_RESULT_OK             = 0,
+  FLASH_ACCESS_RESULT_BADARG         = 1,
+  FLASH_ACCESS_RESULT_ERROR          = 2
+} flash_access_result_t;
 
 /* MAL access layer for Internal/Serial Flash Routines */
 //New routines specific for BM09/BM14 flash usage
@@ -16,24 +21,24 @@ bool FLASH_CheckValidAddressRange(flash_device_t flashDeviceID, uint32_t startAd
 bool FLASH_WriteProtectMemory(flash_device_t flashDeviceID, uint32_t startAddress, uint32_t length, bool protect);
 bool FLASH_EraseMemory(flash_device_t flashDeviceID, uint32_t startAddress, uint32_t length);
 
-typedef bool (*copymem_fn_t)(flash_device_t sourceDeviceID, uint32_t sourceAddress,
-                      flash_device_t destinationDeviceID, uint32_t destinationAddress,
-                      uint32_t length, uint8_t module_function, uint8_t flags);
+typedef int (*copymem_fn_t)(flash_device_t sourceDeviceID, uint32_t sourceAddress,
+                            flash_device_t destinationDeviceID, uint32_t destinationAddress,
+                            uint32_t length, uint8_t module_function, uint8_t flags);
 
 
 /**
  * Determines if the memory copy can be performed.
  */
-bool FLASH_CheckCopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
-                      flash_device_t destinationDeviceID, uint32_t destinationAddress,
-                      uint32_t length, uint8_t module_function, uint8_t flags);
+int FLASH_CheckCopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
+                          flash_device_t destinationDeviceID, uint32_t destinationAddress,
+                          uint32_t length, uint8_t module_function, uint8_t flags);
 
 /**
  * @param validateDestinationAddress checks if the destination address corresponds with the start address in the module
  */
-bool FLASH_CopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
-                      flash_device_t destinationDeviceID, uint32_t destinationAddress,
-                      uint32_t length, uint8_t module_function, uint8_t flags);
+int FLASH_CopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
+                     flash_device_t destinationDeviceID, uint32_t destinationAddress,
+                     uint32_t length, uint8_t module_function, uint8_t flags);
 
 bool FLASH_CompareMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
                          flash_device_t destinationDeviceID, uint32_t destinationAddress,


### PR DESCRIPTION
### Notes

_Targets `feature/dct-locking-recursive-mutex` for now because it's based on it. Makes it easier to review the changes. Should be retargeted to `feature/photon/wiced-3.7.0-7` later._

### Problem

As a safety measure we should verify that when updating bootloader OTA or over YModem the copy operation from ota_module area to the bootloader area has succeeded and the bootloader image in bootloader_module area passes the checks. If not, there is nothing we can do but retry until it does.

### Solution

Verify the bootloader was flashed correctly and retry if not.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
