### PR TITLE
Deprecate Particle.publish() and Particle.subscribe() invoked with default event scope

### DIFF
--- a/user/build.mk
+++ b/user/build.mk
@@ -24,6 +24,8 @@ endif
 
 ifdef TEST
 INCLUDE_PLATFORM?=1
+# Disable compiler warnings when deprecated APIs are used in test code
+CFLAGS+=-DPARTICLE_USING_DEPRECATED_API
 include $(MODULE_PATH)/tests/tests.mk
 -include $(MODULE_PATH)/$(USRSRC)/test.mk
 endif

--- a/wiring/inc/spark_wiring_global.h
+++ b/wiring/inc/spark_wiring_global.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2017 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if defined(PARTICLE_USER_MODULE) && !defined(PARTICLE_USING_DEPRECATED_API)
+#define PARTICLE_DEPRECATED_API(_msg) \
+        __attribute__((deprecated(_msg " Define PARTICLE_USING_DEPRECATED_API macro to avoid this warning.")))
+#else
+#define PARTICLE_DEPRECATED_API(_msg)
+#endif


### PR DESCRIPTION
### Problem

Beginning with 0.8.0 release, `Particle.publish()` and `Particle.subscribe()` methods will require event scope to be specified explicitly. This change will potentially break a lot of existing applications.

### Solution

Generate deprecation warning when `Particle.publish()` and `Particle.subscribe()` are used with a default event scope.

### Steps to Test

Compile and run `wiring/api` test.

### Example App

```cpp
void setup() {
    // Particle.publish()

    Particle.publish("event");
    Particle.publish("event", "data");
    Particle.publish("event", "data", 60);

    // Particle.subscribe()

    void (*handler1)(const char*, const char*) = nullptr;
    Particle.subscribe("event", handler1);

    std::function<void(const char*, const char*)> handler2;
    Particle.subscribe("event", handler2);

    struct Handler3 {
        void handler(const char*, const char*) {
        }
    } handler3;
    Particle.subscribe("event", &Handler3::handler, &handler3);
}

void loop() {
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [x] Added documentation (N/A)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Deprecated API

[`[PR #1365]`](https://github.com/spark/firmware/pull/1365) Beginning with 0.8.0 release, `Particle.publish()` and `Particle.subscribe()` methods will require event scope to be specified explicitly. Please update your apps now to include the event scope to avoid compilation errors in >=0.8.0