### PR TITLE
Remove dependency check in bootloader (0.7.x)

### DIFF
--- a/bootloader/src/photon/bootloader_dct.c
+++ b/bootloader/src/photon/bootloader_dct.c
@@ -49,7 +49,7 @@ static void init_dct_functions() {
     // At the time of writing, part2 contained a complete DCT implementation. Same time, it's easy to
     // introduce an additional dependency during development, so we require part1 to be consistent as well
     const module_info_t* part1 = get_module(MODULE_FUNCTION_SYSTEM_PART, 1, part2->dependency.module_version);
-    if (!part1 || part1->dependency.module_function != MODULE_FUNCTION_NONE) {
+    if (!part1) {
         return;
     }
     // Get addresses of the DCT functions

--- a/modules/shared/system_module_version.mk
+++ b/modules/shared/system_module_version.mk
@@ -10,4 +10,4 @@ USER_PART_MODULE_VERSION ?= 5
 # Skip to next 100 every v0.x.0 release (e.g. 11 for v0.6.2 to 100 for v0.7.0-rc.1),
 # but only if the bootloader has changed since the last v0.x.0 release.
 # Bump by 1 for every updated bootloader image for a release with the same v0.x.* base.
-BOOTLOADER_VERSION ?= 100
+BOOTLOADER_VERSION ?= 101


### PR DESCRIPTION
### Problem

Starting with 0.8.0-rc.1 firmware, part1 on Photon has a dependency on part2 of a specific minimum version. The bootloader doesn't expect that part1 can have any dependencies and fails to import DCT functions, making it impossible to access the DCT when the device is in DFU mode.

### Solution

Remove the failing dependency check from the bootloader on Photon. The fix requires making an intermediate release (0.7.0-rc.5).

### Steps to Test

Prepare 3 sets of the firmware binaries:

- 0.7.0-rc.4 (`release/v0.7.0-rc.4` branch).
- 0.7.0-rc.5 (`fix/bootloader_dep_check_0.7.x` branch). Make sure to set [the module versions](https://github.com/spark/firmware/blob/fix/bootloader_dep_check_0.7.x/modules/shared/system_module_version.mk#L3) to 204.
- 0.8.0-rc.1 (`fix/bootloader_dep_check_0.8.x` branch).

Test steps:

1. Flash 0.7.0-rc.4 binaries (including bootloader) to a Photon device.
2. Try to update the firmware to 0.8.0-rc.1 OTA. The attempt to flash part1 should fail (an intermediate update to 0.7.0-rc.5 is required).
3. Update the firmware to 0.7.0-rc.5 OTA. The device should boot into safe mode due to unmet dependency on the new bootloader. Flash 0.7.0-rc.5 bootloader OTA.
4. Update the firmware to 0.8.0-rc.1.
5. Check that DCT operations in DFU mode work as expected (e.g. by invoking `particle keys doctor`).

### References

- 0.8.x fixes: https://github.com/spark/firmware/pull/1434
- [CH9466]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
