### PR TITLE
Fixes build with PLATFORM=gcc on OSX with clang's gcc wrapper

### DIFF
--- a/crypto/inc/mbedtls_config.h
+++ b/crypto/inc/mbedtls_config.h
@@ -2535,7 +2535,9 @@
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
 
+#if !(PLATFORM_ID == 3 && defined(__clang__))
 #include "mbedtls_weaken.h"
+#endif // !(PLATFORM_ID == 3 && defined(__clang__))
 
 #endif /* MBEDTLS_CONFIG_H */
 

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -58,6 +58,12 @@ const PublishFlag PRIVATE(PUBLISH_EVENT_FLAG_PRIVATE);
 const PublishFlag NO_ACK(PUBLISH_EVENT_FLAG_NO_ACK);
 const PublishFlag WITH_ACK(PUBLISH_EVENT_FLAG_WITH_ACK);
 
+// Test if the paramater a regular C "string" literal
+template <typename T>
+struct is_string_literal {
+    static constexpr bool value = std::is_array<T>::value && std::is_same<typename std::remove_extent<T>::type, char>::value;
+};
+
 class CloudClass {
 
 
@@ -66,7 +72,7 @@ public:
     template <typename T, class ... Types>
     static inline bool variable(const T &name, const Types& ... args)
     {
-        static_assert(!IsStringLiteral(name) || sizeof(name) <= USER_VAR_KEY_LENGTH + 1,
+        static_assert(!is_string_literal<T>::value || sizeof(name) <= USER_VAR_KEY_LENGTH + 1,
             "\n\nIn Particle.variable, name must be " __XSTRING(USER_VAR_KEY_LENGTH) " characters or less\n\n");
 
         return _variable(name, args...);
@@ -175,10 +181,9 @@ public:
     template <typename T, class ... Types>
     static inline bool function(const T &name, Types ... args)
     {
-#if PLATFORM_ID!=3
-        static_assert(!IsStringLiteral(name) || sizeof(name) <= USER_FUNC_KEY_LENGTH + 1,
+        static_assert(!is_string_literal<T>::value || sizeof(name) <= USER_FUNC_KEY_LENGTH + 1,
             "\n\nIn Particle.function, name must be " __XSTRING(USER_FUNC_KEY_LENGTH) " characters or less\n\n");
-#endif
+
         return _function(name, args...);
     }
 
@@ -361,12 +366,6 @@ private:
     {
         const String* s = (const String*)var;
         return s->c_str();
-    }
-
-    // Test if the paramater a regular C "string" literal
-    template <typename T>
-    constexpr static bool IsStringLiteral(const T& param) {
-      return std::is_array<T>::value && std::is_same<typename std::remove_extent<T>::type, char>::value;
     }
 };
 


### PR DESCRIPTION
### Problem

`PLATFORM=gcc` builds fail on OSX with default gcc compiler (which is actually a wrapper over clang).

### Solution

- Provide some clang-specific fixes

### Steps to Test

- `make PLATFORM=gcc clean all` should succeed with OSX gcc:
```
$ gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/c++/4.2.1
Apple LLVM version 7.0.2 (clang-700.1.81)
Target: x86_64-apple-darwin14.5.0
Thread model: posix
```

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation (N/A)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Internal

- [`[PR #1359]`](https://github.com/spark/firmware/pull/1359) Fixes build with `PLATFORM=gcc` on OSX with clang's gcc wrapper