### PR TITLE
Fix error handling in the data usage API (Electron)

### DIFF
--- a/wiring/src/spark_wiring_cellular.cpp
+++ b/wiring/src/spark_wiring_cellular.cpp
@@ -52,15 +52,15 @@ namespace spark {
 
     bool CellularClass::getDataUsage(CellularData &data_get) {
         if (cellular_data_usage_get(&data_hal, NULL) != 0) {
-            data_get.cid = data_hal.cid; // data_hal.cid will indicate -1
             data_get.ok = false; // dataUsage object was not updated
+        } else {
+            data_get.tx_session = data_hal.tx_session;
+            data_get.rx_session = data_hal.rx_session;
+            data_get.tx_total = data_hal.tx_total;
+            data_get.rx_total = data_hal.rx_total;
+            data_get.ok = true;
         }
-        data_get.cid = data_hal.cid;
-        data_get.tx_session = data_hal.tx_session;
-        data_get.rx_session = data_hal.rx_session;
-        data_get.tx_total = data_hal.tx_total;
-        data_get.rx_total = data_hal.rx_total;
-        data_get.ok = true;
+        data_get.cid = data_hal.cid; // data_hal.cid will indicate -1 in case of an error
         return data_get.ok;
     }
 
@@ -70,11 +70,11 @@ namespace spark {
         data_hal.tx_total = data_set.tx_total;
         data_hal.rx_total = data_set.rx_total;
         if (cellular_data_usage_set(&data_hal, NULL) != 0) {
-            data_set.cid = data_hal.cid; // data_hal.cid will indicate -1
             data_set.ok = false; // dataUsage object was not updated
+        } else {
+            data_set.ok = true;
         }
         data_set.cid = data_hal.cid; // update, in case CID changed
-        data_set.ok = true;
         return data_set.ok;
     }
 


### PR DESCRIPTION
### Problem

This PR makes `Cellular::getDataUsage()` and `Cellular::setDataUsage()` return `false` if the data usage counters cannot be retrieved or updated (e.g. if the network is turned off).

Note: https://github.com/spark/firmware/issues/1171 reports a similar problem with `Cellular::resetDataUsage()`, but I wasn't able to reproduce it. 

### Example App

Below is the test application that can be used to check the data usage under various scenarios:

```c
#include "application.h"

SYSTEM_MODE(MANUAL)

namespace {

const Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

CellularData dataUsage;

void logDataUsage() {
    Log.info("ok: %s; cid: %d; tx_session: %d; rx_session: %d; tx_total: %d; rx_total: %d",
            (dataUsage.ok ? "true" : "false"), dataUsage.cid, dataUsage.tx_session, dataUsage.rx_session,
            dataUsage.tx_total, dataUsage.rx_total);
}

void getDataUsage() {
    Log.info("Getting data usage");
    if (!Cellular.getDataUsage(dataUsage)) {
        Log.error("Cellular.getDataUsage() failed");
    }
    logDataUsage();
}

void setDataUsage() {
    Log.info("Setting data usage");
    if (!Cellular.setDataUsage(dataUsage)) {
        Log.error("Cellular.setDataUsage() failed");
    }
    logDataUsage();
}

void resetDataUsage() {
    Log.info("Resetting data usage");
    if (Cellular.resetDataUsage()) {
        getDataUsage();
    } else {
        Log.error("Cellular.resetDataUsage() failed");
    }
}

void off() {
    Log.info("Turning network off");
    Cellular.off();
    Log.info("Network is off");
    delay(1000);
    getDataUsage();
}

void connect() {
    Log.info("Connecting to cloud");
    Particle.connect();
    waitUntil(Particle.connected);
    Log.info("Connected to cloud");
    delay(1000);
    getDataUsage();
}

void publish() {
    Log.info("Publishing event");
    bool done = false;
    Particle.publish("test", PRIVATE | WITH_ACK).onSuccess([&done](bool) {
        Log.info("Received ACK");
        done = true;
    }).onError([&done](Error) {
        done = true;
    });
    while (!done) {
        Particle.process();
    }
    delay(1000);
    getDataUsage();
}

void test() {
    Log.print("======== Basic test\r\n");
    off();
    connect();
    publish();
    off();
    connect();
    publish();

    Log.print("======== Setting data usage\r\n");
    dataUsage.tx_session += 100000;
    dataUsage.rx_session += 100000;
    dataUsage.tx_total += 100000;
    dataUsage.rx_total += 100000;
    setDataUsage();
    publish();

    Log.print("======== Resetting data usage\r\n");
    resetDataUsage();
    publish();

    Log.print("======== Setting data usage when network is off\r\n");
    off();
    setDataUsage();

    Log.print("======== Resetting data usage when network is off\r\n");
    resetDataUsage();
}

} // namespace

void setup() {
    test();
}

void loop() {
}
```

### References

- [CH9469]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)