### PR TITLE
Bootloader downgrade (0.5.x)

### DIFF
--- a/hal/src/stm32f2xx/bootloader.cpp
+++ b/hal/src/stm32f2xx/bootloader.cpp
@@ -29,11 +29,13 @@ extern "C" const unsigned char BOOTLOADER_IMAGE[];
 bool bootloader_requires_update()
 {
     const uint32_t VERSION_OFFSET = 0x184+10;
+    const unsigned BOOTLOADER_0_7_0 = 13; // Module version of the bootloader shipped with 0.7.0
 
     uint16_t current_version = *(uint16_t*)(0x8000000+VERSION_OFFSET);
     uint16_t available_version = *(uint16_t*)(BOOTLOADER_IMAGE+VERSION_OFFSET);
 
-    bool requires_update = current_version<available_version;
+    // Downgrading from 0.7.0 requires a bootloader downgrade
+    bool requires_update = (current_version < available_version || current_version >= BOOTLOADER_0_7_0);
     return requires_update;
 }
 

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -249,7 +249,7 @@ void HAL_Core_Config(void)
     // where WICED isn't ready for a SysTick until after main() has been called to
     // fully intialize the RTOS.
     HAL_Core_Setup_override_interrupts();
-    
+
 #if MODULAR_FIRMWARE
     // write protect system module parts if not already protected
     FLASH_WriteProtectMemory(FLASH_INTERNAL, CORE_FW_ADDRESS, USER_FIRMWARE_IMAGE_LOCATION - CORE_FW_ADDRESS, true);
@@ -278,7 +278,9 @@ void HAL_Core_Setup(void) {
 
     HAL_Core_Setup_finalize();
 
-    bootloader_update_if_needed();
+    if (bootloader_update_if_needed()) {
+        HAL_Core_System_Reset();
+    }
     HAL_Bootloader_Lock(true);
 
 #if !defined(MODULAR_FIRMWARE)
@@ -443,7 +445,7 @@ void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long
          * - To wake up from the Stop mode with an RTC alarm event, it is necessary to:
          * - Configure the EXTI Line 17 to be sensitive to rising edges (Interrupt
          * or Event modes) using the EXTI_Init() function.
-         * 
+         *
          */
         HAL_RTC_Cancel_UnixAlarm();
         HAL_RTC_Set_UnixAlarm((time_t) seconds);


### PR DESCRIPTION
### Problem

When downgrading from 0.7.0 to 0.5.x firmware, the bootloader needs to be downgraded along with other system modules (see [Release notes](https://github.com/spark/firmware/releases/tag/v0.7.0-rc.3)). This PR simplifies the procedure by making the system automatically downgrade the bootloader if necessary.

### Steps to Test

Flash 0.7.0 firmware binaries (including bootloader) to a device, and ensure that the system can be downgraded to 0.5.x following the regular downgrade procedure.

### References

- [CH8765]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)