### PR TITLE
[Diagnostics] RAM usage diagnostic sources

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -179,6 +179,10 @@ typedef struct runtime_info_t {
     uint16_t flags;             /* reserved, set to 0. */
     uint32_t freeheap;          /* Amount of guaranteed heap memory available. */
     uint32_t system_version;
+    uint32_t total_init_heap;
+    uint32_t total_heap;
+    uint32_t max_used_heap; // The "highwater mark" for allocated space—that is, the maximum amount of space that was ever allocated.
+    uint32_t user_static_ram;
 } runtime_info_t;
 
 uint32_t HAL_Core_Runtime_Info(runtime_info_t* info, void* reserved);

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -59,6 +59,8 @@
 #include "wlan_hal.h"
 #endif
 
+extern char link_heap_location, link_heap_location_end;
+
 #define STOP_MODE_EXIT_CONDITION_PIN 0x01
 #define STOP_MODE_EXIT_CONDITION_RTC 0x02
 
@@ -1239,6 +1241,21 @@ uint32_t HAL_Core_Runtime_Info(runtime_info_t* info, void* reserved)
     struct mallinfo heapinfo = mallinfo();
     // fordblks  The total number of bytes in free blocks.
     info->freeheap = heapinfo.fordblks;
+    if (offsetof(runtime_info_t, total_init_heap) + sizeof(info->total_init_heap) <= info->size) {
+        info->total_init_heap = (uint32_t)(&link_heap_location_end - &link_heap_location);
+    }
+
+    if (offsetof(runtime_info_t, total_heap) + sizeof(info->total_heap) <= info->size) {
+        info->total_heap = heapinfo.arena;
+    }
+
+    if (offsetof(runtime_info_t, max_used_heap) + sizeof(info->max_used_heap) <= info->size) {
+        info->max_used_heap = heapinfo.usmblks;
+    }
+
+    if (offsetof(runtime_info_t, user_static_ram) + sizeof(info->user_static_ram) <= info->size) {
+        info->user_static_ram = info->total_init_heap - info->total_heap;
+    }
 
     return 0;
 }

--- a/services/inc/diagnostics.h
+++ b/services/inc/diagnostics.h
@@ -45,6 +45,8 @@ constexpr const char* DIAG_NAME_CLOUD_DISCONNECTS = "cloud:disconn";
 constexpr const char* DIAG_NAME_CLOUD_REPEATED_MESSAGES = "coap:resend";
 constexpr const char* DIAG_NAME_CLOUD_UNACKNOWLEDGED_MESSAGES = "coap:unack";
 constexpr const char* DIAG_NAME_CLOUD_RATE_LIMITED_EVENTS = "pub:limit";
+constexpr const char* DIAG_NAME_SYSTEM_TOTAL_RAM = "sys:tram";
+constexpr const char* DIAG_NAME_SYSTEM_USED_RAM = "sys:uram";
 
 #endif
 
@@ -72,6 +74,8 @@ typedef enum diag_id {
     DIAG_ID_CLOUD_REPEATED_MESSAGES = 21, // coap:resend
     DIAG_ID_CLOUD_UNACKNOWLEDGED_MESSAGES = 22, // coap:unack
     DIAG_ID_CLOUD_RATE_LIMITED_EVENTS = 20, // pub:throttle
+    DIAG_ID_SYSTEM_TOTAL_RAM = 25, // sys:tram
+    DIAG_ID_SYSTEM_USED_RAM = 26, // sys:uram
     DIAG_ID_USER = 32768 // Base value for application-specific source IDs
 } diag_id;
 


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

**NOTE: This PR targets [feature/diagnostics-merge](https://github.com/spark/firmware/tree/feature/diagnostics-merge) branch**

### Solution

This PR adds the following diagnostic sources:
- Total RAM: ID 25, Type: scalar(32)
  -  Total amount of RAM available on the device in bytes. This value normally equals the size of the region shared by the heap and user application static RAM. Does not include static RAM in use by the system parts.
- Used RAM: ID 26, Type: scalar(32)
  - Amount of RAM used out of "Total RAM" (user application static RAM + heap used).

### Steps to Test

- `d` command in listening mode

### Example App

N/A

### References

- [CH8737]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
