### PR TITLE
Adds "License FAQ" to Firmware Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you have questions about software licensing, please contact Particle [support
 
 **Questions / Concerns?**
 
- * Particle intends for this firmware to be commercially useful and safe for our community of makers and enterprises.  Please [Contact Us] if you have any questions or concerns, or if you require special licensing.
+ * Particle intends for this firmware to be commercially useful and safe for our community of makers and enterprises.  Please [Contact Us](https://support.particle.io/) if you have any questions or concerns, or if you require special licensing.
 
 _(Note!  This FAQ isn't meant to be legal advice, if you're unsure, please consult an attorney)_
 

--- a/README.md
+++ b/README.md
@@ -74,24 +74,23 @@ If you have questions about software licensing, please contact Particle [support
 
 ### LICENSE FAQ
 
-** This firmware is released under LGPL version 3, what does that mean for you? **
+**This firmware is released under LGPL version 3, what does that mean for you?**
 
-You may use this commercially to build applications for your devices!  You **DO NOT** need to distribute your object files or the source code of your Application under LGPL.  Your source code belongs to you when you build an Application using this System Firmware.
+ * You may use this commercially to build applications for your devices!  You **DO NOT** need to distribute your object files or the source code of your Application under LGPL.  Your source code belongs to you when you build an Application using this System Firmware.
 
-** When am I required to share my code? **
+**When am I required to share my code?**
 
-You are **NOT required** to share your Application Firmware or object files when linking against libraries or System Firmware licensed under LGPL.
+ * You are **NOT required** to share your Application Firmware or object files when linking against libraries or System Firmware licensed under LGPL.
 
+ * If you make and distribute changes to System Firmware licensed under LGPL, you must release the source code and documentation for those changes under a LGPL license.
 
-If you make and distribute changes to System Firmware licensed under LGPL, you must release the source code and documentation for those changes under a LGPL license.
-
-** Why? **
+**Why?**
 
 This license allows businesses to confidently build firmware and make devices without risk to their intellectual property, while at the same time helping the community benefit from non-proprietary contributions to the shared System Firmware.
 
-** Questions / Concerns? **
+**Questions / Concerns?**
 
-Particle intends for this firmware to be commercially useful and safe for our community of makers and enterprises.  Please [Contact Us] if you have any questions or concerns, or if you require special licensing.
+ * Particle intends for this firmware to be commercially useful and safe for our community of makers and enterprises.  Please [Contact Us] if you have any questions or concerns, or if you require special licensing.
 
 _(Note!  This FAQ isn't meant to be legal advice, if you're unsure, please consult an attorney)_
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,48 @@ The guidelines of the Cypress Community License agreement allow individuals to s
 
 If you have questions about software licensing, please contact Particle [support](https://support.particle.io/).
 
+
+### LICENSE FAQ
+
+* This firmware is released under LGPL version 3, what does that mean for you? *
+
+You may use this commercially to build applications for your devices!  You *DO NOT* need to distribute your object files or the source code of your Application under LGPL.  Your source code belongs to you when you build an Application using this System Firmware.
+
+* When do I need to share my code? *
+
+You are *NOT required* to share your Application Firmware or object files when linking against libraries or System Firmware licensed under LGPL.
+
+
+If you make and distribute changes to System Firmware licensed under LGPL, you must release the source code and documentation for those changes under a LGPL license.
+
+* Why? *
+
+This license allows businesses to confidently build firmware and make devices without risk to their intellectual property, while at the same time helping the community benefit from non-proprietary contributions to the shared System Firmware.
+
+* Questions / Concerns? *
+
+Particle intends for this firmware to be commercially useful and safe for our community of makers and enterprises.  Please [Contact Us] if you have any questions or concerns, or if you require special licensing.
+
+_(Note!  This FAQ isn't meant to be legal advice, if you're unsure, please consult an attorney)_
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ### CONTRIBUTE
 
 Want to contribute to the Particle firmware project? Follow [this link](http://spark.github.io/#contributions) to find out how.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you have questions about software licensing, please contact Particle [support
 
 **Why?**
 
-This license allows businesses to confidently build firmware and make devices without risk to their intellectual property, while at the same time helping the community benefit from non-proprietary contributions to the shared System Firmware.
+ * This license allows businesses to confidently build firmware and make devices without risk to their intellectual property, while at the same time helping the community benefit from non-proprietary contributions to the shared System Firmware.
 
 **Questions / Concerns?**
 

--- a/README.md
+++ b/README.md
@@ -74,43 +74,26 @@ If you have questions about software licensing, please contact Particle [support
 
 ### LICENSE FAQ
 
-* This firmware is released under LGPL version 3, what does that mean for you? *
+** This firmware is released under LGPL version 3, what does that mean for you? **
 
-You may use this commercially to build applications for your devices!  You *DO NOT* need to distribute your object files or the source code of your Application under LGPL.  Your source code belongs to you when you build an Application using this System Firmware.
+You may use this commercially to build applications for your devices!  You **DO NOT** need to distribute your object files or the source code of your Application under LGPL.  Your source code belongs to you when you build an Application using this System Firmware.
 
-* When do I need to share my code? *
+** When am I required to share my code? **
 
-You are *NOT required* to share your Application Firmware or object files when linking against libraries or System Firmware licensed under LGPL.
+You are **NOT required** to share your Application Firmware or object files when linking against libraries or System Firmware licensed under LGPL.
 
 
 If you make and distribute changes to System Firmware licensed under LGPL, you must release the source code and documentation for those changes under a LGPL license.
 
-* Why? *
+** Why? **
 
 This license allows businesses to confidently build firmware and make devices without risk to their intellectual property, while at the same time helping the community benefit from non-proprietary contributions to the shared System Firmware.
 
-* Questions / Concerns? *
+** Questions / Concerns? **
 
 Particle intends for this firmware to be commercially useful and safe for our community of makers and enterprises.  Please [Contact Us] if you have any questions or concerns, or if you require special licensing.
 
 _(Note!  This FAQ isn't meant to be legal advice, if you're unsure, please consult an attorney)_
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 ### CONTRIBUTE


### PR DESCRIPTION
This PR adds a clarifying FAQ section to the README about the license of this project and the implications.  Since we've received some concerns from customers about their obligations under the LGPL licensing, we felt it was very important that we make it explicitly clear that they are not expected to share the source code of their application firmware, only distributed changes to system firmware covered by the LGPL.