### PR TITLE
Compatibility net:rssi diagnostic source

### DIFF
--- a/services/inc/diagnostics.h
+++ b/services/inc/diagnostics.h
@@ -39,6 +39,7 @@ constexpr const char* DIAG_NAME_NETWORK_IPV4_ADDRESS = "net:ip:addr";
 constexpr const char* DIAG_NAME_NETWORK_IPV4_GATEWAY = "net.ip:gw";
 constexpr const char* DIAG_NAME_NETWORK_FLAGS = "net:flags";
 constexpr const char* DIAG_NAME_NETWORK_COUNTRY_CODE = "net:cntry";
+constexpr const char* DIAG_NAME_NETWORK_RSSI = "net:rssi";
 constexpr const char* DIAG_NAME_NETWORK_SIGNAL_STRENGTH = "net:sigstr";
 constexpr const char* DIAG_NAME_NETWORK_SIGNAL_STRENGTH_VALUE = "net:sigstrv";
 constexpr const char* DIAG_NAME_NETWORK_SIGNAL_QUALITY = "net:sigqual";
@@ -73,7 +74,8 @@ typedef enum diag_id {
     DIAG_ID_NETWORK_IPV4_GATEWAY = 16, // net.ip:gw
     DIAG_ID_NETWORK_FLAGS = 17, // net:flags
     DIAG_ID_NETWORK_COUNTRY_CODE = 18, // net:cntry
-    DIAG_ID_NETWORK_SIGNAL_STRENGTH_VALUE = 19, // net:sigstrv
+    DIAG_ID_NETWORK_RSSI = 19, // net:rssi
+    DIAG_ID_NETWORK_SIGNAL_STRENGTH_VALUE = 37, // net:sigstrv
     DIAG_ID_NETWORK_SIGNAL_STRENGTH = 33, // net:sigstr
     DIAG_ID_NETWORK_SIGNAL_QUALITY = 34, // net:sigqual
     DIAG_ID_NETWORK_SIGNAL_QUALITY_VALUE = 35, // net:sigqualv

--- a/system/src/system_network.cpp
+++ b/system/src/system_network.cpp
@@ -124,6 +124,30 @@ public:
     }
 };
 
+class NetworkRssiDiagnosticData: public AbstractIntegerDiagnosticData {
+public:
+    NetworkRssiDiagnosticData() :
+            AbstractIntegerDiagnosticData(DIAG_ID_NETWORK_RSSI, DIAG_NAME_NETWORK_RSSI) {
+    }
+
+    virtual int get(IntType& val) {
+        const Signal* sig = s_signalCache.getSignal();
+        if (sig == nullptr) {
+            return SYSTEM_ERROR_NOT_SUPPORTED;
+        }
+
+        if (sig->getStrength() < 0) {
+            return SYSTEM_ERROR_UNKNOWN;
+        }
+
+        // Convert to signed Q8.8
+        FixedPointSQ<8, 8> str(sig->getStrengthValue());
+        val = str;
+
+        return SYSTEM_ERROR_NONE;
+    }
+};
+
 class SignalStrengthValueDiagnosticData: public AbstractIntegerDiagnosticData {
 public:
     SignalStrengthValueDiagnosticData() :
@@ -219,6 +243,9 @@ SignalStrengthValueDiagnosticData g_signalStrengthValueDiagData;
 SignalQualityDiagnosticData g_signalQualityDiagData;
 SignalQualityValueDiagnosticData g_signalQualityValueDiagData;
 NetworkAccessTechnologyDiagnosticData g_networkAccessTechnologyDiagData;
+//
+NetworkRssiDiagnosticData g_networkRssiDiagData;
+//
 
 } // namespace
 

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -347,7 +347,7 @@ void PowerManager::handlePossibleFaultLoop() {
 }
 
 void PowerManager::logStat(uint8_t stat, uint8_t fault) {
-#if defined(DEBUG_BUILD)
+#if defined(DEBUG_BUILD) && 0
   uint8_t vbus_stat = stat >> 6; // 0 – Unknown (no input, or DPDM detection incomplete), 1 – USB host, 2 – Adapter port, 3 – OTG
   uint8_t chrg_stat = (stat >> 4) & 0x03; // 0 – Not Charging, 1 – Pre-charge (<VBATLOWV), 2 – Fast Charging, 3 – Charge Termination Done
   bool dpm_stat = stat & 0x08;   // 0 – Not DPM, 1 – VINDPM or IINDPM


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

N/A

### Solution

- Brings back `net:rssi` diagnostic source
- Changes signal strength value diagnostic source id to 37
- Small Electron power management fix disabling some debug logs that might flood the log output under certain conditions

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
