### PR TITLE
Bring back part of #1125

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -703,14 +703,9 @@ wlan_result_t wlan_activate()
 wlan_result_t wlan_deactivate()
 {
     wlan_disconnect_now();
-    // FIXME:
-    // This was required for PR #1125 to reduce Wi-Fi power completely for Sleep stop mode
-    // however it introduced a new connectivity bug in LwIP that was unresolved in commit 87892a3837d4,
-    // which was reverted in commit 6b78d7662f62.  WICED should be updated to pull in a newer version of LwIP
-    // before this change is attempted again.
-    // wiced_result_t result = wiced_wlan_connectivity_deinit();
-    // return result;
-    return 0;
+
+    wiced_result_t result = wiced_wlan_connectivity_deinit();
+    return result;
 }
 
 wlan_result_t wlan_disconnect_now()


### PR DESCRIPTION
### Problem

See #1098, #1125

```
    // FIXME:
    // This was required for PR #1125 to reduce Wi-Fi power completely for Sleep stop mode
    // however it introduced a new connectivity bug in LwIP that was unresolved in commit 87892a3837d4,
    // which was reverted in commit 6b78d7662f62.  WICED should be updated to pull in a newer version of LwIP
    // before this change is attempted again.
```

### Solution

This was fixed by updating WICED to 3.7.0-7, LwIP to 1.4.1 and introducing a couple of fixes to those.

`wiced_wlan_connectivity_deinit`/`wiced_wlan_connectivity_init` is also used for WPA Enterprise as a workaround when BCM chip stops responding under some circumstances.

### Steps to Test

See #1125.

Related: `wiring/no_fixture` `WIFI_05_reconnections_that_use_wlan_restart_dont_cause_memory_leaks`

### Example App

`user/tests/app/stop_mode_power_usage_issue_1098`

### References

#1125 
#1098

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### BUGFIX
- [`[PR #1327]`](https://github.com/spark/firmware/pull/1327) [`[Fixes #1098]`](https://github.com/spark/firmware/issues/1098) [Photon/P1] Previously, when entering Sleep-stop mode: `System.sleep(D1, RISING, 60);` while in the process of making a Wi-Fi connection resulted in some parts of the radio still being initialized, consuming about 10-15mA more than normal.