### PR TITLE
[Photon] Fixes WiFi.scan() hardfault

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -856,6 +856,10 @@ wiced_result_t sniffer( wiced_scan_handler_result_t* malloced_scan_result )
 
 wiced_result_t sniff_security(SnifferInfo* info)
 {
+    if (!wiced_wlan_connectivity_initialized())
+    {
+        return WICED_ERROR;
+    }
 
     wiced_result_t result = wiced_rtos_init_semaphore(&info->complete);
     if (result != WICED_SUCCESS)

--- a/user/tests/wiring/no_fixture/wifi.cpp
+++ b/user/tests/wiring/no_fixture/wifi.cpp
@@ -196,4 +196,25 @@ test(WIFI_10_restore_default_hostname)
 
 #endif // PLATFORM_ID == 6 || PLATFORM_ID == 8
 
+test(WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off)
+{
+    WiFiAccessPoint results[5];
+    WiFi.off();
+    uint32_t ms = millis();
+    while (WiFi.ready()) {
+        if (millis() - ms >= 10000) {
+            assertTrue(false);
+        }
+    }
+    assertLessOrEqual(WiFi.scan(results, 5), 0);
+}
+
+test(WIFI_12_restore_connection)
+{
+    if (!Particle.connected())
+    {
+        Particle.connect();
+    }
+}
+
 #endif


### PR DESCRIPTION
### Problem

A call to `WiFi.scan()` when WiFi module is off or not ready results in a hard fault.

See #1062

### Solution

Photon wlan_hal: `sniff_security()` should check that `wiced_wlan_connectivity_initialized()` returns true

### Steps to Test

- wiring/no_fixture: WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off

### Example App

N/A

### References

Closes #1062

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation (If not already documented, should explain to user this function won't work properly when Wi-Fi is off or !ready.)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Bug fix

- [`[PR #1354]`](https://github.com/spark/firmware/pull/1354) [`[Fixes #1062]`](https://github.com/spark/firmware/issues/1062) A call to `WiFi.scan()` when Wi-Fi module is off or not ready was resulting in a hard fault.