### PR TITLE
Fixes Photon monolithic builds on 0.7.0-rc.3

### DIFF
--- a/hal/src/photon/wiced/platform/MCU/STM32F2xx/GCC/app_no_bootloader.ld
+++ b/hal/src/photon/wiced/platform/MCU/STM32F2xx/GCC/app_no_bootloader.ld
@@ -167,6 +167,9 @@ SECTIONS
     INCLUDE backup_ram_user.ld
     INCLUDE backup_ram_system.ld
 
+    link_heap_location = _heap;
+    link_heap_location_end = _eheap;
+
     /DISCARD/ :
     {
         *(.ARM.attributes*)


### PR DESCRIPTION
### Problem

See #1368 

`link_heap_location` and `link_heap_location_end` definitions missing in linker file.

### Solution

Cherry-pick a71eba6aed768356a2d696e73fa28aa8ef158eea from #1369

### Steps to Test

Monolithic build should now succeed.

### Example App

N/A

### References

Closes #1368

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

### Bug fix

[`[PR #1370]`](https://github.com/spark/firmware/pull/1370) [`[Fixes #1368]`](https://github.com/spark/firmware/issues/1368) `[Photon/P1]` Fixes Photon/P1 monolithic builds (MODULAR=n) introduced in 0.7.0-rc.2.