### PR TITLE
Photon/P1: adds system-part2 v0.7.0-rc.4 as a dependency of system-part1

### DIFF
--- a/modules/shared/system_module_version.mk
+++ b/modules/shared/system_module_version.mk
@@ -4,6 +4,18 @@ SYSTEM_PART1_MODULE_VERSION ?= 203
 SYSTEM_PART2_MODULE_VERSION ?= 203
 SYSTEM_PART3_MODULE_VERSION ?= 203
 
+RELEASE_080_MODULE_VERSION_BASE ?= 300
+RELEASE_070_RC4_MODULE_VERSION ?= 203
+
+ifneq (,$(filter $(PLATFORM_ID),6 8))
+ifeq ($(shell test $(SYSTEM_PART2_MODULE_VERSION) -ge $(RELEASE_080_MODULE_VERSION_BASE); echo $$?),0)
+# If this is >= 0.8.x release, Photon and P1 system-part1
+# needs to have a dependency on system-part2 of at least 0.7.0-rc.4
+# in order not to brick the device during OTA or Ymodem upgrade
+SYSTEM_PART1_MODULE_DEPENDENCY ?= ${MODULE_FUNCTION_SYSTEM_PART},2,${RELEASE_070_RC4_MODULE_VERSION}
+endif
+endif
+
 # Bump by 1 if Tinker has been updated
 USER_PART_MODULE_VERSION ?= 5
 


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

Due to the introduction of #1421, we will need to have an intermediate release that will enable OTA/Ymodem upgrades to the system firmware with WiFi firmware compression (0.8.0-rc.1). The support for this has been included into 0.7.0-rc.4 (#1420). When upgrading from < 0.7.0-rc.4 right now, the device will be stuck in hardfault state, immediately after system-part1 is flashed.

### Solution

In order to avoid that, 0.8.0-rc.1 system-part1 needs to have a dependency on 0.7.0-rc.4 system-part2.

### Steps to Test

1. Have < 0.7.0-rc.4 system firmware running on the device
2. Make sure `SYSTEM_PART1_MODULE_VERSION`, `SYSTEM_PART2_MODULE_VERSION`, `SYSTEM_PART3_MODULE_VERSION` in `system_module_version.mk` are >= 0.8.0-rc.1 (300) and build the firmware
3. Flash `system-part1.bin` from step #2
4. Verify that the device is running normally and provided system-part1 has not been applied
5. Upgrade system firmware running on the device to 0.7.0-rc.4
6. Flash `system-part1.bin` from step #2
7. Verify that the device is running normally and provided system-part1 module has been applied

### Example App

N/A

### References

- #1421 
- #1420
- [CH8759]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
