### PR TITLE
[Diagnostics] Datasources: number of unacknowledged messages, number of rate limited events

### DIFF
--- a/communication/src/build.mk
+++ b/communication/src/build.mk
@@ -30,6 +30,7 @@ CPPSRC += $(TARGET_SRC_PATH)/coap_channel.cpp
 CPPSRC += $(TARGET_SRC_PATH)/publisher.cpp
 CPPSRC += $(TARGET_SRC_PATH)/protocol_defs.cpp
 CPPSRC += $(TARGET_SRC_PATH)/mbedtls_communication.cpp
+CPPSRC += $(TARGET_SRC_PATH)/communication_diagnostic.cpp
 
 # ASM source files included in this build.
 ASRC +=

--- a/communication/src/coap_channel.cpp
+++ b/communication/src/coap_channel.cpp
@@ -20,6 +20,7 @@
 #include "coap_channel.h"
 #include "service_debug.h"
 #include "messages.h"
+#include "communication_diagnostic.h"
 
 namespace particle { namespace protocol {
 
@@ -47,6 +48,7 @@ bool CoAPMessageStore::retransmit(CoAPMessage* msg, Channel& channel, system_tic
 
 void CoAPMessageStore::message_timeout(CoAPMessage& msg, Channel& channel)
 {
+	g_unacknowledgedMessageCounter++;
 	msg.notify_timeout();
 	if (msg.is_request())
 		channel.command(MessageChannel::CLOSE);

--- a/communication/src/communication_diagnostic.cpp
+++ b/communication/src/communication_diagnostic.cpp
@@ -1,4 +1,4 @@
 #include "communication_diagnostic.h"
 
-particle::SimpleIntegerDiagnosticData g_rateLimitedEventsCounter(DIAG_ID_CLOUD_RATE_LIMITED_EVENTS, DIAG_ID_CLOUD_RATE_LIMITED_EVENTS_NAME);
-particle::SimpleIntegerDiagnosticData g_unacknowledgedMessageCounter(DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES, DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES_NAME);
+particle::SimpleIntegerDiagnosticData g_rateLimitedEventsCounter(DIAG_ID_CLOUD_RATE_LIMITED_EVENTS, "cloud.rateLimited");
+particle::SimpleIntegerDiagnosticData g_unacknowledgedMessageCounter(DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES, "cloud.protoUnack");

--- a/communication/src/communication_diagnostic.cpp
+++ b/communication/src/communication_diagnostic.cpp
@@ -1,0 +1,4 @@
+#include "communication_diagnostic.h"
+
+particle::SimpleIntegerDiagnosticData g_rateLimitedEventsCounter(DIAG_ID_CLOUD_RATE_LIMITED_EVENTS, DIAG_ID_CLOUD_RATE_LIMITED_EVENTS_NAME);
+particle::SimpleIntegerDiagnosticData g_unacknowledgedMessageCounter(DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES, DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES_NAME);

--- a/communication/src/communication_diagnostic.h
+++ b/communication/src/communication_diagnostic.h
@@ -1,0 +1,4 @@
+#include "spark_wiring_diagnostics.h"
+
+extern particle::SimpleIntegerDiagnosticData g_rateLimitedEventsCounter;
+extern particle::SimpleIntegerDiagnosticData g_unacknowledgedMessageCounter;

--- a/communication/src/publisher.h
+++ b/communication/src/publisher.h
@@ -25,6 +25,7 @@
 #include "messages.h"
 
 #include "completion_handler.h"
+#include "communication_diagnostic.h"
 
 namespace particle
 {
@@ -98,8 +99,10 @@ public:
 	{
 		bool is_system_event = is_system(event_name);
 		bool rate_limited = is_rate_limited(is_system_event, time);
-		if (rate_limited)
+		if (rate_limited) {
+			g_rateLimitedEventsCounter++;
 			return BANDWIDTH_EXCEEDED;
+		}
 
 		Message message;
 		channel.create(message);

--- a/communication/src/spark_protocol.cpp
+++ b/communication/src/spark_protocol.cpp
@@ -510,12 +510,7 @@ int SparkProtocol::variable_value(unsigned char *buf,
 
 inline bool is_system(const char* event_name) {
     // if there were a strncmpi this would be easier!
-    char prefix[6];
-    if (!*event_name || strlen(event_name)<5)
-        return false;
-    memcpy(prefix, event_name, 5);
-    prefix[5] = '\0';
-    return !strcasecmp(prefix, "spark");
+    return !strncasecmp(event_name, "spark", 5);
 }
 
 // Returns true on success, false on sending timeout or rate-limiting failure

--- a/communication/src/spark_protocol.cpp
+++ b/communication/src/spark_protocol.cpp
@@ -45,6 +45,8 @@ LOG_SOURCE_CATEGORY("comm.sparkprotocol")
 #include "mbedtls_util.h"
 #endif
 
+#include "communication_diagnostic.h"
+
 using namespace particle::protocol;
 
 #if 0
@@ -535,6 +537,7 @@ bool SparkProtocol::send_event(const char *event_name, const char *data, int ttl
       uint16_t currentMinute = uint16_t(callbacks.millis()>>16);
       if (currentMinute==lastMinute) {      // == handles millis() overflow
           if (eventsThisMinute==255) {
+              g_rateLimitedEventsCounter++;
               handler.setError(SYSTEM_ERROR_LIMIT_EXCEEDED);
               return false;
           }
@@ -558,6 +561,7 @@ bool SparkProtocol::send_event(const char *event_name, const char *data, int ttl
     if (now - recent_event_ticks[evt_tick_idx] < 1000)
     {
       // exceeded allowable burst of 4 events per second
+      g_rateLimitedEventsCounter++;
       handler.setError(SYSTEM_ERROR_LIMIT_EXCEEDED);
       return false;
     }

--- a/services/inc/diagnostics.h
+++ b/services/inc/diagnostics.h
@@ -66,6 +66,9 @@ typedef enum diag_service_cmd {
     DIAG_SERVICE_CMD_START = 2 // Start the service
 } diag_service_cmd;
 
+#define DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES_NAME   "cloud.unacked"
+#define DIAG_ID_CLOUD_RATE_LIMITED_EVENTS_NAME       "cloud.ratelimed"
+
 typedef struct diag_source diag_source;
 
 typedef int(*diag_source_cmd_callback)(const diag_source* src, int cmd, void* data);

--- a/services/inc/diagnostics.h
+++ b/services/inc/diagnostics.h
@@ -66,9 +66,6 @@ typedef enum diag_service_cmd {
     DIAG_SERVICE_CMD_START = 2 // Start the service
 } diag_service_cmd;
 
-#define DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES_NAME   "cloud.unacked"
-#define DIAG_ID_CLOUD_RATE_LIMITED_EVENTS_NAME       "cloud.ratelimed"
-
 typedef struct diag_source diag_source;
 
 typedef int(*diag_source_cmd_callback)(const diag_source* src, int cmd, void* data);


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Solution

Implements:
- Datasource for the number of unacknowledged CoAP messages (`DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES`)
- Datasource for the number of events dropped due to rate limiting (`DIAG_ID_CLOUD_RATE_LIMITED_EVENTS`)

### Steps to Test

N/A

### Example App

N/A

### References

- [CH7640]
- [CH7641]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
