### PR TITLE
Updates minimal ARM gcc version required to 5.3.1

### DIFF
--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -32,12 +32,11 @@ LDFLAGS += -flto -Os -fuse-linker-plugin
 endif
 
 # Check if the compiler version is the minimum required
-arm_gcc_version:=$(shell $(CC) --version | head -n 1)
-arm_gcc_version:=$(strip $(subst arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors),,$(arm_gcc_version)))
-expected_version:=4.8.4
 quote="
 lt=\<
 dollar=$$
+arm_gcc_version:=$(strip $(shell $(CC) -dumpversion))
+expected_version:=5.3.1
 #$(info result $(shell test $(quote)$(arm_gcc_version)$(quote) $(lt) $(quote)$(expected_version)$(quote);echo $$?))
 ifeq ($(shell test $(quote)$(arm_gcc_version)$(quote) $(lt) $(quote)$(expected_version)$(quote); echo $$?),0)
      $(error "ARM gcc version $(expected_version) or later required, but found $(arm_gcc_version)")


### PR DESCRIPTION
### Problem

Currently, minimum ARM gcc version is set to 4.8.4, which will fail to build firmware starting with 0.7.0.

### Solution

- Update minimal ARM gcc version to 5.3.1
- Update gcc version check in arm-tools.mk to use `arm-none-eabi-gcc -dumpversion` instead of `arm-none-eabi-gcc --version`

### Steps to Test

- Check that firmware successfully builds with gcc 5.3.1
- Check that firmware fails to build with gcc < 5.3.1 and reports error:
```
../build/arm-tools.mk:45: *** "ARM gcc version 5.3.1 or later required, but found 4.9.3".  Stop.
```

### Example App

N/A

### References

Related issue: #1356

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Internal

- [`[PR #1358]`](https://github.com/spark/firmware/pull/1358) Updates minimal ARM gcc version required to 5.3.1