### PR TITLE
[Electron] Power management

### DIFF
--- a/services/inc/diagnostics.h
+++ b/services/inc/diagnostics.h
@@ -31,6 +31,7 @@ constexpr const char* DIAG_NAME_SYSTEM_SYSTEM_LOOPS = "sys:loop";
 constexpr const char* DIAG_NAME_SYSTEM_APPLICATION_LOOPS = "app:loop";
 constexpr const char* DIAG_NAME_SYSTEM_UPTIME = "sys:uptime";
 constexpr const char* DIAG_NAME_SYSTEM_BATTERY_STATE = "batt:state";
+constexpr const char* DIAG_NAME_SYSTEM_POWER_SOURCE = "pwr:src";
 constexpr const char* DIAG_NAME_NETWORK_CONNECTION_STATUS = "net:stat";
 constexpr const char* DIAG_NAME_NETWORK_CONNECTION_ERROR_CODE = "net:err";
 constexpr const char* DIAG_NAME_NETWORK_DISCONNECTS = "net:dx";
@@ -58,6 +59,9 @@ typedef enum diag_id {
     DIAG_ID_SYSTEM_APPLICATION_LOOPS = 5, // app:loops
     DIAG_ID_SYSTEM_UPTIME = 6, // sys:uptime
     DIAG_ID_SYSTEM_BATTERY_STATE = 7, // batt:state
+    // FIXME: id
+    DIAG_ID_SYSTEM_POWER_SOURCE = 32000, // pwr::src
+    // /FIXME
     DIAG_ID_NETWORK_CONNECTION_STATUS = 8, // net:stat
     DIAG_ID_NETWORK_CONNECTION_ERROR_CODE = 9, // net:error
     DIAG_ID_NETWORK_DISCONNECTS = 12, // net:disconn

--- a/services/inc/diagnostics.h
+++ b/services/inc/diagnostics.h
@@ -59,9 +59,7 @@ typedef enum diag_id {
     DIAG_ID_SYSTEM_APPLICATION_LOOPS = 5, // app:loops
     DIAG_ID_SYSTEM_UPTIME = 6, // sys:uptime
     DIAG_ID_SYSTEM_BATTERY_STATE = 7, // batt:state
-    // FIXME: id
-    DIAG_ID_SYSTEM_POWER_SOURCE = 32000, // pwr::src
-    // /FIXME
+    DIAG_ID_SYSTEM_POWER_SOURCE = 24, // pwr::src
     DIAG_ID_NETWORK_CONNECTION_STATUS = 8, // net:stat
     DIAG_ID_NETWORK_CONNECTION_ERROR_CODE = 9, // net:error
     DIAG_ID_NETWORK_DISCONNECTS = 12, // net:disconn

--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -57,6 +57,9 @@ enum SystemEvents {
     button_final_click = 1<<13,     // generated for last click in series - data is the number of clicks in the lower 4 bits.
     time_changed = 1<<14,
     low_battery = 1<<15,            // generated when low battery condition is detected
+    battery_state = 1<<16,
+    power_source = 1<<17,
+
 
     all_events = 0xFFFFFFFFFFFFFFFF
 };

--- a/system/inc/system_power.h
+++ b/system/inc/system_power.h
@@ -55,5 +55,4 @@ extern particle::SimpleEnumDiagnosticData<particle::power::battery_state_t> g_ba
 extern particle::SimpleEnumDiagnosticData<particle::power::power_source_t> g_powerSource;
 
 void system_power_management_init();
-void system_power_management_update();
 void system_power_management_sleep(bool sleep = true);

--- a/system/inc/system_power.h
+++ b/system/inc/system_power.h
@@ -35,13 +35,24 @@ typedef enum {
     BATTERY_STATE_CHARGING = 2,
     BATTERY_STATE_CHARGED = 3,
     BATTERY_STATE_DISCHARGING = 4,
-    BATTERY_STATE_FAULT = 5
-} BatteryState;
+    BATTERY_STATE_FAULT = 5,
+    BATTERY_STATE_DISCONNECTED = 6
+} battery_state_t;
+
+typedef enum {
+    POWER_SOURCE_UNKNOWN = 0,
+    POWER_SOURCE_VIN = 1,
+    POWER_SOURCE_USB_HOST = 2,
+    POWER_SOURCE_USB_ADAPTER = 3,
+    POWER_SOURCE_USB_OTG = 4,
+    POWER_SOURCE_BATTERY = 5
+} power_source_t;
 
 } } // particle::power
 
 extern particle::power::BatteryChargeDiagnosticData g_batteryCharge;
-extern particle::SimpleEnumDiagnosticData<particle::power::BatteryState> g_batteryState;
+extern particle::SimpleEnumDiagnosticData<particle::power::battery_state_t> g_batteryState;
+extern particle::SimpleEnumDiagnosticData<particle::power::power_source_t> g_powerSource;
 
 void system_power_management_init();
 void system_power_management_update();

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -277,9 +277,6 @@ protected:
                 }
                 console.loop();
             }
-#if Wiring_Cellular == 1
-            system_power_management_update();
-#endif
 #if PLATFORM_THREADING
             SystemISRTaskQueue.process();
             if (!APPLICATION_THREAD_CURRENT()) {

--- a/system/src/system_power.cpp
+++ b/system/src/system_power.cpp
@@ -1,14 +1,13 @@
 #include "system_power.h"
 #include "spark_wiring_platform.h"
-#include "spark_wiring_power.h"
 #include "spark_wiring_fuel.h"
 #include "spark_wiring_diagnostics.h"
 #include "spark_wiring_fixed_point.h"
 #include "debug.h"
 
 #if Wiring_Cellular == 1
-/* flag used to initiate system_power_management_update() from main thread */
-static volatile bool SYSTEM_POWER_MGMT_UPDATE = true;
+
+#include "system_power_manager.h"
 
 namespace particle { namespace power {
 
@@ -18,7 +17,7 @@ BatteryChargeDiagnosticData::BatteryChargeDiagnosticData(uint16_t id, const char
 
 int BatteryChargeDiagnosticData::get(IntType& val) {
     FuelGauge fuel(true);
-    float soc = fuel.getSoC();
+    float soc = fuel.getNormalizedSoC();
     val = particle::FixedPointUQ<8, 8>(soc);
     return SYSTEM_ERROR_NONE;
 }
@@ -29,254 +28,21 @@ using namespace particle;
 using namespace particle::power;
 
 BatteryChargeDiagnosticData g_batteryCharge(DIAG_ID_SYSTEM_BATTERY_CHARGE, DIAG_NAME_SYSTEM_BATTERY_CHARGE);
-SimpleEnumDiagnosticData<BatteryState> g_batteryState(DIAG_ID_SYSTEM_BATTERY_STATE, DIAG_NAME_SYSTEM_BATTERY_STATE, BATTERY_STATE_UNKNOWN);
-
-static bool s_lowBattEventEnabled = true;
-static system_tick_t s_possibleFaultTimestamp = 0;
-static uint32_t s_possibleFaultCounter = 0;
-
-void system_power_log_stat(uint8_t stat, uint8_t fault);
-void system_power_handle_state_change(BatteryState from, BatteryState to, bool low);
-
-/*******************************************************************************
- * Function Name  : Power_Management_Handler
- * Description    : Sets default power management IC charging rate when USB
-                    input power source changes or low battery indicated by
-                    fuel gauge IC.
- * Output         : SYSTEM_POWER_MGMT_UPDATE is set to true.
- *******************************************************************************/
-extern "C" void Power_Management_Handler(void)
-{
-    SYSTEM_POWER_MGMT_UPDATE = true;
-}
-
-void system_power_init_default_params() {
-    PMIC power(true);
-    power.begin();
-    power.disableWatchdog();
-    power.disableDPDM();
-    // power.setInputVoltageLimit(4360); // default
-    power.setInputCurrentLimit(900);     // 900mA
-    power.setChargeCurrent(0,0,0,0,0,0); // 512mA
-    power.setChargeVoltage(4112);        // 4.112V termination voltage
-    power.enableCharging();
-}
+SimpleEnumDiagnosticData<battery_state_t> g_batteryState(DIAG_ID_SYSTEM_BATTERY_STATE, DIAG_NAME_SYSTEM_BATTERY_STATE, BATTERY_STATE_UNKNOWN);
+SimpleEnumDiagnosticData<power_source_t> g_powerSource(DIAG_ID_SYSTEM_POWER_SOURCE, DIAG_NAME_SYSTEM_POWER_SOURCE, POWER_SOURCE_UNKNOWN);
 
 void system_power_management_init()
 {
-    INFO("Power Management Initializing.");
-    system_power_init_default_params();
-    FuelGauge fuel(true);
-    fuel.wakeup();
-    fuel.setAlertThreshold(10); // Low Battery alert at 10% (about 3.6V)
-    fuel.clearAlert(); // Ensure this is cleared, or interrupts will never occur
-    INFO("State of Charge: %-6.2f%%", fuel.getSoC());
-    INFO("Battery Voltage: %-4.2fV", fuel.getVCell());
-    attachInterrupt(LOW_BAT_UC, Power_Management_Handler, FALLING);
-
-    system_power_management_update();
+    PowerManager::instance()->init();
 }
 
 void system_power_management_sleep(bool sleep) {
-    // When going into sleep we do not want to exceed the default charging parameters set
-    // by system_power_init_default_params(), which will be reset in case we are in a fault mode with
-    // PMIC watchdog enabled. Reset to the defaults and disable watchdog before going into sleep.
-    if (sleep && g_batteryState == BATTERY_STATE_FAULT) {
-        system_power_init_default_params();
-        SYSTEM_POWER_MGMT_UPDATE = true;
-    }
+    PowerManager::instance()->sleep(sleep);
 }
 
-void system_power_management_update()
-{
-    if (!SYSTEM_POWER_MGMT_UPDATE) {
-        return;
-    }
+#else /* Wiring_Cellular != 1 */
 
-    SYSTEM_POWER_MGMT_UPDATE = false;
-
-    PMIC power(true);
-    FuelGauge fuel(true);
-    power.begin();
-
-    // In order to read the current fault status, the host has to read REG09 two times
-    // consecutively. The 1st reads fault register status from the last read and the 2nd
-    // reads the current fault register status.
-    const uint8_t lastFault = power.getFault();
-    const uint8_t curFault = power.getFault();
-
-    const uint8_t status = power.getSystemStatus();
-
-    // Watchdog fault
-    if ((curFault | lastFault) & 0x80) {
-        // Restore parameters
-        system_power_init_default_params();
-    }
-
-    BatteryState state = BATTERY_STATE_UNKNOWN;
-
-    // Deduce current battery state
-    const uint8_t chrg_stat = (status >> 4) & 0b11;
-    if (chrg_stat) {
-        // Charging or charged
-        if (chrg_stat == 0b11) {
-            state = BATTERY_STATE_CHARGED;
-        } else {
-            state = BATTERY_STATE_CHARGING;
-        }
-    } else {
-        // For now we only know that the battery is not charging
-        state = BATTERY_STATE_NOT_CHARGING;
-        // Now we need to deduce whether it is NOT_CHARGING, DISCHARGING, or in a FAULT state
-        // const uint8_t chrg_fault = (curFault >> 4) & 0b11;
-        const uint8_t bat_fault = (curFault >> 3) & 0b01;
-        // const uint8_t ntc_fault = curFault & 0b111;
-        const uint8_t pwr_good = (status >> 2) & 0b01;
-        if (bat_fault) {
-            state = BATTERY_STATE_FAULT;
-        } else if (!pwr_good) {
-            state = BATTERY_STATE_DISCHARGING;
-        }
-    }
-
-    const bool lowBat = fuel.getAlert();
-    system_power_handle_state_change(g_batteryState, state, lowBat);
-
-    if (lowBat) {
-        fuel.clearAlert();
-        if (s_lowBattEventEnabled) {
-            s_lowBattEventEnabled = false;
-            system_notify_event(low_battery);
-        }
-    }
-
-    system_power_log_stat(status, curFault);
-}
-
-BatteryState system_power_handle_possible_fault(BatteryState from, BatteryState to) {
-    if (from == BATTERY_STATE_CHARGED || from == BATTERY_STATE_CHARGING) {
-        system_tick_t m = millis();
-        if (m - s_possibleFaultTimestamp > 1000) {
-            s_possibleFaultTimestamp = m;
-            s_possibleFaultCounter = 0;
-        } else {
-            s_possibleFaultCounter++;
-            if (s_possibleFaultCounter > 5) {
-                return BATTERY_STATE_FAULT;
-            }
-        }
-    }
-    return to;
-}
-
-void system_power_handle_state_change(BatteryState from, BatteryState to, bool low) {
-    BatteryState toOriginal = to;
-
-    switch (from) {
-        case BATTERY_STATE_CHARGING:
-        case BATTERY_STATE_CHARGED: {
-            if (!low) {
-                to = system_power_handle_possible_fault(from, to);
-            }
-            break;
-        }
-        default: {
-            if (from == to) {
-                // No state change occured
-                return;
-            }
-        }
-    }
-
-    switch (from) {
-        case BATTERY_STATE_UNKNOWN:
-            break;
-        case BATTERY_STATE_NOT_CHARGING: {
-            if (to == BATTERY_STATE_CHARGING) {
-                // Reconfigure the PMIC current limits due to possible input source change
-                system_power_init_default_params();
-            }
-            break;
-        }
-        case BATTERY_STATE_CHARGING:
-            break;
-        case BATTERY_STATE_CHARGED:
-            break;
-        case BATTERY_STATE_DISCHARGING:
-            break;
-        case BATTERY_STATE_FAULT: {
-            // When going from FAULT state to any other state, reset FuelGauge
-            FuelGauge fuel;
-            fuel.quickStart();
-
-            system_power_init_default_params();
-            break;
-        }
-    }
-
-    switch (to) {
-        case BATTERY_STATE_CHARGING: {
-            // When going into CHARGING state, enable low battery event
-            s_lowBattEventEnabled = true;
-            break;
-        }
-        case BATTERY_STATE_UNKNOWN:
-            break;
-        case BATTERY_STATE_NOT_CHARGING:
-            break;
-        case BATTERY_STATE_CHARGED:
-            break;
-        case BATTERY_STATE_DISCHARGING:
-            break;
-        case BATTERY_STATE_FAULT: {
-            if (from != to && to != toOriginal) {
-                // A fault condition was detected by system_power_handle_possible_fault()
-                PMIC power;
-                // Enable watchdog that should re-enable charging in 40 seconds
-                power.setWatchdog(0b01);
-                // Disable charging
-                power.disableCharging();
-            }
-            break;
-        }
-    }
-
-    g_batteryState = to;
-
-#if defined(DEBUG_BUILD) || 1
-    static const char* states[] = {
-        "UNKNOWN",
-        "NOT_CHARGING",
-        "CHARGING",
-        "CHARGED",
-        "DISCHARGING",
-        "FAULT"
-    };
-    LOG(TRACE, "Battery state %s -> %s", states[from], states[to]);
-#endif // defined(DEBUG_BUILD)
-}
-
-void system_power_log_stat(uint8_t stat, uint8_t fault) {
-#if defined(DEBUG_BUILD) && 0
-    if (LOG_ENABLED(TRACE)) {
-        uint8_t vbus_stat = stat >> 6; // 0 – Unknown (no input, or DPDM detection incomplete), 1 – USB host, 2 – Adapter port, 3 – OTG
-        uint8_t chrg_stat = (stat >> 4) & 0x03; // 0 – Not Charging, 1 – Pre-charge (<VBATLOWV), 2 – Fast Charging, 3 – Charge Termination Done
-        bool dpm_stat = stat & 0x08;   // 0 – Not DPM, 1 – VINDPM or IINDPM
-        bool pg_stat = stat & 0x04;    // 0 – Not Power Good, 1 – Power Good
-        bool therm_stat = stat & 0x02; // 0 – Normal, 1 – In Thermal Regulation
-        bool vsys_stat = stat & 0x01;  // 0 – Not in VSYSMIN regulation (BAT > VSYSMIN), 1 – In VSYSMIN regulation (BAT < VSYSMIN)
-        bool wd_fault = fault & 0x80;  // 0 – Normal, 1- Watchdog timer expiration
-        uint8_t chrg_fault = (fault >> 4) & 0x03; // 0 – Normal, 1 – Input fault (VBUS OVP or VBAT < VBUS < 3.8 V),
-                                                  // 2 - Thermal shutdown, 3 – Charge Safety Timer Expiration
-        bool bat_fault = fault & 0x08;    // 0 – Normal, 1 – BATOVP
-        uint8_t ntc_fault = fault & 0x07; // 0 – Normal, 5 – Cold, 6 – Hot
-        LOG(TRACE, "[ PMIC STAT ] VBUS:%d CHRG:%d DPM:%d PG:%d THERM:%d VSYS:%d", vbus_stat, chrg_stat, dpm_stat, pg_stat, therm_stat, vsys_stat);
-        LOG(TRACE, "[ PMIC FAULT ] WATCHDOG:%d CHRG:%d BAT:%d NTC:%d", wd_fault, chrg_fault, bat_fault, ntc_fault);
-        delay(50);
-    }
-#endif
-}
-#else
 void system_power_management_sleep(bool sleep) {
 }
-#endif
+
+#endif /* Wiring_Cellular == 1 */

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -1,0 +1,367 @@
+#include "logging.h"
+LOG_SOURCE_CATEGORY("sys.power")
+
+#include "system_power.h"
+#include "system_power_manager.h"
+#include "spark_wiring_fuel.h"
+#include "spark_wiring_power.h"
+#include "concurrent_hal.h"
+#include "debug.h"
+#include "spark_wiring_platform.h"
+#include "pinmap_hal.h"
+
+#if Wiring_Cellular == 1
+
+using namespace particle::power;
+
+volatile bool PowerManager::update_ = true;
+
+PowerManager::PowerManager() {
+  os_queue_create(&queue_, sizeof(update_), 1, nullptr);
+  SPARK_ASSERT(queue_ != nullptr);
+}
+
+PowerManager* PowerManager::instance() {
+  static PowerManager mng;
+  return &mng;
+}
+
+void PowerManager::init() {
+  os_thread_create(&thread_, "pwr", OS_THREAD_PRIORITY_CRITICAL, &PowerManager::loop, nullptr,
+#if defined(DEBUG_BUILD)
+    4 * 1024);
+#else
+    512);
+#endif // defined(DEBUIG_BUILD)
+  SPARK_ASSERT(thread_ != nullptr);
+}
+
+void PowerManager::update() {
+  update_ = true;
+  os_queue_put(queue_, (const void*)&update_, 0, nullptr);
+}
+
+void PowerManager::sleep(bool s) {
+  // When going into sleep we do not want to exceed the default charging parameters set
+  // by initDefault(), which will be reset in case we are in a DISCONNECTED state with
+  // PMIC watchdog enabled. Reset to the defaults and disable watchdog before going into sleep.
+  if (s) {
+    // Going into sleep
+    if (g_batteryState == BATTERY_STATE_DISCONNECTED) {
+      initDefault();
+    }
+  } else {
+    // Wake up
+    initDefault();
+    update();
+  }
+}
+
+void PowerManager::handleUpdate() {
+  if (!update_) {
+    return;
+  }
+
+  update_ = false;
+
+  PMIC power(true);
+  FuelGauge fuel(true);
+
+  // In order to read the current fault status, the host has to read REG09 two times
+  // consecutively. The 1st reads fault register status from the last read and the 2nd
+  // reads the current fault register status.
+  const uint8_t lastFault = power.getFault();
+  (void)lastFault;
+  const uint8_t curFault = power.getFault();
+  const uint8_t status = power.getSystemStatus();
+  const uint8_t misc = power.readOpControlRegister();
+
+  // Watchdog fault
+  if ((curFault) & 0x80) {
+    // Restore parameters
+    initDefault();
+  }
+
+  battery_state_t state = BATTERY_STATE_UNKNOWN;
+
+  const uint8_t pwr_good = (status >> 2) & 0b01;
+
+  // Deduce current battery state
+  const uint8_t chrg_stat = (status >> 4) & 0b11;
+  if (chrg_stat) {
+    // Charging or charged
+    if (chrg_stat == 0b11) {
+      state = BATTERY_STATE_CHARGED;
+    } else {
+      state = BATTERY_STATE_CHARGING;
+    }
+  } else {
+    // For now we only know that the battery is not charging
+    state = BATTERY_STATE_NOT_CHARGING;
+    // Now we need to deduce whether it is NOT_CHARGING, DISCHARGING, or in a FAULT state
+    // const uint8_t chrg_fault = (curFault >> 4) & 0b11;
+    const uint8_t bat_fault = (curFault >> 3) & 0b01;
+    // const uint8_t ntc_fault = curFault & 0b111;
+    if (bat_fault) {
+      state = BATTERY_STATE_FAULT;
+    } else if (!pwr_good) {
+      state = BATTERY_STATE_DISCHARGING;
+    }
+  }
+
+  const bool lowBat = fuel.getAlert();
+  handleStateChange(g_batteryState, state, lowBat);
+
+  power_source_t src = g_powerSource;
+  if (pwr_good) {
+    uint8_t vbus_stat = status >> 6;
+    switch (vbus_stat) {
+      case 0x01:
+        src = POWER_SOURCE_USB_HOST;
+        break;
+      case 0x02:
+        src = POWER_SOURCE_USB_ADAPTER;
+        break;
+      case 0x03:
+        src = POWER_SOURCE_USB_OTG;
+        break;
+      case 0x00:
+      default:
+        if ((misc & 0x80) == 0x00) {
+          // Not in DPDM detection anymore
+          src = POWER_SOURCE_VIN;
+          // It's not easy to detect when DPDM detection actually finishes,
+          // so just check input current source register whenever we are in this state
+          if (power.getInputCurrentLimit() != DEFAULT_INPUT_CURRENT_LIMIT) {
+            power.setInputCurrentLimit(DEFAULT_INPUT_CURRENT_LIMIT);
+          }
+        }
+        break;
+    }
+  } else {
+    if (g_batteryState == BATTERY_STATE_DISCHARGING) {
+      src = POWER_SOURCE_BATTERY;
+    } else {
+      src = POWER_SOURCE_UNKNOWN;
+    }
+  }
+
+  if (g_powerSource != src) {
+    g_powerSource = src;
+    system_notify_event(power_source, (int)g_powerSource);
+  }
+
+  if (lowBat) {
+    fuel.clearAlert();
+    if (lowBatEnabled_) {
+      lowBatEnabled_ = false;
+      system_notify_event(low_battery);
+    }
+  }
+
+  logStat(status, curFault);
+}
+
+void PowerManager::loop(void* arg) {
+  PowerManager* self = PowerManager::instance();
+  {
+    LOG_DEBUG(INFO, "Power Management Initializing.");
+    self->initDefault();
+    FuelGauge fuel(true);
+    fuel.wakeup();
+    fuel.setAlertThreshold(20); // Low Battery alert at 10% (about 3.6V)
+    fuel.clearAlert(); // Ensure this is cleared, or interrupts will never occur
+    LOG_DEBUG(INFO, "State of Charge: %-6.2f%%", fuel.getSoC());
+    LOG_DEBUG(INFO, "Battery Voltage: %-4.2fV", fuel.getVCell());
+    attachInterrupt(LOW_BAT_UC, &PowerManager::isrHandler, FALLING);
+  }
+
+  uint32_t tmp;
+  while (true) {
+    os_queue_take(self->queue_, &tmp, DEFAULT_QUEUE_WAIT, nullptr);
+    while (self->update_) {
+      self->handleUpdate();
+    }
+    self->handlePossibleFaultLoop();
+  }
+}
+
+void PowerManager::isrHandler() {
+  PowerManager* self = PowerManager::instance();
+  self->update();
+}
+
+void PowerManager::initDefault() {
+  PMIC power(true);
+  power.begin();
+  // Enters host-managed mode
+  power.disableWatchdog();
+
+  // Adjust charge voltage
+  power.setChargeVoltage(4112);        // 4.112V termination voltage
+
+  // Set recharge threshold to default value - 100mV
+  power.setRechargeThreshold(100);
+  // power.setChargeCurrent(0,0,0,0,0,0); // 512mA
+  // Force-start input current limit detection
+  power.enableDPDM();
+  // Enable charging
+  power.enableCharging();
+
+  faultSuppressed_ = 0;
+
+  /* This only disables currently running detection, whenever the power source changes,
+   * the DPDM detection will run again
+   */
+  // power.disableDPDM();
+
+  /* Every time the power source changes, bq24195 will run current limit detection
+   * and will change the limit anyway. This limit is instead adjusted in update()
+   * under certain conditions.
+   */
+  // power.setInputCurrentLimit(900);     // 900mA
+}
+
+void PowerManager::handleStateChange(battery_state_t from, battery_state_t to, bool low) {
+  switch (from) {
+    case BATTERY_STATE_CHARGING:
+    case BATTERY_STATE_CHARGED: {
+      if (!low) {
+        to = handlePossibleFault(from, to);
+      }
+    }
+    // NOTE: fall-through
+    default: {
+      if (from == to) {
+        // No state change occured
+        return;
+      }
+    }
+  }
+
+  switch (from) {
+    case BATTERY_STATE_UNKNOWN:
+      break;
+    case BATTERY_STATE_NOT_CHARGING:
+      break;
+    case BATTERY_STATE_CHARGING:
+      break;
+    case BATTERY_STATE_CHARGED:
+      break;
+    case BATTERY_STATE_DISCHARGING:
+      break;
+    case BATTERY_STATE_FAULT:
+      break;
+    case BATTERY_STATE_DISCONNECTED: {
+      // When going from DISCONNECTED state to any other state quick start fuel gauge
+      FuelGauge fuel;
+      fuel.quickStart();
+
+      initDefault();
+    }
+    break;
+  }
+
+  switch (to) {
+    case BATTERY_STATE_CHARGING: {
+      // When going into CHARGING state, enable low battery event
+      lowBatEnabled_ = true;
+      break;
+    }
+    case BATTERY_STATE_CHARGED:
+      break;
+    case BATTERY_STATE_UNKNOWN:
+      break;
+    case BATTERY_STATE_NOT_CHARGING:
+      break;
+    case BATTERY_STATE_DISCHARGING:
+      break;
+    case BATTERY_STATE_FAULT:
+      break;
+    case BATTERY_STATE_DISCONNECTED: {
+      PMIC power;
+      // Disable charging
+      power.disableCharging();
+      // Enable watchdog that should re-enable charging in 40 seconds
+      power.setWatchdog(0b01);
+      break;
+    }
+  }
+
+  if (from == to) {
+      return;
+  }
+
+  g_batteryState = to;
+
+  system_notify_event(battery_state, (int)g_batteryState);
+
+#if defined(DEBUG_BUILD)
+  static const char* states[] = {
+    "UNKNOWN",
+    "NOT_CHARGING",
+    "CHARGING",
+    "CHARGED",
+    "DISCHARGING",
+    "FAULT",
+    "DISCONNECTED"
+  };
+  LOG_DEBUG(TRACE, "Battery state %s -> %s", states[from], states[to]);
+#endif // defined(DEBUG_BUILD)
+}
+
+battery_state_t PowerManager::handlePossibleFault(battery_state_t from, battery_state_t to) {
+  if (to == BATTERY_STATE_CHARGED || to == BATTERY_STATE_CHARGING) {
+    system_tick_t m = millis();
+    if (m - possibleFaultTimestamp_ > DEFAULT_FAULT_WINDOW) {
+      possibleFaultTimestamp_ = m;
+      possibleFaultCounter_ = 0;
+      faultSecondaryCounter_ = 0;
+    } else {
+      possibleFaultCounter_++;
+      if (possibleFaultCounter_ >= DEFAULT_FAULT_COUNT_THRESHOLD &&
+         (faultSuppressed_ == 0 || (m - faultSuppressed_ >= DEFAULT_FAULT_SUPPRESSION_PERIOD))) {
+        if (faultSecondaryCounter_ > 0) {
+          faultSecondaryCounter_ = 0;
+          return BATTERY_STATE_DISCONNECTED;
+        } else {
+          PMIC power;
+          power.setRechargeThreshold(300);
+          possibleFaultCounter_ = 0;
+          faultSecondaryCounter_ = 1;
+          possibleFaultTimestamp_ = millis();
+        }
+      }
+    }
+  }
+  return to;
+}
+
+void PowerManager::handlePossibleFaultLoop() {
+  if (faultSecondaryCounter_ == 1 && (millis() - possibleFaultTimestamp_ > DEFAULT_FAULT_WINDOW)) {
+      PMIC power;
+      power.setRechargeThreshold(100);
+      faultSecondaryCounter_ = 0;
+      faultSuppressed_ = millis();
+  }
+}
+
+void PowerManager::logStat(uint8_t stat, uint8_t fault) {
+#if defined(DEBUG_BUILD)
+  uint8_t vbus_stat = stat >> 6; // 0 – Unknown (no input, or DPDM detection incomplete), 1 – USB host, 2 – Adapter port, 3 – OTG
+  uint8_t chrg_stat = (stat >> 4) & 0x03; // 0 – Not Charging, 1 – Pre-charge (<VBATLOWV), 2 – Fast Charging, 3 – Charge Termination Done
+  bool dpm_stat = stat & 0x08;   // 0 – Not DPM, 1 – VINDPM or IINDPM
+  bool pg_stat = stat & 0x04;    // 0 – Not Power Good, 1 – Power Good
+  bool therm_stat = stat & 0x02; // 0 – Normal, 1 – In Thermal Regulation
+  bool vsys_stat = stat & 0x01;  // 0 – Not in VSYSMIN regulation (BAT > VSYSMIN), 1 – In VSYSMIN regulation (BAT < VSYSMIN)
+  bool wd_fault = fault & 0x80;  // 0 – Normal, 1- Watchdog timer expiration
+  uint8_t chrg_fault = (fault >> 4) & 0x03; // 0 – Normal, 1 – Input fault (VBUS OVP or VBAT < VBUS < 3.8 V),
+                                            // 2 - Thermal shutdown, 3 – Charge Safety Timer Expiration
+  bool bat_fault = fault & 0x08;    // 0 – Normal, 1 – BATOVP
+  uint8_t ntc_fault = fault & 0x07; // 0 – Normal, 5 – Cold, 6 – Hot
+  LOG_DEBUG(TRACE, "[ PMIC STAT ] VBUS:%d CHRG:%d DPM:%d PG:%d THERM:%d VSYS:%d", vbus_stat, chrg_stat, dpm_stat, pg_stat, therm_stat, vsys_stat);
+  LOG_DEBUG(TRACE, "[ PMIC FAULT ] WATCHDOG:%d CHRG:%d BAT:%d NTC:%d", wd_fault, chrg_fault, bat_fault, ntc_fault);
+#endif
+}
+
+#endif /* Wiring_Cellular == 1 */

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -1,0 +1,45 @@
+#include "system_power.h"
+#include <cstdint>
+
+namespace particle { namespace power {
+
+static const uint16_t DEFAULT_INPUT_CURRENT_LIMIT = 900;
+static const system_tick_t DEFAULT_FAULT_WINDOW = 1000;
+static const uint32_t DEFAULT_FAULT_COUNT_THRESHOLD = 5;
+static const system_tick_t DEFAULT_FAULT_SUPPRESSION_PERIOD = 60000;
+static const system_tick_t DEFAULT_QUEUE_WAIT = 1000;
+
+class PowerManager {
+public:
+  static PowerManager* instance();
+
+  void init();
+  void sleep(bool s = true);
+
+protected:
+  PowerManager();
+
+private:
+  static void loop(void* arg);
+  static void isrHandler();
+  void update();
+  void handleUpdate();
+  void initDefault();
+  void handleStateChange(battery_state_t from, battery_state_t to, bool low);
+  battery_state_t handlePossibleFault(battery_state_t from, battery_state_t to);
+  void handlePossibleFaultLoop();
+  void logStat(uint8_t stat, uint8_t fault);
+
+private:
+  static volatile bool update_;
+  os_thread_t thread_ = nullptr;
+  os_queue_t queue_ = nullptr;
+  system_tick_t faultSuppressed_ = 0;
+  uint32_t faultSecondaryCounter_ = 0;
+  uint32_t possibleFaultCounter_ = 0;
+  system_tick_t possibleFaultTimestamp_ = 0;
+  bool lowBatEnabled_ = true;
+};
+
+
+} } // particle::power

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -449,10 +449,6 @@ void Spark_Idle_Events(bool force_events/*=false*/)
         system_pending_shutdown();
     }
     system_shutdown_if_needed();
-
-#if Wiring_Cellular == 1
-    system_power_management_update();
-#endif
 }
 
 /*

--- a/wiring/inc/spark_wiring_fuel.h
+++ b/wiring/inc/spark_wiring_fuel.h
@@ -58,6 +58,7 @@ class FuelGauge {
     boolean begin();
     float getVCell();
     float getSoC();
+    float getNormalizedSoC();
     int getVersion();
     byte getCompensateValue();
     byte getAlertThreshold();

--- a/wiring/inc/spark_wiring_power.h
+++ b/wiring/inc/spark_wiring_power.h
@@ -64,7 +64,7 @@ public:
     bool enableBuck(void);
     bool disableBuck(void);
     bool setInputCurrentLimit(uint16_t current);
-    byte getInputCurrentLimit(void);
+    uint16_t getInputCurrentLimit(void);
     bool setInputVoltageLimit(uint16_t voltage);
     byte getInputVoltageLimit(void);
 
@@ -91,6 +91,7 @@ public:
     //Charge Voltage Control Register
     bool setChargeVoltage(uint16_t voltage);
     byte getChargeVoltage();
+    uint16_t getChargeVoltageValue();
 
     //CHARGE_TIMER_CONTROL_REGISTER
     byte readChargeTermRegister();
@@ -102,6 +103,10 @@ public:
     //Thermal Regulation Control Register
     bool setThermalRegulation();
     byte getThermalRegulation();
+
+    // Recharge threshold
+    uint16_t getRechargeThreshold();
+    bool setRechargeThreshold(uint16_t voltage);
 
     //Misc Operation Control Register
     byte readOpControlRegister();


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Solution

This PR:
- Adds `DIAG_ID_SYSTEM_POWER_SOURCE` diagnostics data source:
  - `POWER_SOURCE_UNKNOWN = 0`
    - Default value
  - `POWER_SOURCE_VIN = 1`
    - The device is being powered by VIN pin or a non-compliant USB-charger
  - `POWER_SOURCE_USB_HOST = 2`
    - The device is being powered by a USB Host
  - `POWER_SOURCE_USB_ADAPTER = 3`
    - The device is being powered by a compliant USB-charger
  - `POWER_SOURCE_USB_OTG = 4`
    - The device is being powered by an [USB-OTG device](https://en.wikipedia.org/wiki/USB_On-The-Go) (e.g. phone, tablet etc)
  - `POWER_SOURCE_BATTERY = 5`
    - The device is being powered from battery (battery state diagnostic should indicate `BATTERY_STATE_DISCHARGING`)
- Introduces a number of changes to Electron's power management (**TODO:** write documentation explaining new behavior and peculiarities)
- Adds new battery state `BATTERY_STATE_DISCONNECTED`
- Adds two new system events that replicate battery state and power source diagnostic data sources:
  - `battery_state`
  - `power_source`
- Modifies battery state of charge diagnostic to report logical value based on termination voltage (upper bound) and fixed (physical 20% of charge) lower bound (see https://github.com/spark/firmware/compare/feature/diagnostics-merge...feature/power-management?expand=1#diff-1138d49e8c7669f2b798c130b6a61046R89)

### Steps to Test

N/A

### Example App

N/A

### References

- Supersedes #1398, #1395
- [CH8644]
- [CH8643]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
