### PR TITLE
Low latency (direct) interrupt handlers

### DIFF
--- a/build/arm/startup/startup_stm32f2xx_electron.S
+++ b/build/arm/startup/startup_stm32f2xx_electron.S
@@ -1,0 +1,511 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32f2xx.s
+  * @author    MCD Application Team
+  * @version   V1.1.3
+  * @date      05-March-2012
+  * @brief     STM32F2xx Devices vector table.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Configure the system clock
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M3 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m3
+  .fpu softvfp
+  .thumb
+
+.global  g_pfnVectors
+.global  Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word  _sidata
+/* start address for the .data section. defined in linker script */
+.word  _sdata
+/* end address for the .data section. defined in linker script */
+.word  _edata
+/* start address for the .bss section. defined in linker script */
+.word  _sbss
+/* end address for the .bss section. defined in linker script */
+.word  _ebss
+/* stack used for SystemInit_ExtMemCtl; always internal RAM used */
+
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+*/
+
+    .section  .text.Reset_Handler
+  .weak  Reset_Handler
+  .type  Reset_Handler, %function
+Reset_Handler:
+
+/* Copy the data segment initializers from flash to SRAM */
+  movs  r1, #0
+  b  LoopCopyDataInit
+
+CopyDataInit:
+  ldr  r3, =_sidata
+  ldr  r3, [r3, r1]
+  str  r3, [r0, r1]
+  adds  r1, r1, #4
+
+LoopCopyDataInit:
+  ldr  r0, =_sdata
+  ldr  r3, =_edata
+  adds  r2, r0, r1
+  cmp  r2, r3
+  bcc  CopyDataInit
+  ldr  r2, =_sbss
+  b  LoopFillZerobss
+/* Zero fill the bss segment. */
+FillZerobss:
+  movs  r3, #0
+  str  r3, [r2], #4
+
+LoopFillZerobss:
+  ldr  r3, = _ebss
+  cmp  r2, r3
+  bcc  FillZerobss
+/* Call the clock system intitialization function.*/
+  bl  SystemInit
+  .include "spark_init.S"
+/* Call the application's entry point.*/
+  bl  main
+  bx  lr
+.size  Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ * @param  None
+ * @retval None
+*/
+    .section  .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b  Infinite_Loop
+  .size  Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex M3. Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+*******************************************************************************/
+   .section  .interrupt_vector_table,"a",%progbits
+  .type  g_pfnVectors, %object
+  .size  g_pfnVectors, .-g_pfnVectors
+
+
+g_pfnVectors:
+  .word  _estack
+  .word  Reset_Handler
+  .word  NMI_Handler
+  .word  HardFault_Handler
+  .word  MemManage_Handler
+  .word  BusFault_Handler
+  .word  UsageFault_Handler
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  SVC_Handler
+  .word  DebugMon_Handler
+  .word  0
+  .word  PendSV_Handler
+  .word  SysTickOverride
+
+  /* External Interrupts */
+  .word     WWDG_IRQHandler                   /* Window WatchDog              */
+  .word     PVD_IRQHandler                    /* PVD through EXTI Line detection */
+  .word     TAMP_STAMP_IRQHandler             /* Tamper and TimeStamps through the EXTI line */
+  .word     RTC_WKUP_IRQHandler               /* RTC Wakeup through the EXTI line */
+  .word     FLASH_IRQHandler                  /* FLASH                        */
+  .word     RCC_IRQHandler                    /* RCC                          */
+  .word     EXTI0_IRQHandler                  /* EXTI Line0                   */
+  .word     EXTI1_IRQHandler                  /* EXTI Line1                   */
+  .word     EXTI2_IRQHandler                  /* EXTI Line2                   */
+  .word     EXTI3_IRQHandler                  /* EXTI Line3                   */
+  .word     EXTI4_IRQHandler                  /* EXTI Line4                   */
+  .word     DMA1_Stream0_IRQHandler           /* DMA1 Stream 0                */
+  .word     DMA1_Stream1_IRQHandler           /* DMA1 Stream 1                */
+  .word     DMA1_Stream2_irq                  /* DMA1 Stream 2                */
+  .word     DMA1_Stream3_IRQHandler           /* DMA1 Stream 3                */
+  .word     DMA1_Stream4_IRQHandler           /* DMA1 Stream 4                */
+  .word     DMA1_Stream5_IRQHandler           /* DMA1 Stream 5                */
+  .word     DMA1_Stream6_IRQHandler           /* DMA1 Stream 6                */
+  .word     ADC_irq                           /* ADC1, ADC2 and ADC3s         */
+  .word     CAN1_TX_irq                       /* CAN1 TX                      */
+  .word     CAN1_RX0_irq                      /* CAN1 RX0                     */
+  .word     CAN1_RX1_irq                      /* CAN1 RX1                     */
+  .word     CAN1_SCE_irq                      /* CAN1 SCE                     */
+  .word     EXTI9_5_IRQHandler                /* External Line[9:5]s          */
+  .word     TIM1_BRK_TIM9_irq                 /* TIM1 Break and TIM9          */
+  .word     TIM1_UP_TIM10_irq                 /* TIM1 Update and TIM10        */
+  .word     TIM1_TRG_COM_TIM11_irq            /* TIM1 Trigger and Commutation and TIM11 */
+  .word     TIM1_CC_irq                       /* TIM1 Capture Compare         */
+  .word     TIM2_irq                          /* TIM2                         */
+  .word     TIM3_irq                          /* TIM3                         */
+  .word     TIM4_irq                          /* TIM4                         */
+  .word     I2C1_EV_irq                       /* I2C1 Event                   */
+  .word     I2C1_ER_irq                       /* I2C1 Error                   */
+  .word     I2C2_EV_IRQHandler                /* I2C2 Event                   */
+  .word     I2C2_ER_IRQHandler                /* I2C2 Error                   */
+  .word     SPI1_IRQHandler                   /* SPI1                         */
+  .word     SPI2_IRQHandler                   /* SPI2                         */
+  .word     HAL_USART1_Handler                /* USART1                       */
+  .word     HAL_USART2_Handler                /* USART2                       */
+  .word     HAL_USART3_Handler                /* USART3                       */
+  .word     EXTI15_10_IRQHandler              /* External Line[15:10]s        */
+  .word     RTC_Alarm_irq                     /* RTC Alarm (A and B) through EXTI Line */
+  .word     OTG_FS_WKUP_irq                   /* USB OTG FS Wakeup through EXTI line */
+  .word     TIM8_BRK_TIM12_irq                /* TIM8 Break and TIM12         */
+  .word     TIM8_UP_TIM13_irq                 /* TIM8 Update and TIM13        */
+  .word     TIM8_TRG_COM_TIM14_irq            /* TIM8 Trigger and Commutation and TIM14 */
+  .word     TIM8_CC_irq                       /* TIM8 Capture Compare         */
+  .word     DMA1_Stream7_irq                  /* DMA1 Stream7                 */
+  .word     FSMC_IRQHandler                   /* FSMC                         */
+  .word     SDIO_IRQHandler                   /* SDIO                         */
+  .word     TIM5_irq                          /* TIM5                         */
+  .word     SPI3_IRQHandler                   /* SPI3                         */
+  .word     HAL_USART4_Handler                /* UART4                        */
+  .word     HAL_USART5_Handler                /* UART5                        */
+  .word     TIM6_DAC_irq                      /* TIM6 and DAC1&2 underrun errors */
+  .word     TIM7_override                     /* TIM7                         */
+  .word     DMA2_Stream0_IRQHandler           /* DMA2 Stream 0                */
+  .word     DMA2_Stream1_IRQHandler           /* DMA2 Stream 1                */
+  .word     DMA2_Stream2_irq_override         /* DMA2 Stream 2                */
+  .word     DMA2_Stream3_IRQHandler           /* DMA2 Stream 3                */
+  .word     DMA2_Stream4_IRQHandler           /* DMA2 Stream 4                */
+  .word     ETH_IRQHandler                    /* Ethernet                     */
+  .word     ETH_WKUP_IRQHandler               /* Ethernet Wakeup through EXTI line */
+  .word     CAN2_TX_irq                       /* CAN2 TX                      */
+  .word     CAN2_RX0_irq                      /* CAN2 RX0                     */
+  .word     CAN2_RX1_irq                      /* CAN2 RX1                     */
+  .word     CAN2_SCE_irq                      /* CAN2 SCE                     */
+  .word     OTG_FS_irq                        /* USB OTG FS                   */
+  .word     DMA2_Stream5_irq                  /* DMA2 Stream 5                */
+  .word     DMA2_Stream6_IRQHandler           /* DMA2 Stream 6                */
+  .word     DMA2_Stream7_IRQHandler           /* DMA2 Stream 7                */
+  .word     USART6_IRQHandler                 /* USART6                       */
+  .word     I2C3_EV_irq                       /* I2C3 event                   */
+  .word     I2C3_ER_irq                       /* I2C3 error                   */
+  .word     OTG_HS_EP1_OUT_irq                /* USB OTG HS End Point 1 Out   */
+  .word     OTG_HS_EP1_IN_irq                 /* USB OTG HS End Point 1 In    */
+  .word     OTG_HS_WKUP_irq                   /* USB OTG HS Wakeup through EXTI */
+  .word     OTG_HS_irq                        /* USB OTG HS                   */
+  .word     DCMI_IRQHandler                   /* DCMI                         */
+  .word     CRYP_IRQHandler                   /* CRYP crypto                  */
+  .word     HASH_RNG_IRQHandler               /* Hash and Rng                 */
+
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+   .weak      NMI_Handler
+   .thumb_set NMI_Handler,Default_Handler
+
+   .weak      HardFault_Handler
+   .thumb_set HardFault_Handler,Default_Handler
+
+   .weak      MemManage_Handler
+   .thumb_set MemManage_Handler,Default_Handler
+
+   .weak      BusFault_Handler
+   .thumb_set BusFault_Handler,Default_Handler
+
+   .weak      UsageFault_Handler
+   .thumb_set UsageFault_Handler,Default_Handler
+
+   .weak      SVC_Handler
+   .thumb_set SVC_Handler,Default_Handler
+
+   .weak      DebugMon_Handler
+   .thumb_set DebugMon_Handler,Default_Handler
+
+   .weak      PendSV_Handler
+   .thumb_set PendSV_Handler,Default_Handler
+
+   .weak      SysTick_Handler
+   .thumb_set SysTick_Handler,Default_Handler
+
+   .weak      WWDG_IRQHandler
+   .thumb_set WWDG_IRQHandler,Default_Handler
+
+   .weak      PVD_IRQHandler
+   .thumb_set PVD_IRQHandler,Default_Handler
+
+   .weak      TAMP_STAMP_IRQHandler
+   .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
+
+   .weak      RTC_WKUP_IRQHandler
+   .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+   .weak      FLASH_IRQHandler
+   .thumb_set FLASH_IRQHandler,Default_Handler
+
+   .weak      RCC_IRQHandler
+   .thumb_set RCC_IRQHandler,Default_Handler
+
+   .weak      EXTI0_IRQHandler
+   .thumb_set EXTI0_IRQHandler,Default_Handler
+
+   .weak      EXTI1_IRQHandler
+   .thumb_set EXTI1_IRQHandler,Default_Handler
+
+   .weak      EXTI2_IRQHandler
+   .thumb_set EXTI2_IRQHandler,Default_Handler
+
+   .weak      EXTI3_IRQHandler
+   .thumb_set EXTI3_IRQHandler,Default_Handler
+
+   .weak      EXTI4_IRQHandler
+   .thumb_set EXTI4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream0_IRQHandler
+   .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream1_IRQHandler
+   .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream2_IRQHandler
+   .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream3_IRQHandler
+   .thumb_set DMA1_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream4_IRQHandler
+   .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream5_IRQHandler
+   .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream6_IRQHandler
+   .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
+
+   .weak      ADC_IRQHandler
+   .thumb_set ADC_IRQHandler,Default_Handler
+
+   .weak      CAN1_TX_IRQHandler
+   .thumb_set CAN1_TX_IRQHandler,Default_Handler
+
+   .weak      CAN1_RX0_IRQHandler
+   .thumb_set CAN1_RX0_IRQHandler,Default_Handler
+
+   .weak      CAN1_RX1_IRQHandler
+   .thumb_set CAN1_RX1_IRQHandler,Default_Handler
+
+   .weak      CAN1_SCE_IRQHandler
+   .thumb_set CAN1_SCE_IRQHandler,Default_Handler
+
+   .weak      EXTI9_5_IRQHandler
+   .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+   .weak      TIM1_BRK_TIM9_IRQHandler
+   .thumb_set TIM1_BRK_TIM9_IRQHandler,Default_Handler
+
+   .weak      TIM1_UP_TIM10_IRQHandler
+   .thumb_set TIM1_UP_TIM10_IRQHandler,Default_Handler
+
+   .weak      TIM1_TRG_COM_TIM11_IRQHandler
+   .thumb_set TIM1_TRG_COM_TIM11_IRQHandler,Default_Handler
+
+   .weak      TIM1_CC_IRQHandler
+   .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+   .weak      TIM2_IRQHandler
+   .thumb_set TIM2_IRQHandler,Default_Handler
+
+   .weak      TIM3_IRQHandler
+   .thumb_set TIM3_IRQHandler,Default_Handler
+
+   .weak      TIM4_IRQHandler
+   .thumb_set TIM4_IRQHandler,Default_Handler
+
+   .weak      I2C1_EV_IRQHandler
+   .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+   .weak      I2C1_ER_IRQHandler
+   .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+   .weak      I2C2_EV_IRQHandler
+   .thumb_set I2C2_EV_IRQHandler,Default_Handler
+
+   .weak      I2C2_ER_IRQHandler
+   .thumb_set I2C2_ER_IRQHandler,Default_Handler
+
+   .weak      SPI1_IRQHandler
+   .thumb_set SPI1_IRQHandler,Default_Handler
+
+   .weak      SPI2_IRQHandler
+   .thumb_set SPI2_IRQHandler,Default_Handler
+
+   .weak      USART1_IRQHandler
+   .thumb_set USART1_IRQHandler,Default_Handler
+
+   .weak      USART2_IRQHandler
+   .thumb_set USART2_IRQHandler,Default_Handler
+
+   .weak      USART3_IRQHandler
+   .thumb_set USART3_IRQHandler,Default_Handler
+
+   .weak      EXTI15_10_IRQHandler
+   .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+   .weak      RTC_Alarm_IRQHandler
+   .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+   .weak      OTG_FS_WKUP_IRQHandler
+   .thumb_set OTG_FS_WKUP_IRQHandler,Default_Handler
+
+   .weak      TIM8_BRK_TIM12_IRQHandler
+   .thumb_set TIM8_BRK_TIM12_IRQHandler,Default_Handler
+
+   .weak      TIM8_UP_TIM13_IRQHandler
+   .thumb_set TIM8_UP_TIM13_IRQHandler,Default_Handler
+
+   .weak      TIM8_TRG_COM_TIM14_IRQHandler
+   .thumb_set TIM8_TRG_COM_TIM14_IRQHandler,Default_Handler
+
+   .weak      TIM8_CC_IRQHandler
+   .thumb_set TIM8_CC_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream7_IRQHandler
+   .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
+
+   .weak      FSMC_IRQHandler
+   .thumb_set FSMC_IRQHandler,Default_Handler
+
+   .weak      SDIO_IRQHandler
+   .thumb_set SDIO_IRQHandler,Default_Handler
+
+   .weak      TIM5_IRQHandler
+   .thumb_set TIM5_IRQHandler,Default_Handler
+
+   .weak      SPI3_IRQHandler
+   .thumb_set SPI3_IRQHandler,Default_Handler
+
+   .weak      UART4_IRQHandler
+   .thumb_set UART4_IRQHandler,Default_Handler
+
+   .weak      UART5_IRQHandler
+   .thumb_set UART5_IRQHandler,Default_Handler
+
+   .weak      TIM6_DAC_IRQHandler
+   .thumb_set TIM6_DAC_IRQHandler,Default_Handler
+
+   .weak      TIM7_IRQHandler
+   .thumb_set TIM7_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream0_IRQHandler
+   .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream1_IRQHandler
+   .thumb_set DMA2_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream2_IRQHandler
+   .thumb_set DMA2_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream3_IRQHandler
+   .thumb_set DMA2_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream4_IRQHandler
+   .thumb_set DMA2_Stream4_IRQHandler,Default_Handler
+
+   .weak      ETH_IRQHandler
+   .thumb_set ETH_IRQHandler,Default_Handler
+
+   .weak      ETH_WKUP_IRQHandler
+   .thumb_set ETH_WKUP_IRQHandler,Default_Handler
+
+   .weak      CAN2_TX_IRQHandler
+   .thumb_set CAN2_TX_IRQHandler,Default_Handler
+
+   .weak      CAN2_RX0_IRQHandler
+   .thumb_set CAN2_RX0_IRQHandler,Default_Handler
+
+   .weak      CAN2_RX1_IRQHandler
+   .thumb_set CAN2_RX1_IRQHandler,Default_Handler
+
+   .weak      CAN2_SCE_IRQHandler
+   .thumb_set CAN2_SCE_IRQHandler,Default_Handler
+
+   .weak      OTG_FS_IRQHandler
+   .thumb_set OTG_FS_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream5_IRQHandler
+   .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream6_IRQHandler
+   .thumb_set DMA2_Stream6_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream7_IRQHandler
+   .thumb_set DMA2_Stream7_IRQHandler,Default_Handler
+
+   .weak      USART6_IRQHandler
+   .thumb_set USART6_IRQHandler,Default_Handler
+
+   .weak      I2C3_EV_IRQHandler
+   .thumb_set I2C3_EV_IRQHandler,Default_Handler
+
+   .weak      I2C3_ER_IRQHandler
+   .thumb_set I2C3_ER_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_EP1_OUT_IRQHandler
+   .thumb_set OTG_HS_EP1_OUT_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_EP1_IN_IRQHandler
+   .thumb_set OTG_HS_EP1_IN_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_WKUP_IRQHandler
+   .thumb_set OTG_HS_WKUP_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_IRQHandler
+   .thumb_set OTG_HS_IRQHandler,Default_Handler
+
+   .weak      DCMI_IRQHandler
+   .thumb_set DCMI_IRQHandler,Default_Handler
+
+   .weak      CRYP_IRQHandler
+   .thumb_set CRYP_IRQHandler,Default_Handler
+
+   .weak      HASH_RNG_IRQHandler
+   .thumb_set HASH_RNG_IRQHandler,Default_Handler
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/build/platform-id.mk
+++ b/build/platform-id.mk
@@ -270,6 +270,10 @@ CFLAGS += -DSTM32_DEVICE
 CFLAGS += -D$(STM32_DEVICE)
 endif
 
+ifneq ("$(SPARK_NO_PLATFORM)","")
+CFLAGS += -DSPARK_NO_PLATFORM
+endif
+
 ifeq ("$(PRODUCT_ID)","")
 # ifeq (,$(submake))
 # $(info PRODUCT_ID not defined - using default: $(DEFAULT_PRODUCT_ID))

--- a/communication/src/communication_dynalib.cpp
+++ b/communication/src/communication_dynalib.cpp
@@ -17,6 +17,7 @@
 
 #define DYNALIB_EXPORT
 #include "communication_dynalib.h"
+#define INTERRUPTS_HAL_EXCLUDE_PLATFORM_HEADERS
 #include "core_hal.h"
 
 #if PARTICLE_PROTOCOL

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -85,6 +85,7 @@ DYNALIB_FN(32, hal_gpio, HAL_PWM_Get_Frequency_Ext, uint32_t(uint16_t))
 DYNALIB_FN(33, hal_gpio, HAL_PWM_Get_AnalogValue_Ext, uint32_t(uint16_t))
 DYNALIB_FN(34, hal_gpio, HAL_PWM_Get_Max_Frequency, uint32_t(uint16_t))
 DYNALIB_FN(35, hal_gpio, HAL_Interrupts_Detach_Ext, void(uint16_t, uint8_t, void*))
+DYNALIB_FN(36, hal_gpio, HAL_Set_Direct_Interrupt_Handler, int(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved))
 
 DYNALIB_END(hal_gpio)
 

--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -29,7 +29,12 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "pinmap_hal.h"
+#if !defined(SPARK_NO_PLATFORM) && !defined(INTERRUPTS_HAL_EXCLUDE_PLATFORM_HEADERS)
 #include "interrupts_irq.h"
+#else
+typedef int32_t IRQn_Type;
+typedef int32_t hal_irq_t;
+#endif // SPARK_NO_PLATFORM
 #include "hal_irq_flag.h"
 
 /* Exported types ------------------------------------------------------------*/
@@ -40,6 +45,15 @@ typedef enum InterruptMode {
 } InterruptMode;
 
 typedef void (*HAL_InterruptHandler)(void* data);
+
+typedef void (*HAL_Direct_Interrupt_Handler)(void);
+
+typedef enum {
+  HAL_DIRECT_INTERRUPT_FLAG_NONE    = 0x00,
+  HAL_DIRECT_INTERRUPT_FLAG_RESTORE = 0x01,
+  HAL_DIRECT_INTERRUPT_FLAG_DISABLE = 0x02,
+  HAL_DIRECT_INTERRUPT_FLAG_ENABLE  = 0x04
+} HAL_Direct_Interrupt_Flags;
 
 /* Exported constants --------------------------------------------------------*/
 
@@ -88,6 +102,8 @@ void HAL_Interrupts_Trigger(uint16_t pin, void* reserved);
 uint8_t HAL_Set_System_Interrupt_Handler(hal_irq_t irq, const HAL_InterruptCallback* callback, HAL_InterruptCallback* previous, void* reserved);
 uint8_t HAL_Get_System_Interrupt_Handler(hal_irq_t irq, HAL_InterruptCallback* callback, void* reserved);
 void HAL_System_Interrupt_Trigger(hal_irq_t irq, void* reserved);
+
+int HAL_Set_Direct_Interrupt_Handler(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved);
 
 #ifdef USE_STDPERIPH_DRIVER
 #if defined(STM32F10X_MD) || defined(STM32F10X_HD)

--- a/hal/src/core/interrupts_hal.c
+++ b/hal/src/core/interrupts_hal.c
@@ -287,4 +287,8 @@ void HAL_enable_irq(int is) {
     }
 }
 
-
+int HAL_Set_Direct_Interrupt_Handler(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved)
+{
+    // Not supported
+    return 1;
+}

--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -45,6 +45,8 @@ extern char link_interrupt_vectors_location;
 extern char link_ram_interrupt_vectors_location;
 extern char link_ram_interrupt_vectors_location_end;
 
+void SysTickChain();
+
 #if 0
 IDX[x] = added IRQ handler
 00 [ ] _estack
@@ -147,67 +149,6 @@ IDX[x] = added IRQ handler
 96 [ ] HASH_RNG_IRQHandler               // Hash and Rng
 #endif
 
-// Reset_Handler defined in startup_stm32f2xx.s (index 1)
-const unsigned NMI_Handler_Idx                      = 2;
-const unsigned HardFault_Handler_Idx                = 3;
-const unsigned MemManage_Handler_Idx                = 4;
-const unsigned BusFault_Handler_Idx                 = 5;
-const unsigned UsageFault_Handler_Idx               = 6;
-const unsigned SVC_Handler_Idx                      = 11;
-const unsigned DebugMon_Handler_Idx                 = 12;
-const unsigned PendSV_Handler_Idx                   = 14;
-const unsigned SysTick_Handler_Idx                  = 15;
-const unsigned EXTI0_IRQHandler_Idx                 = 22;
-const unsigned EXTI1_IRQHandler_Idx                 = 23;
-const unsigned EXTI2_IRQHandler_Idx                 = 24;
-const unsigned EXTI3_IRQHandler_Idx                 = 25;
-const unsigned EXTI4_IRQHandler_Idx                 = 26;
-const unsigned DMA1_Stream2_IRQHandler_Idx          = 29;
-const unsigned ADC_IRQHandler_Idx                   = 34;
-const unsigned CAN1_TX_IRQHandler_Idx               = 35;
-const unsigned CAN1_RX0_IRQHandler_Idx              = 36;
-const unsigned CAN1_RX1_IRQHandler_Idx              = 37;
-const unsigned CAN1_SCE_IRQHandler_Idx              = 38;
-const unsigned EXTI9_5_IRQHandler_Idx               = 39;
-const unsigned TIM1_BRK_TIM9_IRQHandler_Idx         = 40;
-const unsigned TIM1_UP_TIM10_IRQHandler_Idx         = 41;
-const unsigned TIM1_TRG_COM_TIM11_IRQHandler_Idx    = 42;
-const unsigned TIM1_CC_IRQHandler_Idx               = 43;
-const unsigned TIM2_IRQHandler_Idx                  = 44;
-const unsigned TIM3_IRQHandler_Idx                  = 45;
-const unsigned TIM4_IRQHandler_Idx                  = 46;
-const unsigned I2C1_EV_IRQHandler_Idx               = 47;
-const unsigned I2C1_ER_IRQHandler_Idx               = 48;
-const unsigned USART1_IRQHandler_Idx                = 53;
-const unsigned USART2_IRQHandler_Idx                = 54;
-const unsigned USART3_IRQHandler_Idx                = 55;
-const unsigned EXTI15_10_IRQHandler_Idx             = 56;
-const unsigned RTC_Alarm_IRQHandler_Idx             = 57;
-const unsigned OTG_FS_WKUP_IRQHandler_Idx           = 58;
-const unsigned TIM8_BRK_TIM12_IRQHandler_Idx        = 59;
-const unsigned TIM8_UP_TIM13_IRQHandler_Idx         = 60;
-const unsigned TIM8_TRG_COM_TIM14_IRQHandler_Idx    = 61;
-const unsigned TIM8_CC_IRQHandler_Idx               = 62;
-const unsigned DMA1_Stream7_IRQHandler_Idx          = 63;
-const unsigned TIM5_IRQHandler_Idx                  = 66;
-const unsigned UART4_IRQHandler_Idx                 = 68;
-const unsigned UART5_IRQHandler_Idx                 = 69;
-const unsigned TIM6_DAC_IRQHandler_Idx              = 70;
-const unsigned TIM7_IRQHandler_Idx                  = 71;
-const unsigned DMA2_Stream2_IRQHandler_Idx          = 74;
-const unsigned CAN2_TX_IRQHandler_Idx               = 79;
-const unsigned CAN2_RX0_IRQHandler_Idx              = 80;
-const unsigned CAN2_RX1_IRQHandler_Idx              = 81;
-const unsigned CAN2_SCE_IRQHandler_Idx              = 82;
-const unsigned OTG_FS_IRQHandler_Idx                = 83;
-const unsigned DMA2_Stream5_IRQHandler_Idx          = 84;
-const unsigned I2C3_EV_IRQHandler_Idx               = 88;
-const unsigned I2C3_ER_IRQHandler_Idx               = 89;
-const unsigned OTG_HS_EP1_OUT_IRQHandler_Idx        = 90;
-const unsigned OTG_HS_EP1_IN_IRQHandler_Idx         = 91;
-const unsigned OTG_HS_WKUP_IRQHandler_Idx           = 92;
-const unsigned OTG_HS_IRQHandler_Idx                = 93;
-
 /* Extern variables ---------------------------------------------------------*/
 /**
  * Updated by HAL_1Ms_Tick()
@@ -230,73 +171,20 @@ void HAL_Core_Setup_override_interrupts(void)
 {
     memcpy(&link_ram_interrupt_vectors_location, &link_interrupt_vectors_location, &link_ram_interrupt_vectors_location_end-&link_ram_interrupt_vectors_location);
     uint32_t* isrs                          = (uint32_t*)&link_ram_interrupt_vectors_location;
-    isrs[NMI_Handler_Idx]                   = (uint32_t)NMI_Handler;
-    isrs[HardFault_Handler_Idx]             = (uint32_t)HardFault_Handler;
-    isrs[MemManage_Handler_Idx]             = (uint32_t)MemManage_Handler;
-    isrs[BusFault_Handler_Idx]              = (uint32_t)BusFault_Handler;
-    isrs[UsageFault_Handler_Idx]            = (uint32_t)UsageFault_Handler;
-    isrs[SVC_Handler_Idx]                   = (uint32_t)SVC_Handler;
-    isrs[DebugMon_Handler_Idx]              = (uint32_t)DebugMon_Handler;
-    isrs[PendSV_Handler_Idx]                = (uint32_t)PendSV_Handler;
-    isrs[SysTick_Handler_Idx]               = (uint32_t)SysTickOverride;
-    isrs[EXTI0_IRQHandler_Idx]              = (uint32_t)EXTI0_IRQHandler;
-    isrs[EXTI1_IRQHandler_Idx]              = (uint32_t)EXTI1_IRQHandler;
-    isrs[EXTI2_IRQHandler_Idx]              = (uint32_t)EXTI2_IRQHandler;
-    isrs[EXTI3_IRQHandler_Idx]              = (uint32_t)EXTI3_IRQHandler;
-    isrs[EXTI4_IRQHandler_Idx]              = (uint32_t)EXTI4_IRQHandler;
-    isrs[ADC_IRQHandler_Idx]                = (uint32_t)ADC_irq;
-    isrs[CAN1_TX_IRQHandler_Idx]            = (uint32_t)CAN1_TX_irq;
-    isrs[CAN1_RX0_IRQHandler_Idx]           = (uint32_t)CAN1_RX0_irq;
-    isrs[CAN1_RX1_IRQHandler_Idx]           = (uint32_t)CAN1_RX1_irq;
-    isrs[CAN1_SCE_IRQHandler_Idx]           = (uint32_t)CAN1_SCE_irq;
-    isrs[EXTI9_5_IRQHandler_Idx]            = (uint32_t)EXTI9_5_IRQHandler;
-    isrs[TIM1_BRK_TIM9_IRQHandler_Idx]      = (uint32_t)TIM1_BRK_TIM9_irq;
-    isrs[TIM1_UP_TIM10_IRQHandler_Idx]      = (uint32_t)TIM1_UP_TIM10_irq;
-    isrs[TIM1_TRG_COM_TIM11_IRQHandler_Idx] = (uint32_t)TIM1_TRG_COM_TIM11_irq;
-    isrs[TIM1_CC_IRQHandler_Idx]            = (uint32_t)TIM1_CC_irq;
-    isrs[TIM2_IRQHandler_Idx]               = (uint32_t)TIM2_irq;
-    isrs[TIM3_IRQHandler_Idx]               = (uint32_t)TIM3_irq;
-    isrs[TIM4_IRQHandler_Idx]               = (uint32_t)TIM4_irq;
-    isrs[USART1_IRQHandler_Idx]             = (uint32_t)HAL_USART1_Handler;
-    isrs[USART2_IRQHandler_Idx]             = (uint32_t)HAL_USART2_Handler;
-    isrs[USART3_IRQHandler_Idx]             = (uint32_t)HAL_USART3_Handler;
-#ifdef USE_USB_OTG_FS
-    isrs[OTG_FS_WKUP_IRQHandler_Idx]        = (uint32_t)OTG_FS_WKUP_irq;
-#endif
-    isrs[TIM8_BRK_TIM12_IRQHandler_Idx]     = (uint32_t)TIM8_BRK_TIM12_irq;
-    isrs[TIM8_UP_TIM13_IRQHandler_Idx]      = (uint32_t)TIM8_UP_TIM13_irq;
-    isrs[TIM8_TRG_COM_TIM14_IRQHandler_Idx] = (uint32_t)TIM8_TRG_COM_TIM14_irq;
-    isrs[TIM8_CC_IRQHandler_Idx]            = (uint32_t)TIM8_CC_irq;
-    isrs[TIM5_IRQHandler_Idx]               = (uint32_t)TIM5_irq;
-    isrs[UART4_IRQHandler_Idx]              = (uint32_t)HAL_USART4_Handler;
-    isrs[UART5_IRQHandler_Idx]              = (uint32_t)HAL_USART5_Handler;
-    isrs[TIM6_DAC_IRQHandler_Idx]           = (uint32_t)TIM6_DAC_irq;
-    isrs[DMA2_Stream2_IRQHandler_Idx]       = (uint32_t)DMA2_Stream2_irq_override;
-    isrs[TIM7_IRQHandler_Idx]               = (uint32_t)TIM7_override;  // WICED uses this for a JTAG watchdog handler
-    isrs[CAN2_TX_IRQHandler_Idx]            = (uint32_t)CAN2_TX_irq;
-    isrs[CAN2_RX0_IRQHandler_Idx]           = (uint32_t)CAN2_RX0_irq;
-    isrs[CAN2_RX1_IRQHandler_Idx]           = (uint32_t)CAN2_RX1_irq;
-    isrs[CAN2_SCE_IRQHandler_Idx]           = (uint32_t)CAN2_SCE_irq;
-#ifdef USE_USB_OTG_FS
-    isrs[OTG_FS_IRQHandler_Idx]             = (uint32_t)OTG_FS_irq;
-#elif defined USE_USB_OTG_HS
-    isrs[OTG_HS_EP1_OUT_IRQHandler_Idx]     = (uint32_t)OTG_HS_EP1_OUT_irq;
-    isrs[OTG_HS_EP1_IN_IRQHandler_Idx]      = (uint32_t)OTG_HS_EP1_IN_irq;
-    isrs[OTG_HS_WKUP_IRQHandler_Idx]        = (uint32_t)OTG_HS_WKUP_irq;
-    isrs[OTG_HS_IRQHandler_Idx]             = (uint32_t)OTG_HS_irq;
-#endif
-    isrs[EXTI15_10_IRQHandler_Idx]          = (uint32_t)EXTI15_10_IRQHandler;
-    isrs[I2C1_EV_IRQHandler_Idx]            = (uint32_t)I2C1_EV_irq;
-    isrs[I2C1_ER_IRQHandler_Idx]            = (uint32_t)I2C1_ER_irq;
-    isrs[I2C3_EV_IRQHandler_Idx]            = (uint32_t)I2C3_EV_irq;
-    isrs[I2C3_ER_IRQHandler_Idx]            = (uint32_t)I2C3_ER_irq;
-    isrs[DMA1_Stream7_IRQHandler_Idx]       = (uint32_t)DMA1_Stream7_irq;
-    isrs[DMA2_Stream5_IRQHandler_Idx]       = (uint32_t)DMA2_Stream5_irq;
-    isrs[DMA1_Stream2_IRQHandler_Idx]       = (uint32_t)DMA1_Stream2_irq;
-
-    isrs[RTC_Alarm_IRQHandler_Idx]          = (uint32_t)RTC_Alarm_irq;
     SCB->VTOR = (unsigned long)isrs;
 }
+
+void HAL_Core_Restore_Interrupt(IRQn_Type irqn) {
+    uint32_t handler = ((const uint32_t*)&link_interrupt_vectors_location)[IRQN_TO_IDX(irqn)];
+
+    if (irqn == SysTick_IRQn) {
+        handler = (uint32_t)SysTickChain;
+    }
+
+    volatile uint32_t* isrs = (volatile uint32_t*)SCB->VTOR;
+    isrs[IRQN_TO_IDX(irqn)] = handler;
+}
+
 
 static TaskHandle_t  app_thread_handle;
 #define APPLICATION_STACK_SIZE 6144
@@ -344,21 +232,20 @@ int main(void)
     return 0;
 }
 
+void SysTickChain()
+{
+    SysTick_Handler();
+    SysTickOverride();
+}
+
 /**
  * Called by HAL_Core_Init() to pre-initialize any low level hardware before
  * the main loop runs.
  */
 void HAL_Core_Init_finalize(void)
 {
-}
-
-void SysTickChain()
-{
-    void (*chain)(void) = (void (*)(void))((uint32_t*)&link_interrupt_vectors_location)[SysTick_Handler_Idx];
-
-    chain();
-
-    SysTickOverride();
+    uint32_t* isrs = (uint32_t*)&link_ram_interrupt_vectors_location;
+    isrs[IRQN_TO_IDX(SysTick_IRQn)] = (uint32_t)SysTickChain;
 }
 
 void HAL_1Ms_Tick()
@@ -375,8 +262,6 @@ void HAL_1Ms_Tick()
  */
 void HAL_Core_Setup_finalize(void)
 {
-    uint32_t* isrs = (uint32_t*)&link_ram_interrupt_vectors_location;
-    isrs[SysTick_Handler_Idx] = (uint32_t)SysTickChain;
     // retained memory is critical for efficient data use on the electron
     HAL_Feature_Set(FEATURE_RETAINED_MEMORY, ENABLE);
 }
@@ -629,3 +514,8 @@ void USART6_IRQHandler(void)        {__ASM("bkpt 0");}
 void DCMI_IRQHandler(void)          {__ASM("bkpt 0");}
 void CRYP_IRQHandler(void)          {__ASM("bkpt 0");}
 void HASH_RNG_IRQHandler(void)      {__ASM("bkpt 0");}
+
+void OTG_HS_EP1_OUT_irq(void)       {__ASM("bkpt 0");}
+void OTG_HS_EP1_IN_irq(void)        {__ASM("bkpt 0");}
+void OTG_HS_WKUP_irq(void)          {__ASM("bkpt 0");}
+void OTG_HS_irq(void)               {__ASM("bkpt 0");}

--- a/hal/src/electron/include.mk
+++ b/hal/src/electron/include.mk
@@ -48,7 +48,7 @@ LDFLAGS += -Wl,-Map,$(TARGET_BASE).map
 LDFLAGS += -u uxTopUsedPriority
 #
 # assembler startup script
-ASRC += $(COMMON_BUILD)/arm/startup/startup_$(STM32_DEVICE_LC).S
+ASRC += $(COMMON_BUILD)/arm/startup/startup_$(STM32_DEVICE_LC)_electron.S
 ASFLAGS += -I$(COMMON_BUILD)/arm/startup
 ASFLAGS +=  -Wa,--defsym -Wa,SPARK_INIT_STARTUP=1
 #

--- a/hal/src/newhal/interrupts_irq.h
+++ b/hal/src/newhal/interrupts_irq.h
@@ -1,0 +1,18 @@
+#ifndef INTERRUPTS_IRQ_H
+#define INTERRUPTS_IRQ_H
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+typedef int32_t IRQn_Type;
+
+typedef enum hal_irq_t {
+    __Last_irq = 0
+} hal_irq_t;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif  /* INTERRUPTS_IRQ_H */

--- a/hal/src/stm32/interrupts_irq.h
+++ b/hal/src/stm32/interrupts_irq.h
@@ -14,6 +14,28 @@ extern "C" {
 
 #include "static_assert.h"
 
+#ifdef USE_STDPERIPH_DRIVER
+
+#if defined(STM32F10X_MD) || defined(STM32F10X_HD)
+#include "stm32f10x.h"
+#else
+#include "stm32f2xx.h"
+#endif
+
+typedef struct {
+  IRQn_Type irq;
+  void (*handler)(void);
+} HAL_InterruptOverrideEntry;
+
+extern const HAL_InterruptOverrideEntry hal_interrupt_overrides[];
+
+#define IRQN_TO_IDX(irqn) ((int)irqn + 16)
+
+void HAL_Core_Restore_Interrupt(IRQn_Type irqn);
+#else
+typedef int32_t IRQn_Type;
+#endif // USE_STDPERIPH_DRIVER
+
 typedef enum hal_irq_t {
 #if defined(STM32F10X_MD) || defined(STM32F10X_HD)
     __All_irq = 0,

--- a/hal/src/template/interrupts_hal.cpp
+++ b/hal/src/template/interrupts_hal.cpp
@@ -76,3 +76,7 @@ void HAL_enable_irq(int is)
 {
 }
 
+int HAL_Set_Direct_Interrupt_Handler(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved)
+{
+    return 1;
+}

--- a/modules/electron/system-part3/build.mk
+++ b/modules/electron/system-part3/build.mk
@@ -7,6 +7,6 @@ LDFLAGS += -L$(SYSTEM_PART3_MODULE_PATH)
 
 
 LDFLAGS += -Wl,--defsym,__STACKSIZE__=1400
-ASRC += $(COMMON_BUILD)/arm/startup/startup_$(STM32_DEVICE_LC).S
+ASRC += $(COMMON_BUILD)/arm/startup/startup_$(STM32_DEVICE_LC)_electron.S
 ASFLAGS += -I$(COMMON_BUILD)/arm/startup
 ASFLAGS +=  -Wa,--defsym -Wa,SPARK_INIT_STARTUP=1

--- a/platform/MCU/STM32F2xx/CMSIS/Device/ST/Include/stm32f2xx.h
+++ b/platform/MCU/STM32F2xx/CMSIS/Device/ST/Include/stm32f2xx.h
@@ -145,6 +145,7 @@ typedef enum IRQn
 {
 /******  Cortex-M3 Processor Exceptions Numbers ****************************************************************/
   NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  HardFault_IRQn              = -13,    /*!< 3 Hard Fault Interrupt                                            */
   MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M3 Memory Management Interrupt                           */
   BusFault_IRQn               = -11,    /*!< 5 Cortex-M3 Bus Fault Interrupt                                   */
   UsageFault_IRQn             = -10,    /*!< 6 Cortex-M3 Usage Fault Interrupt                                 */

--- a/services/src/led_service.cpp
+++ b/services/src/led_service.cpp
@@ -24,6 +24,7 @@
 // TODO: Move synchronization macros to some header file
 #if PLATFORM_ID != 3
 
+#define INTERRUPTS_HAL_EXCLUDE_PLATFORM_HEADERS
 #include "spark_wiring_interrupts.h"
 
 #define LED_SERVICE_DECLARE_LOCK(name)

--- a/services/src/panic.c
+++ b/services/src/panic.c
@@ -5,6 +5,7 @@
  *      Author: david_s5
  */
 
+#define INTERRUPTS_HAL_EXCLUDE_PLATFORM_HEADERS
 #include <stdint.h>
 #include "spark_macros.h"
 #include "panic.h"

--- a/user/tests/unit/makefile
+++ b/user/tests/unit/makefile
@@ -92,6 +92,7 @@ INCLUDE_DIRS += $(PLATFORM)MCU/STM32F2xx/SPARK_Firmware_Driver/inc
 # prefix $(SRC_ROOT)
 ABS_INCLUDE_DIRS += $(patsubst %,$(SRC_ROOT)/%,$(INCLUDE_DIRS))
 
+DEFINES += SPARK_NO_PLATFORM
 
 ifeq ("$(BOOST_ROOT)","")
 $(error BOOST_ROOT not defined)

--- a/wiring/inc/spark_wiring_interrupts.h
+++ b/wiring/inc/spark_wiring_interrupts.h
@@ -60,6 +60,9 @@ bool attachSystemInterrupt(hal_irq_t irq, wiring_interrupt_handler_t handler);
  */
 bool detachSystemInterrupt(hal_irq_t irq);
 
+bool attachInterruptDirect(IRQn_Type irq, HAL_Direct_Interrupt_Handler handler, bool enable = true);
+bool detachInterruptDirect(IRQn_Type irq, bool disable = true);
+
 
 class AtomicSection {
 	int prev;

--- a/wiring/src/spark_wiring_interrupts.cpp
+++ b/wiring/src/spark_wiring_interrupts.cpp
@@ -169,3 +169,17 @@ bool detachSystemInterrupt(hal_irq_t irq)
     delete (wiring_interrupt_handler_t*)prev.data;
     return ok;
 }
+
+bool attachInterruptDirect(IRQn_Type irq, HAL_Direct_Interrupt_Handler handler, bool enable)
+{
+    const bool ok = !HAL_Set_Direct_Interrupt_Handler(irq, handler, enable ? HAL_DIRECT_INTERRUPT_FLAG_ENABLE : HAL_DIRECT_INTERRUPT_FLAG_NONE, nullptr);
+    return ok;
+}
+
+bool detachInterruptDirect(IRQn_Type irq, bool disable)
+{
+    const bool ok = !HAL_Set_Direct_Interrupt_Handler(irq, nullptr,
+        HAL_DIRECT_INTERRUPT_FLAG_RESTORE | (disable ? HAL_DIRECT_INTERRUPT_FLAG_DISABLE : HAL_DIRECT_INTERRUPT_FLAG_NONE), nullptr);
+
+    return ok;
+}


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

See #1168 #1333

### Solution

This PR adds two wiring functions `attachInterruptDirect()` and `detachInterruptDirect()` that allow the user code to directly insert interrupt handlers into the interrupt vector table.

### Steps to Test

- `wiring/no_fixture`: `INTERRUPTS_04_attachInterruptDirect`

### Example App

```c++
void pvd_irqn_handler() {
    // Do something
}

void setup() {
    attachInterruptDirect(PVD_IRQn, pvd_irqn_handler);
}

void loop() {

}
```

### References

- Closes #1168 
- Closes #1333
- [CH7827]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] **TODO:** Add documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
