### PR TITLE
USB serial number descriptor should report device ID in lower case (0.8.x)

### DIFF
--- a/bootloader/src/stm32f2xx/usbd_desc.c
+++ b/bootloader/src/stm32f2xx/usbd_desc.c
@@ -185,7 +185,7 @@ uint8_t *  USBD_USR_SerialStrDescriptor( uint8_t speed , uint16_t *length)
     char deviceIdHex[sizeof(deviceId) * 2 + 1] = {0};
     unsigned deviceIdLen = 0;
     deviceIdLen = HAL_device_ID(deviceId, sizeof(deviceId));
-    bytes2hexbuf(deviceId, deviceIdLen, deviceIdHex);
+    bytes2hexbuf_lower_case(deviceId, deviceIdLen, deviceIdHex);
     USBD_GetString (deviceIdHex, USBD_StrDesc, length);
     return USBD_StrDesc;
 }

--- a/hal/src/stm32f2xx/usbd_desc_stm32f2xx.c
+++ b/hal/src/stm32f2xx/usbd_desc_stm32f2xx.c
@@ -162,7 +162,7 @@ uint8_t *  USBD_USR_SerialStrDescriptor( uint8_t speed , uint16_t *length)
     char deviceIdHex[sizeof(deviceId) * 2 + 1] = {0};
     unsigned deviceIdLen = 0;
     deviceIdLen = HAL_device_ID(deviceId, sizeof(deviceId));
-    bytes2hexbuf(deviceId, deviceIdLen, deviceIdHex);
+    bytes2hexbuf_lower_case(deviceId, deviceIdLen, deviceIdHex);
     USBD_GetString (deviceIdHex, USBD_StrDesc, length);
     return USBD_StrDesc;
 }

--- a/services/inc/bytes2hexbuf.h
+++ b/services/inc/bytes2hexbuf.h
@@ -20,8 +20,17 @@
 
 static inline char ascii_nibble(uint8_t nibble) {
     char hex_digit = nibble + 48;
-    if (57 < hex_digit)
+    if (57 < hex_digit) {
         hex_digit += 7;
+    }
+    return hex_digit;
+}
+
+static inline char ascii_nibble_lower_case(uint8_t nibble) {
+    char hex_digit = nibble + 48;
+    if (57 < hex_digit) {
+        hex_digit += 39;
+    }
     return hex_digit;
 }
 
@@ -31,17 +40,32 @@ static inline char* concat_nibble(char* p, uint8_t nibble)
     return p;
 }
 
+static inline char* concat_nibble_lower_case(char* p, uint8_t nibble)
+{
+    *p++ = ascii_nibble_lower_case(nibble);
+    return p;
+}
+
 static inline char* bytes2hexbuf(const uint8_t* buf, unsigned len, char* out)
 {
     unsigned i;
     char* result = out;
     for (i = 0; i < len; ++i)
     {
-        concat_nibble(out, (buf[i] >> 4));
-        out++;
-        concat_nibble(out, (buf[i] & 0xF));
-        out++;
+        out = concat_nibble(out, (buf[i] >> 4));
+        out = concat_nibble(out, (buf[i] & 0xF));
     }
     return result;
 }
 
+static inline char* bytes2hexbuf_lower_case(const uint8_t* buf, unsigned len, char* out)
+{
+    unsigned i;
+    char* result = out;
+    for (i = 0; i < len; ++i)
+    {
+        out = concat_nibble_lower_case(out, (buf[i] >> 4));
+        out = concat_nibble_lower_case(out, (buf[i] & 0xF));
+    }
+    return result;
+}


### PR DESCRIPTION
### Problem

Fixes https://github.com/spark/firmware/issues/1432.

### Steps to Test

Ensure that the USB serial descriptor reports the device ID in all lower case in both the regular and DFU device modes.

### References

- The same fix for 0.7.x release: https://github.com/spark/firmware/pull/1436
- [CH9628]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
