### PR TITLE
Updates recommended stable branch in compile error

### DIFF
--- a/build/checks.mk
+++ b/build/checks.mk
@@ -3,7 +3,7 @@ git_branch := $(shell git rev-parse --abbrev-ref HEAD)
 ifeq ("$(git_branch)","develop")
     ifndef PARTICLE_DEVELOP
        $(error Please note the develop branch contains untested, unreleased code. \
-        We recommend using the 'latest' branch which contains the latest released firmware code. \
+        We recommend using the 'release/stable' branch which contains the latest released firmware code. \
         To build the develop branch, please see the the build documentation at \
         https://github.com/spark/firmware/blob/develop/docs/build.md#building-the-develop-branch)
     endif


### PR DESCRIPTION
Problem: When building on the `develop` branch a compile error recommended using the `latest` branch which doesn't exist.

Solution: Recommend `release/stable` instead.

- [x] Problem and Solution clearly stated
- [n/a] Run unit/integration/application tests on device
- [n/a] Added documentation
- [n/a] Added to CHANGELOG.md after merging (add links to docs and issues)
