### PR TITLE
Move global declarations to a namespace

### DIFF
--- a/system/inc/active_object.h
+++ b/system/inc/active_object.h
@@ -31,6 +31,8 @@
 #include "channel.h"
 #include "concurrent_hal.h"
 
+namespace particle {
+
 /**
  * Configuratino data for an active object.
  */
@@ -436,9 +438,11 @@ public:
 
 };
 
+#else
 
+namespace particle {
 
-#endif // PLATFORM_THREADING
+#endif // !PLATFORM_THREADING
 
 /**
  * This class implements a queue of asynchronous calls that can be scheduled from an ISR and then
@@ -466,3 +470,5 @@ private:
     Task* firstTask_; // Task queue
     Task* lastTask_;
 };
+
+} // namespace particle

--- a/system/inc/system_threading.h
+++ b/system/inc/system_threading.h
@@ -20,7 +20,8 @@
 #define	SYSTEM_THREADING_H
 
 #include "active_object.h"
-extern ISRTaskQueue SystemISRTaskQueue;
+
+extern particle::ISRTaskQueue SystemISRTaskQueue;
 
 #if PLATFORM_THREADING
 
@@ -38,12 +39,12 @@ extern ISRTaskQueue SystemISRTaskQueue;
 /**
  * System thread runs on a separate thread
  */
-extern ActiveObjectThreadQueue SystemThread;
+extern particle::ActiveObjectThreadQueue SystemThread;
 
 /**
  * Application queue runs on the calling thread (main)
  */
-extern ActiveObjectCurrentThreadQueue ApplicationThread;
+extern particle::ActiveObjectCurrentThreadQueue ApplicationThread;
 
 #endif
 
@@ -100,7 +101,7 @@ FFL(F const &func)
 
 #define _THREAD_CONTEXT_ASYNC(thread, fn)
 #define _THREAD_CONTEXT_ASYNC_RESULT(thread, fn, result)
-#define SYSTEM_THREAD_CONTEXT_SYNC(fn) 
+#define SYSTEM_THREAD_CONTEXT_SYNC(fn)
 #endif
 
 #define SYSTEM_THREAD_CONTEXT_ASYNC(fn) _THREAD_CONTEXT_ASYNC(SystemThread, fn)

--- a/system/src/active_object.cpp
+++ b/system/src/active_object.cpp
@@ -22,6 +22,8 @@
 #include "spark_wiring_interrupts.h"
 #include "debug.h"
 
+using namespace particle;
+
 #if PLATFORM_THREADING
 
 #include <string.h>

--- a/system/src/system_threading.cpp
+++ b/system/src/system_threading.cpp
@@ -3,6 +3,8 @@
 #include <time.h>
 #include <string.h>
 
+using namespace particle;
+
 #if PLATFORM_THREADING
 
 #define THREAD_STACK_SIZE (5 * 1024)

--- a/user/inc/application.h
+++ b/user/inc/application.h
@@ -84,9 +84,16 @@
 
 #include "stdio.h"
 
+#include "spark_wiring_arduino.h"
+
+#ifndef PARTICLE_NO_GLOBAL_NAMESPACE
 using namespace spark;
 using namespace particle;
-
-#include "spark_wiring_arduino.h"
+#else
+namespace particle {
+// TODO: Move all public APIs to the `particle` namespace
+using namespace spark;
+}
+#endif // defined(PARTICLE_NO_GLOBAL_NAMESPACE)
 
 #endif /* APPLICATION_H_ */


### PR DESCRIPTION
### Problem

Particle APIs get pulled into the global namespace and cause conflicts with an application code. This behavior cannot be overridden by application developers.

### Solution

Add `PARTICLE_NO_GLOBAL_NAMESPACE` macro that can be defined by applications to avoid having Particle APIs declared in the global namespace.

**Note:** This PR doesn't attempt to move all current APIs to the `particle` namespace, and some classes and functions are still declared in the global namespace directly. I suggest we start moving such declarations to namespaces iteratively, on occasion.

### Steps to Test

`wiring/api` test should compile successfully.

### Example App

```cpp
#define PARTICLE_NO_GLOBAL_NAMESPACE

#include "application.h"

// I just need my own WiFi class
class WiFi {
};

void test(WiFi&) {
}
```

### References

* fixes #1267
* [ch8449]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)