### PR TITLE
Rename system_error to system_error_t

### DIFF
--- a/communication/src/protocol_defs.cpp
+++ b/communication/src/protocol_defs.cpp
@@ -17,7 +17,7 @@
 
 #include "protocol_defs.h"
 
-system_error particle::protocol::toSystemError(ProtocolError error) {
+system_error_t particle::protocol::toSystemError(ProtocolError error) {
     switch (error) {
     case NO_ERROR:
         return SYSTEM_ERROR_NONE;

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -55,7 +55,7 @@ enum ProtocolError
 };
 
 // Converts protocol error to system error code
-system_error toSystemError(ProtocolError error);
+system_error_t toSystemError(ProtocolError error);
 
 typedef uint16_t chunk_index_t;
 

--- a/services/inc/system_error.h
+++ b/services/inc/system_error.h
@@ -59,12 +59,12 @@
 extern "C" {
 #endif
 
-typedef enum system_error {
+typedef enum system_error_t {
     // SYSTEM_ERROR_NONE = 0,
     // SYSTEM_ERROR_UNKNOWN = -100,
     // ...
     SYSTEM_ERROR_ENUM_VALUES(SYSTEM_ERROR_)
-} system_error;
+} system_error_t;
 
 // Returns default error message
 const char* system_error_message(int error, void* reserved);

--- a/wiring/inc/spark_wiring_error.h
+++ b/wiring/inc/spark_wiring_error.h
@@ -91,7 +91,7 @@ inline particle::Error::Type particle::Error::type() const {
 }
 
 inline const char* particle::Error::message() const {
-    return (msg_ ? msg_ : system_error_message((system_error)type_, nullptr));
+    return (msg_ ? msg_ : system_error_message((system_error_t)type_, nullptr));
 }
 
 inline bool particle::Error::operator==(const Error& error) const {


### PR DESCRIPTION
### Problem

C++11 defines `std::system_error` class which may cause global name conflicts with the firmware's `system_error` enum, especially in applications that abuse `using namespace std`.

### Solution

Rename `system_error` enum to `system_error_t`. We never exposed `system_error` as part of any public API, so the fix won't affect existing applications.

### Steps to Test

The firmware and unit tests should build normally.

### Example App

N/A

### References

Original community post: https://community.particle.io/t/compile-error-gcc-arm-on-linux-firmware-v-0-6-1/31157

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)