### PR TITLE
"net.rssi" diagnostic data

### DIFF
--- a/system/src/system_network.cpp
+++ b/system/src/system_network.cpp
@@ -19,7 +19,6 @@
 
 #include "spark_wiring_ticks.h"
 #include "spark_wiring_diagnostics.h"
-#include "spark_wiring_fixed_point.h"
 #include "system_setup.h"
 #include "system_network.h"
 #include "system_network_internal.h"
@@ -88,8 +87,7 @@ public:
         if (rssi >= 0) {
             return SYSTEM_ERROR_UNKNOWN;
         }
-        // TODO: FixedPointQ should have a constructor taking an integer value
-        val = FixedPointSQ<8, 8>((float)rssi).value();
+        val = (rssi << 8); // Convert to the Q8.8 fixed point format
         return SYSTEM_ERROR_NONE;
     }
 };

--- a/system/src/system_network.cpp
+++ b/system/src/system_network.cpp
@@ -87,7 +87,7 @@ public:
         if (rssi >= 0) {
             return SYSTEM_ERROR_UNKNOWN;
         }
-        val = (rssi << 8); // Convert to the Q8.8 fixed point format
+        val = ((unsigned)rssi & 0xff) << 8; // Convert to the Q8.8 fixed point format
         return SYSTEM_ERROR_NONE;
     }
 };


### PR DESCRIPTION
### Problem

The system should expose RSSI diagnostic info on platforms that have a wireless network module.

### Solution

Add `net.rssi` diagnostic data source.

### Example App

```cpp
#include "application.h"

namespace {

const Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

bool logDiagData(void* appender, const uint8_t* data, size_t size) {
    Log.write(LOG_LEVEL_INFO, (const char*)data, size);
    return true;
}

} // namespace

void setup() {
    uint16_t id = DIAG_ID_NETWORK_RSSI;
    system_format_diag_data(&id, 1, 0, logDiagData, nullptr, nullptr);
    Log.print("\r\n");
}

void loop() {
}
```

### References

* [ch7642]
* #1390 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
