### PR TITLE
Do not read or write feature flags from an ISR

### DIFF
--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -263,33 +263,44 @@ static void Init_Last_Reset_Info()
 
 static int Write_Feature_Flag(uint32_t flag, bool value, bool *prev_value)
 {
+    if (HAL_IsISR()) {
+        return -1; // DCT cannot be accessed from an ISR
+    }
     uint32_t flags = 0;
-    dct_read_app_data_copy(DCT_FEATURE_FLAGS_OFFSET, &flags, sizeof(flags));
+    int result = dct_read_app_data_copy(DCT_FEATURE_FLAGS_OFFSET, &flags, sizeof(flags));
+    if (result != 0) {
+        return result;
+    }
     const bool cur_value = flags & flag;
-    if (prev_value)
-    {
+    if (prev_value) {
         *prev_value = cur_value;
     }
-    if (cur_value != value)
-    {
-        if (value)
-        {
+    if (cur_value != value) {
+        if (value) {
             flags |= flag;
-        }
-        else
-        {
+        } else {
             flags &= ~flag;
         }
-        return dct_write_app_data(&flags, DCT_FEATURE_FLAGS_OFFSET, 4);
+        result = dct_write_app_data(&flags, DCT_FEATURE_FLAGS_OFFSET, 4);
+        if (result != 0) {
+            return result;
+        }
     }
     return 0;
 }
 
-static bool Read_Feature_Flag(uint32_t flag)
+static int Read_Feature_Flag(uint32_t flag, bool* value)
 {
+    if (HAL_IsISR()) {
+        return -1; // DCT cannot be accessed from an ISR
+    }
     uint32_t flags = 0;
-    dct_read_app_data_copy(DCT_FEATURE_FLAGS_OFFSET, &flags, sizeof(flags));
-    return flags & flag;
+    const int result = dct_read_app_data_copy(DCT_FEATURE_FLAGS_OFFSET, &flags, sizeof(flags));
+    if (result != 0) {
+        return result;
+    }
+    *value = flags & flag;
+    return 0;
 }
 
 /* Extern variables ----------------------------------------------------------*/
@@ -1255,8 +1266,7 @@ int HAL_Feature_Set(HAL_Feature feature, bool enabled)
         }
         case FEATURE_RESET_INFO:
         {
-            Write_Feature_Flag(FEATURE_FLAG_RESET_INFO, enabled, NULL);
-            return 0;
+            return Write_Feature_Flag(FEATURE_FLAG_RESET_INFO, enabled, NULL);
         }
 
 #if PLATFORM_ID==PLATFORM_P1
@@ -1270,10 +1280,9 @@ int HAL_Feature_Set(HAL_Feature feature, bool enabled)
                 current |= 2;   // 0bxxxxxx10 to disable the clock, any other value to enable it.
             }
             dct_write_app_data(&current, DCT_RADIO_FLAGS_OFFSET, 1);
+            return 0;
         }
 #endif
-
-
     }
     return -1;
 }
@@ -1304,7 +1313,8 @@ bool HAL_Feature_Get(HAL_Feature feature)
         }
         case FEATURE_RESET_INFO:
         {
-            return Read_Feature_Flag(FEATURE_FLAG_RESET_INFO);
+            bool value = false;
+            return (Read_Feature_Flag(FEATURE_FLAG_RESET_INFO, &value) == 0) ? value : false;
         }
     }
     return false;


### PR DESCRIPTION
### Problem

Device panic (assertion failure) occurs when DFU mode is triggered via baud rate change.

### Solution

Do not read or write feature flags, which are stored in DCT, from an ISR. Users are still allowed to call such methods as `System.reset()` and `System.dfu()` from an ISR to preserve backwards compatibility.

### Steps to Test

- Try to enable DFU mode via baud rate change.
- Check what happens with System.resetReason(), characterize the behavior.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)