### PR TITLE
"sys.uptime" diagnostic data

### DIFF
--- a/hal/inc/hal_dynalib.h
+++ b/hal/inc/hal_dynalib.h
@@ -81,6 +81,8 @@ DYNALIB_FN(BASE_IDX + 18, hal,HAL_EEPROM_Has_Pending_Erase, bool(void))
 DYNALIB_FN(BASE_IDX + 19, hal,HAL_EEPROM_Perform_Pending_Erase, void(void))
 DYNALIB_FN(BASE_IDX + 20, hal, HAL_RTC_Time_Is_Valid, uint8_t(void*))
 
+DYNALIB_FN(BASE_IDX + 21, hal, HAL_Timer_Get_Seconds, system_tick_t(void))
+
 DYNALIB_END(hal)
 
 #undef BASE_IDX

--- a/hal/inc/hal_dynalib.h
+++ b/hal/inc/hal_dynalib.h
@@ -81,7 +81,7 @@ DYNALIB_FN(BASE_IDX + 18, hal,HAL_EEPROM_Has_Pending_Erase, bool(void))
 DYNALIB_FN(BASE_IDX + 19, hal,HAL_EEPROM_Perform_Pending_Erase, void(void))
 DYNALIB_FN(BASE_IDX + 20, hal, HAL_RTC_Time_Is_Valid, uint8_t(void*))
 
-DYNALIB_FN(BASE_IDX + 21, hal, HAL_Timer_Get_Seconds, system_tick_t(void))
+DYNALIB_FN(BASE_IDX + 21, hal, hal_timer_millis, uint64_t(void*))
 
 DYNALIB_END(hal)
 

--- a/hal/inc/timer_hal.h
+++ b/hal/inc/timer_hal.h
@@ -46,6 +46,11 @@ extern "C" {
 system_tick_t HAL_Timer_Get_Micro_Seconds(void);
 system_tick_t HAL_Timer_Get_Milli_Seconds(void);
 
+/**
+ * Returns the number of seconds since the device was powered on or woken up from sleep.
+ */
+system_tick_t HAL_Timer_Get_Seconds(void);
+
 #define HAL_Timer_Microseconds HAL_Timer_Get_Micro_Seconds
 #define HAL_Timer_Milliseconds HAL_Timer_Get_Milli_Seconds
 

--- a/hal/inc/timer_hal.h
+++ b/hal/inc/timer_hal.h
@@ -36,23 +36,23 @@
 
 /* Exported macros -----------------------------------------------------------*/
 
+#define HAL_Timer_Microseconds HAL_Timer_Get_Micro_Seconds
+#define HAL_Timer_Milliseconds HAL_Timer_Get_Milli_Seconds
+
 /* Exported functions --------------------------------------------------------*/
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 system_tick_t HAL_Timer_Get_Micro_Seconds(void);
 system_tick_t HAL_Timer_Get_Milli_Seconds(void);
 
 /**
- * Returns the number of seconds since the device was powered on or woken up from sleep.
+ * Returns the number of milliseconds passed since the device was last reset. This function is
+ * similar to HAL_Timer_Get_Milli_Seconds() but returns a 64-bit value.
  */
-system_tick_t HAL_Timer_Get_Seconds(void);
-
-#define HAL_Timer_Microseconds HAL_Timer_Get_Micro_Seconds
-#define HAL_Timer_Milliseconds HAL_Timer_Get_Milli_Seconds
+uint64_t hal_timer_millis(void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/src/core/timer_hal.c
+++ b/hal/src/core/timer_hal.c
@@ -58,3 +58,8 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
 {
     return GetSystem1MsTick();
 }
+
+system_tick_t HAL_Timer_Get_Seconds(void)
+{
+    return GetSystem1sTick();
+}

--- a/hal/src/core/timer_hal.c
+++ b/hal/src/core/timer_hal.c
@@ -61,5 +61,5 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
 
 uint64_t hal_timer_millis(void* reserved)
 {
-    return GetSystem1MsTick();
+    return GetSystem1MsTick64();
 }

--- a/hal/src/core/timer_hal.c
+++ b/hal/src/core/timer_hal.c
@@ -59,7 +59,7 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
     return GetSystem1MsTick();
 }
 
-system_tick_t HAL_Timer_Get_Seconds(void)
+uint64_t hal_timer_millis(void* reserved)
 {
-    return GetSystem1sTick();
+    return GetSystem1MsTick();
 }

--- a/hal/src/gcc/timer_hal.cpp
+++ b/hal/src/gcc/timer_hal.cpp
@@ -4,27 +4,24 @@
 
 namespace {
 
-const auto startMicros = boost::posix_time::microsec_clock::universal_time();
-const auto startSeconds = boost::posix_time::second_clock::universal_time();
+const auto start = boost::posix_time::microsec_clock::universal_time();
 
 } // namespace
 
 system_tick_t HAL_Timer_Get_Micro_Seconds(void)
 {
     auto now = boost::posix_time::microsec_clock::universal_time();
-    auto diff = now - startMicros;
+    auto diff = now - start;
     return diff.total_microseconds();
 }
 
 system_tick_t HAL_Timer_Get_Milli_Seconds(void)
 {
-    auto now = boost::posix_time::microsec_clock::universal_time();
-    auto diff = now - startMicros;
-    return diff.total_milliseconds();
+    return hal_timer_millis(nullptr);
 }
 
-system_tick_t HAL_Timer_Get_Seconds(void)
+uint64_t hal_timer_millis(void* reserved)
 {
-    const auto now = boost::posix_time::second_clock::universal_time();
-    return (now - startSeconds).total_seconds();
+    const auto now = boost::posix_time::microsec_clock::universal_time();
+    return (now - start).total_milliseconds();
 }

--- a/hal/src/gcc/timer_hal.cpp
+++ b/hal/src/gcc/timer_hal.cpp
@@ -1,23 +1,30 @@
-
 #include "timer_hal.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-auto start = boost::posix_time::microsec_clock::universal_time();
+namespace {
+
+const auto startMicros = boost::posix_time::microsec_clock::universal_time();
+const auto startSeconds = boost::posix_time::second_clock::universal_time();
+
+} // namespace
 
 system_tick_t HAL_Timer_Get_Micro_Seconds(void)
 {
     auto now = boost::posix_time::microsec_clock::universal_time();
-    auto diff = now - start;
+    auto diff = now - startMicros;
     return diff.total_microseconds();
 }
 
 system_tick_t HAL_Timer_Get_Milli_Seconds(void)
 {
     auto now = boost::posix_time::microsec_clock::universal_time();
-    auto diff = now - start;
+    auto diff = now - startMicros;
     return diff.total_milliseconds();
 }
 
-
-
+system_tick_t HAL_Timer_Get_Seconds(void)
+{
+    const auto now = boost::posix_time::second_clock::universal_time();
+    return (now - startSeconds).total_seconds();
+}

--- a/hal/src/stm32f2xx/timer_hal.c
+++ b/hal/src/stm32f2xx/timer_hal.c
@@ -62,5 +62,5 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
 
 uint64_t hal_timer_millis(void* reserved)
 {
-    return GetSystem1MsTick();
+    return GetSystem1MsTick64();
 }

--- a/hal/src/stm32f2xx/timer_hal.c
+++ b/hal/src/stm32f2xx/timer_hal.c
@@ -60,7 +60,7 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
     return GetSystem1MsTick();
 }
 
-system_tick_t HAL_Timer_Get_Seconds(void)
+uint64_t hal_timer_millis(void* reserved)
 {
-    return GetSystem1sTick();
+    return GetSystem1MsTick();
 }

--- a/hal/src/stm32f2xx/timer_hal.c
+++ b/hal/src/stm32f2xx/timer_hal.c
@@ -59,3 +59,8 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
     // review - wiced_time_get_time()) ??
     return GetSystem1MsTick();
 }
+
+system_tick_t HAL_Timer_Get_Seconds(void)
+{
+    return GetSystem1sTick();
+}

--- a/hal/src/template/timer_hal.cpp
+++ b/hal/src/template/timer_hal.cpp
@@ -53,3 +53,8 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
 {
   return 0;
 }
+
+system_tick_t HAL_Timer_Get_Seconds(void)
+{
+  return 0;
+}

--- a/hal/src/template/timer_hal.cpp
+++ b/hal/src/template/timer_hal.cpp
@@ -54,7 +54,7 @@ system_tick_t HAL_Timer_Get_Milli_Seconds(void)
   return 0;
 }
 
-system_tick_t HAL_Timer_Get_Seconds(void)
+uint64_t hal_timer_millis(void* reserved)
 {
   return 0;
 }

--- a/platform/MCU/newhal-mcu/inc/hw_ticks.h
+++ b/platform/MCU/newhal-mcu/inc/hw_ticks.h
@@ -48,9 +48,15 @@ void System1UsTick(void);
 /**
  * Fetch the current milliseconds count.
  * @return the number of milliseconds since the device was powered on or woken up from
- * sleep.
+ * sleep. Automatically wraps around when above UINT_MAX;
  */
-uint64_t GetSystem1MsTick();
+system_tick_t GetSystem1MsTick();
+
+/**
+ * Fetches the milliseconds counter. This function is similar to GetSystem1MsTick() but
+ * returns a 64-bit value.
+ */
+uint64_t GetSystem1MsTick64();
 
 /**
  * Fetch the current microseconds count.

--- a/platform/MCU/newhal-mcu/inc/hw_ticks.h
+++ b/platform/MCU/newhal-mcu/inc/hw_ticks.h
@@ -48,9 +48,9 @@ void System1UsTick(void);
 /**
  * Fetch the current milliseconds count.
  * @return the number of milliseconds since the device was powered on or woken up from
- * sleep. Automatically wraps around when above UINT_MAX;
+ * sleep.
  */
-system_tick_t GetSystem1MsTick();
+uint64_t GetSystem1MsTick();
 
 /**
  * Fetch the current microseconds count.

--- a/platform/MCU/shared/STM32/inc/hw_ticks.h
+++ b/platform/MCU/shared/STM32/inc/hw_ticks.h
@@ -44,9 +44,15 @@ void System1UsTick(void);
 /**
  * Fetch the current milliseconds count.
  * @return the number of milliseconds since the device was powered on or woken up from
- * sleep.
+ * sleep. Automatically wraps around when above UINT_MAX;
  */
-uint64_t GetSystem1MsTick();
+system_tick_t GetSystem1MsTick();
+
+/**
+ * Fetches the milliseconds counter. This function is similar to GetSystem1MsTick() but
+ * returns a 64-bit value.
+ */
+uint64_t GetSystem1MsTick64();
 
 /**
  * Fetch the current microseconds count.

--- a/platform/MCU/shared/STM32/inc/hw_ticks.h
+++ b/platform/MCU/shared/STM32/inc/hw_ticks.h
@@ -56,6 +56,12 @@ system_tick_t GetSystem1MsTick();
  */
 system_tick_t GetSystem1UsTick();
 
+/**
+ * Fetch the current seconds count.
+ * @return the number of seconds since the device was powered on or woken up from sleep.
+ * Automatically wraps around when above UINT_MAX.
+ */
+system_tick_t GetSystem1sTick();
 
 /**
  * Testing method that simulates advancing the time forward.

--- a/platform/MCU/shared/STM32/inc/hw_ticks.h
+++ b/platform/MCU/shared/STM32/inc/hw_ticks.h
@@ -21,16 +21,15 @@
 
 #pragma once
 
-#ifdef	__cplusplus
-extern "C" {
-#endif
-
-
 #include "platform_config.h"
 #include "system_tick_hal.h"
 
-#define SYSTEM_US_TICKS		(SystemCoreClock / 1000000)//cycles per microsecond
+#define SYSTEM_US_TICKS     (SystemCoreClock / 1000000)//cycles per microsecond
 #define SYSTEM_TICK_COUNTER     (DWT->CYCCNT)
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
 
 /**
  * Increment the millisecond tick counter.
@@ -45,9 +44,9 @@ void System1UsTick(void);
 /**
  * Fetch the current milliseconds count.
  * @return the number of milliseconds since the device was powered on or woken up from
- * sleep. Automatically wraps around when above UINT_MAX;
+ * sleep.
  */
-system_tick_t GetSystem1MsTick();
+uint64_t GetSystem1MsTick();
 
 /**
  * Fetch the current microseconds count.
@@ -57,16 +56,9 @@ system_tick_t GetSystem1MsTick();
 system_tick_t GetSystem1UsTick();
 
 /**
- * Fetch the current seconds count.
- * @return the number of seconds since the device was powered on or woken up from sleep.
- * Automatically wraps around when above UINT_MAX.
- */
-system_tick_t GetSystem1sTick();
-
-/**
  * Testing method that simulates advancing the time forward.
  */
-void __advance_system1MsTick(system_tick_t millis, system_tick_t micros_from_rollover);
+void __advance_system1MsTick(uint64_t millis, system_tick_t micros_from_rollover);
 
 void SysTick_Disable();
 

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -102,6 +102,7 @@ void __advance_system1MsTick(uint64_t millis, system_tick_t micros_from_rollover
     __disable_irq();
 
     DWT->CYCCNT = UINT_MAX - (micros_from_rollover * SYSTEM_US_TICKS);
+    system_millis_clock = DWT->CYCCNT;
     system_millis = millis;
 
     if ((is & 1) == 0) {

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -54,11 +54,16 @@ void System1MsTick(void)
  * Fetches the current millisecond tick counter.
  * @return
  */
-uint64_t GetSystem1MsTick()
+system_tick_t GetSystem1MsTick()
+{
+    return GetSystem1MsTick64();
+}
+
+uint64_t GetSystem1MsTick64()
 {
     uint64_t millis = 0;
 
-    int is = __get_PRIMASK();
+    const int is = __get_PRIMASK();
     __disable_irq();
 
     millis = system_millis + (DWT->CYCCNT - system_millis_clock) / SYSTEM_US_TICKS / 1000;

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -53,6 +53,7 @@
 #include "spark_wiring_cellular.h"
 #include "spark_wiring_cellular_printable.h"
 #include "spark_wiring_led.h"
+#include "spark_wiring_diagnostics.h"
 
 #if PLATFORM_ID == 3
 // Application loop uses std::this_thread::sleep_for() to workaround 100% CPU usage on the GCC platform
@@ -626,9 +627,23 @@ private:
     }
 };
 
+class UptimeDiagnosticData: public AbstractIntegerDiagnosticData {
+public:
+    UptimeDiagnosticData() :
+            AbstractIntegerDiagnosticData(DIAG_ID_SYSTEM_UPTIME, "sys.uptime") {
+    }
+
+    virtual int get(IntType& val) override {
+        val = HAL_Timer_Get_Seconds();
+        return 0; // OK
+    }
+};
+
 // Certain HAL events can be generated before app_setup_and_loop() is called. Using constructor of a
 // global variable allows to register a handler for HAL events early
 HALEventHandler halEventHandler;
+
+UptimeDiagnosticData uptimeDiagData;
 
 } // namespace
 

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -634,16 +634,16 @@ public:
     }
 
     virtual int get(IntType& val) override {
-        val = HAL_Timer_Get_Seconds();
+        val = System.uptime();
         return 0; // OK
     }
 };
 
 // Certain HAL events can be generated before app_setup_and_loop() is called. Using constructor of a
 // global variable allows to register a handler for HAL events early
-HALEventHandler halEventHandler;
+HALEventHandler g_halEventHandler;
 
-UptimeDiagnosticData uptimeDiagData;
+UptimeDiagnosticData g_uptimeDiagData;
 
 } // namespace
 

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -242,3 +242,14 @@ test(system_mode_button)
     API_COMPILE(System.disableButtonMirror());
     API_COMPILE(System.disableButtonMirror(false));
 }
+
+test(system_uptime_millis) {
+    uint64_t u64 = 0;
+    unsigned u = 0;
+
+    API_COMPILE(u64 = System.millis());
+    API_COMPILE(u = System.uptime());
+
+    (void)u64;
+    (void)u;
+}

--- a/user/tests/wiring/no_fixture_long_running/pwm.cpp
+++ b/user/tests/wiring/no_fixture_long_running/pwm.cpp
@@ -12,7 +12,7 @@
 
 static const uint32_t maxPulseSamples = 100;
 static const uint32_t minimumFrequency = 100;
- 
+
 uint8_t pwm_pins[] = {
 
 #if defined(STM32F2XX)
@@ -22,7 +22,7 @@ uint8_t pwm_pins[] = {
 #endif
 };
 
-static pin_t pin = pwm_pins[0];
+// static pin_t pin = pwm_pins[0];
 
 template <typename F> void for_all_pwm_pins(F callback)
 {

--- a/user/tests/wiring/no_fixture_long_running/ticks.cpp
+++ b/user/tests/wiring/no_fixture_long_running/ticks.cpp
@@ -119,13 +119,19 @@ void assert_ticks_interrupts(system_tick_t duration)
 
 test(TICKS_00_millis_micros_baseline_test)
 {
-    #define THREE_SECONDS 3*1000
-    system_tick_t start = millis();
-    delay(THREE_SECONDS);
-    assertMoreOrEqual(millis()-start,THREE_SECONDS);
-    start = micros();
-    delayMicroseconds(THREE_SECONDS);
-    assertMoreOrEqual(micros()-start,THREE_SECONDS);
+    const system_tick_t DELAY = 3 * 1000;
+    system_tick_t startMillis = millis();
+    system_tick_t startMicros = micros();
+    system_tick_t startSeconds = seconds();
+    delay(DELAY);
+    assertMoreOrEqual(millis() - startMillis, DELAY);
+    assertMoreOrEqual(micros() - startMicros, DELAY * 1000);
+    assertMoreOrEqual(seconds() - startSeconds, DELAY / 1000);
+    startMillis = millis();
+    startMicros = micros();
+    delayMicroseconds(DELAY);
+    assertMoreOrEqual(millis() - startMillis, DELAY / 1000);
+    assertMoreOrEqual(micros() - startMicros, DELAY);
 }
 
 #if !MODULAR_FIRMWARE

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -301,6 +301,15 @@ public:
         HAL_Core_Button_Mirror_Pin_Disable((uint8_t)bootloader, 0, NULL);
     }
 
+    // This function is similar to the global millis() but returns a 64-bit value
+    static uint64_t millis() {
+        return hal_timer_millis(nullptr);
+    }
+
+    static unsigned uptime() {
+        return (hal_timer_millis(nullptr) / 1000);
+    }
+
 private:
 
     static inline uint8_t get_flag(system_flag_t flag)


### PR DESCRIPTION
### Problem

The system should report its uptime in seconds.

### Solution

* ~Add `HAL_Timer_Get_Seconds()` function returning the number of seconds passed since the device was powered on or woken up from sleep.~
* Add `hal_timer_millis()` function returning the number of milliseconds passed since the device was last reset as a 64-bit value.
* Add `System.uptime()` and `System.millis()` methods returning the system uptime in seconds and milliseconds respectively.
* Add `sys.uptime` diagnostic data source.

### Steps to Test

Run `wiring/no_fixture_long_running` test.

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(MANUAL)

namespace {

const Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

bool logDiagData(void* appender, const uint8_t* data, size_t size) {
    Log.write(LOG_LEVEL_INFO, (const char*)data, size);
    return true;
}

} // namespace

void setup() {
    delay(3000);
    uint16_t id = DIAG_ID_SYSTEM_UPTIME;
    system_format_diag_data(&id, 1, 0, logDiagData, nullptr, nullptr);
    Log.print("\r\n");
}

void loop() {
}
```

### References

* https://github.com/spark/firmware/pull/1390
* [ch8155]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)