### PR TITLE
USB serial number descriptor should report device ID in lower case (0.7.x)

### DIFF
--- a/bootloader/src/stm32f2xx/usbd_desc.c
+++ b/bootloader/src/stm32f2xx/usbd_desc.c
@@ -185,7 +185,7 @@ uint8_t *  USBD_USR_SerialStrDescriptor( uint8_t speed , uint16_t *length)
     char deviceIdHex[sizeof(deviceId) * 2 + 1] = {0};
     unsigned deviceIdLen = 0;
     deviceIdLen = HAL_device_ID(deviceId, sizeof(deviceId));
-    bytes2hexbuf(deviceId, deviceIdLen, deviceIdHex);
+    bytes2hexbuf_lower_case(deviceId, deviceIdLen, deviceIdHex);
     USBD_GetString (deviceIdHex, USBD_StrDesc, length);
     return USBD_StrDesc;
 }

--- a/hal/src/stm32f2xx/usbd_desc_stm32f2xx.c
+++ b/hal/src/stm32f2xx/usbd_desc_stm32f2xx.c
@@ -162,7 +162,7 @@ uint8_t *  USBD_USR_SerialStrDescriptor( uint8_t speed , uint16_t *length)
     char deviceIdHex[sizeof(deviceId) * 2 + 1] = {0};
     unsigned deviceIdLen = 0;
     deviceIdLen = HAL_device_ID(deviceId, sizeof(deviceId));
-    bytes2hexbuf(deviceId, deviceIdLen, deviceIdHex);
+    bytes2hexbuf_lower_case(deviceId, deviceIdLen, deviceIdHex);
     USBD_GetString (deviceIdHex, USBD_StrDesc, length);
     return USBD_StrDesc;
 }

--- a/services/inc/bytes2hexbuf.h
+++ b/services/inc/bytes2hexbuf.h
@@ -20,8 +20,17 @@
 
 static inline char ascii_nibble(uint8_t nibble) {
     char hex_digit = nibble + 48;
-    if (57 < hex_digit)
+    if (57 < hex_digit) {
         hex_digit += 7;
+    }
+    return hex_digit;
+}
+
+static inline char ascii_nibble_lower_case(uint8_t nibble) {
+    char hex_digit = nibble + 48;
+    if (57 < hex_digit) {
+        hex_digit += 39;
+    }
     return hex_digit;
 }
 
@@ -31,17 +40,32 @@ static inline char* concat_nibble(char* p, uint8_t nibble)
     return p;
 }
 
+static inline char* concat_nibble_lower_case(char* p, uint8_t nibble)
+{
+    *p++ = ascii_nibble_lower_case(nibble);
+    return p;
+}
+
 static inline char* bytes2hexbuf(const uint8_t* buf, unsigned len, char* out)
 {
     unsigned i;
     char* result = out;
     for (i = 0; i < len; ++i)
     {
-        concat_nibble(out, (buf[i] >> 4));
-        out++;
-        concat_nibble(out, (buf[i] & 0xF));
-        out++;
+        out = concat_nibble(out, (buf[i] >> 4));
+        out = concat_nibble(out, (buf[i] & 0xF));
     }
     return result;
 }
 
+static inline char* bytes2hexbuf_lower_case(const uint8_t* buf, unsigned len, char* out)
+{
+    unsigned i;
+    char* result = out;
+    for (i = 0; i < len; ++i)
+    {
+        out = concat_nibble_lower_case(out, (buf[i] >> 4));
+        out = concat_nibble_lower_case(out, (buf[i] & 0xF));
+    }
+    return result;
+}

--- a/user/tests/unit/service_bytes2hex.cpp
+++ b/user/tests/unit/service_bytes2hex.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 
 #include "bytes2hexbuf.h"
+#include <cstring>
 
 TEST_CASE("bytes2hex_lower_") {
 	SECTION("bytes are converted to lowercase hex") {

--- a/user/tests/unit/service_bytes2hex.cpp
+++ b/user/tests/unit/service_bytes2hex.cpp
@@ -1,0 +1,14 @@
+#include "catch.hpp"
+
+#include "bytes2hexbuf.h"
+
+TEST_CASE("bytes2hex_lower_") {
+	SECTION("bytes are converted to lowercase hex") {
+		uint8_t bytes[]  = { 0x01, 0xFF, 0xA0, 0xb9 };
+		char out[4*2+1];
+		char* result = bytes2hexbuf_lower_case(bytes, 4, out);
+		REQUIRE(out[8]==0);
+		REQUIRE(!strcmp(out, "01ffa0b9"));
+		REQUIRE(result==out);
+	}
+}


### PR DESCRIPTION
### Problem

Fixes https://github.com/spark/firmware/issues/1432.

Note: There's no need to increment the bootloader version, since it has already been done in https://github.com/spark/firmware/pull/1433.

### Steps to Test

Ensure that the USB serial descriptor reports the device ID in all lower case in both the regular and DFU device modes.

### References

- [CH9628]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
