### PR TITLE
4-digit code has extra characters at the end 

### DIFF
--- a/hal/src/stm32f2xx/device_code.cpp
+++ b/hal/src/stm32f2xx/device_code.cpp
@@ -62,7 +62,9 @@ bool fetch_or_generate_device_code(device_code_t* SSID) {
     }
     else {
         memcpy(dest, suffix, DEVICE_CODE_LEN);
-        code_length = strnlen((char*)dest, DEVICE_CODE_LEN);
+        // prior to 0.7.0-rc.3 the device code was 4 digits
+        // termination character is just unwritten flash, 0xFF
+        code_length = (dest[4]>127 || dest[4]<32) ? 4 : DEVICE_CODE_LEN;
         dct_read_app_data_unlock(DCT_DEVICE_CODE_OFFSET);
     }
     SSID->length += code_length;


### PR DESCRIPTION
### Problem

fixes issue #1380 [ch7922] where invalid characters were appearing after the end of an existing 4-digit setup code. 

### Solution

Fixes by checking the actual length of the string. The code previously assumed the string was null-terminated, which is not the case typically.  The check looks for any invalid character at location 4 (valid v is (32 < v < 128)) to detect an existing 4-digit code.

### Steps to Test

- Flash 0.6.2 to the device (`particle update` worked at the time of writing.)
- Erase the existing setup code (my device already had a 6-digit code.)
 - `echo -e -n  "\xFF\xFF\xFF\xFF\xFF\xFF" > ff6`
 - `dfu-util -d 2b04:d006 -a 1 -s 1852 -D ff6`
- Reboot the device, and enter listening mode
- Use your pc/mobile app to verify the Photon has a 4 digit code
- Flash system part1/2 built from this PR
- Reboot the device, and enter listening mode
- Use your pc/mobile app to verify the Photon has the same 4-digit code
- Finally, to verify 6-digit codes still function
 - Erase the existing code (flash ff6 via dfu as above)
 - reboot the device and enter listening mode
 - Use your pc/mobile app to verify the Photon now has a new 6-digit code

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)