### PR TITLE
[USB] Fixes an issue with Serial when receiving consecutive multiple 64-byte transmissions from Host

### DIFF
--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_mcdc.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/usbd_mcdc.c
@@ -143,7 +143,11 @@ static const uint8_t USBD_MCDC_CfgDesc[USBD_MCDC_CONFIG_DESC_SIZE] __ALIGN_END =
   0x02,                              /* bmAttributes: Bulk */
   LOBYTE(CDC_DATA_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
   HIBYTE(CDC_DATA_MAX_PACKET_SIZE),
-  0x00,                              /* bInterval: ignore for Bulk transfer */
+#ifdef USE_USB_OTG_HS
+  0x10,                          /* bInterval: */
+#else
+  0xFF,                          /* bInterval: */
+#endif /* USE_USB_OTG_HS */
 
   /*Endpoint IN Descriptor*/
   0x07,   /* bLength: Endpoint Descriptor size */


### PR DESCRIPTION
### Problem

With RX queue full, the device NAKs OUT (Host->Device) transfers. With `bInterval` set to `0` (1 ms) this causes the device to spend too much time in USB interrupt, not giving any processing time to the application/system thread to consume RX queue. For some reason CDC driver on OSX doesn't attempt to send any data after about 300 NAKed transfers. Closing/re-opening the port doesn't help either.

### Solution

Set `bInterval` to a maximum value (16 ms) on OUT endpoint to give enough time for the device to consume RX queue and not send too many NAKs to Host.

We should probably add some workaround as well: e.g. count the number of NAKs sent and silently drop incoming data after a certain threshold instead of NAKing it. Even though this is OSX driver's fault. :face_with_head_bandage:

### Steps to Test

The bug is easily reproducible on OSX when setting WPA Enterprise credentials over Serial. A simple copy-paste of a certificate (e.g. CA) will not complete and get stuck somewhere half-way through.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Bug fix

- [`[PR #1336]`](https://github.com/spark/firmware/pull/1336) Fixes an issue with Serial when receiving consecutive multiple 64-byte transmissions from Host