### PR TITLE
Bootloader downgrade (0.6.x)

### DIFF
--- a/hal/src/stm32f2xx/bootloader.cpp
+++ b/hal/src/stm32f2xx/bootloader.cpp
@@ -44,7 +44,7 @@ bool bootloader_requires_update(const uint8_t* bootloader_image, uint32_t length
         return false;
 
     const uint32_t VERSION_OFFSET = 0x184+10;
-    const unsigned BOOTLOADER_0_7_0 = 13; // Module version of the bootloader shipped with 0.7.0
+    const unsigned BOOTLOADER_0_7_0 = 100; // Module version of the bootloader shipped with 0.7.0
 
     uint16_t current_version = *(uint16_t*)(0x8000000+VERSION_OFFSET);
     uint16_t available_version = *(uint16_t*)(bootloader_image+VERSION_OFFSET);

--- a/hal/src/stm32f2xx/bootloader.cpp
+++ b/hal/src/stm32f2xx/bootloader.cpp
@@ -44,11 +44,13 @@ bool bootloader_requires_update(const uint8_t* bootloader_image, uint32_t length
         return false;
 
     const uint32_t VERSION_OFFSET = 0x184+10;
+    const unsigned BOOTLOADER_0_7_0 = 13; // Module version of the bootloader shipped with 0.7.0
 
     uint16_t current_version = *(uint16_t*)(0x8000000+VERSION_OFFSET);
     uint16_t available_version = *(uint16_t*)(bootloader_image+VERSION_OFFSET);
 
-    bool requires_update = current_version<available_version;
+    // Downgrading from 0.7.0 requires a bootloader downgrade
+    bool requires_update = (current_version < available_version || current_version >= BOOTLOADER_0_7_0);
     return requires_update;
 }
 

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -376,7 +376,9 @@ void HAL_Core_Setup(void) {
 
     HAL_Core_Setup_finalize();
 
-    bootloader_update_if_needed();
+    if (bootloader_update_if_needed()) {
+        HAL_Core_System_Reset();
+    }
     HAL_Bootloader_Lock(true);
 
     HAL_save_device_id(DCT_DEVICE_ID_OFFSET);


### PR DESCRIPTION
### Problem

When downgrading from 0.7.0 to 0.6.x firmware, the bootloader needs to be downgraded along with other system modules (see [Release notes](https://github.com/spark/firmware/releases/tag/v0.7.0-rc.3)). This PR simplifies the procedure by making the system automatically downgrade the bootloader if necessary.

### Steps to Test

Flash 0.7.0 firmware binaries (including bootloader) to a device, and ensure that the system can be downgraded to 0.6.x following the regular downgrade procedure.

### References

- [CH8765]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
