### PR TITLE
Test for RGB.onChange() handler leak

### DIFF
--- a/user/tests/wiring/no_fixture/led.cpp
+++ b/user/tests/wiring/no_fixture/led.cpp
@@ -251,4 +251,45 @@ test(LED_11_MirroringWorks) {
     RGB.control(false);
 }
 
-#endif
+namespace {
+
+// Handler class for RGB.onChange() that counts number of its instances
+class OnChangeHandler {
+public:
+    OnChangeHandler() {
+        ++s_count;
+    }
+
+    OnChangeHandler(const OnChangeHandler&) {
+        ++s_count;
+    }
+
+    ~OnChangeHandler() {
+        --s_count;
+    }
+
+    static unsigned instanceCount() {
+        return s_count;
+    }
+
+    void operator()(uint8_t r, uint8_t g, uint8_t b) {
+    }
+
+private:
+    static unsigned s_count;
+};
+
+unsigned OnChangeHandler::s_count = 0;
+
+} // namespace
+
+test(LED_12_NoLeakWhenOnChangeHandlerIsOverridden) {
+    RGB.onChange(OnChangeHandler());
+    assertEqual(OnChangeHandler::instanceCount(), 1);
+    RGB.onChange(OnChangeHandler());
+    assertEqual(OnChangeHandler::instanceCount(), 1); // Previous handler has been destroyed
+    RGB.onChange(nullptr);
+    assertEqual(OnChangeHandler::instanceCount(), 0); // Current handler has been destroyed
+}
+
+#endif // PLATFORM_ID >= 3


### PR DESCRIPTION
This PR adds a test for `RGB.onChange()` handler leak which was fixed in https://github.com/spark/firmware/pull/1237

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation (N/A)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Internal 

- [`[PR #1352]`](https://github.com/spark/firmware/pull/1352) Added test for `RGB.onChange()` handler leak