### PR TITLE
Feature/go faster stripes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,20 @@ sudo: required
 services:
   - docker
 install:
-  - 'if [ ! -z "$DOCKER_HUB_EMAIL" ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD; fi'
-  - wget https://api.github.com/repos/spark/firmware-buildpack-builder/tarball/feature/go_faster_stripes -O - | tar -xz -C ../ --strip-components 1
-  - ../scripts/build-image
+  - scripts/docker-hub-login
+  - scripts/fetch-buildpack
+  - buildpack/scripts/build-image
 
 script:
-  - ../scripts/run-tests-in-container
+  - buildpak/scripts/run-tests-in-container
+  - buildpack/scripts/push-image
+
+  # - 'if [ ! -z "$DOCKER_HUB_EMAIL" ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD; fi'
+  # - wget https://api.github.com/repos/spark/firmware-buildpack-builder/tarball/feature/go_faster_stripes -O - | tar -xz -C ../ --strip-components 1
+  # - ../scripts/build-image
+
+#script:
+  # - ../scripts/run-tests-in-container
   # - 'if [ "${UNIT_TEST}" = "y" ]; then ./ci/unit_tests.sh; else cd $DIR && make -s clean all DEBUG_BUILD=$DEBUG_BUILD PLATFORM=$PLATFORM COMPILE_LTO=$COMPILE_LTO TEST=$TEST SPARK_CLOUD=$SPARK_CLOUD APP=$APP; fi'
   # TODO - ./ci/integration_tests.sh
   # TODO  - ./ci/test_memory_available_with_real_core.sh
@@ -15,28 +23,22 @@ script:
 #after_success: ./ci/update-gh-pages.sh
 
 
-jobs:
-  include:
-    - script: ../scripts/run-tests-in-container
-  # - 'if [ "${UNIT_TEST}" = "y" ]; then ./ci/unit_tests.sh; else cd $DIR && make -s clean all DEBUG_BUILD=$DEBUG_BUILD PLATFORM=$PLATFORM COMPILE_LTO=$COMPILE_LTO TEST=$TEST SPARK_CLOUD=$SPARK_CLOUD APP=$APP; fi'
-  # TODO - ./ci/integration_tests.sh
-  # TODO  - ./ci/test_memory_available_with_real_core.sh
-     - stage: deploy
-       script: ../scripts/push-image
-
 stages:
+  - prep
+  - build_image
+  - test
   - name: deploy
-    if: tag =~ +*
+    if: tag IS present
 
 env:
   matrix:
-      BUILD_PLATFORM=unit-test
-      BUILD_PLATFORM=core
-      BUILD_PLATFORM=photon
-      BUILD_PLATFORM=p1
-      BUILD_PLATFORM=electron
-      BUILD_PLATFORM=newhal
-      BUILD_PLATFORM=gcc
+    - BUILD_PLATFORM=unit-test photon
+        # BUILD_PLATFORM=core
+        # BUILD_PLATFORM=photon
+        # BUILD_PLATFORM=p1
+    - BUILD_PLATFORM=electron
+        # BUILD_PLATFORM=newhal
+        # BUILD_PLATFORM=gcc
 
   # matrix:
   # - UNIT_TEST=y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 sudo: required
+
+# setting the language to bash speeds up builds compared to the default since there is no ruby installation
 language: bash
+
+cache:
+  ccache: true
+  directories:
+    $HOME/.ci/boost
 
 services:
   - docker
@@ -25,24 +32,12 @@ script:
 
 #after_success: ./ci/update-gh-pages.sh
 
-
-stages:
-  - prep
-  - build_image
-  - test
-  - name: deploy
-    if: tag IS present
-
 env:
   matrix:
-    - BUILD_PLATFORM=unit-test
-    - BUILD_PLATFORM=photon
-        # BUILD_PLATFORM=core
-        # BUILD_PLATFORM=photon
-        # BUILD_PLATFORM=p1
+    - BUILD_PLATFORM=unit-test gcc
+    - BUILD_PLATFORM=photon p1
+    - BUILD_PLATFORM=core newhal
     - BUILD_PLATFORM=electron
-        # BUILD_PLATFORM=newhal
-    - BUILD_PLATFORM=gcc
 
   # matrix:
   # - UNIT_TEST=y

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - buildpack/scripts/build-image
 
 script:
-  - buildpak/scripts/run-tests-in-container
+  - buildpack/scripts/run-tests-in-container
   - buildpack/scripts/push-image
 
   # - 'if [ ! -z "$DOCKER_HUB_EMAIL" ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD; fi'
@@ -32,13 +32,14 @@ stages:
 
 env:
   matrix:
-    - BUILD_PLATFORM=unit-test photon
+    - BUILD_PLATFORM=unit-test
+    - BUILD_PLATFORM=photon
         # BUILD_PLATFORM=core
         # BUILD_PLATFORM=photon
         # BUILD_PLATFORM=p1
     - BUILD_PLATFORM=electron
         # BUILD_PLATFORM=newhal
-        # BUILD_PLATFORM=gcc
+    - BUILD_PLATFORM=gcc
 
   # matrix:
   # - UNIT_TEST=y

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 install:
   - 'if [ ! -z "$DOCKER_HUB_EMAIL" ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD; fi'
-  - wget https://github.com/spark/firmware-buildpack-builder/archive/master.tar.gz -O - | tar -xz -C ../ --strip-components 1
+  - wget https://api.github.com/repos/spark/firmware-buildpack-builder/tarball/feature/go_faster_stripes -O - | tar -xz -C ../ --strip-components 1
   - ../scripts/build-image
 
 script:
@@ -13,9 +13,31 @@ script:
   # TODO  - ./ci/test_memory_available_with_real_core.sh
 
 #after_success: ./ci/update-gh-pages.sh
-after_success: ../scripts/push-image
+
+
+jobs:
+  include:
+    - script: ../scripts/run-tests-in-container
+  # - 'if [ "${UNIT_TEST}" = "y" ]; then ./ci/unit_tests.sh; else cd $DIR && make -s clean all DEBUG_BUILD=$DEBUG_BUILD PLATFORM=$PLATFORM COMPILE_LTO=$COMPILE_LTO TEST=$TEST SPARK_CLOUD=$SPARK_CLOUD APP=$APP; fi'
+  # TODO - ./ci/integration_tests.sh
+  # TODO  - ./ci/test_memory_available_with_real_core.sh
+     - stage: deploy
+       script: ../scripts/push-image
+
+stages:
+  - name: deploy
+    if: tag =~ +*
 
 env:
+  matrix:
+      BUILD_PLATFORM=unit-test
+      BUILD_PLATFORM=core
+      BUILD_PLATFORM=photon
+      BUILD_PLATFORM=p1
+      BUILD_PLATFORM=electron
+      BUILD_PLATFORM=newhal
+      BUILD_PLATFORM=gcc
+
   # matrix:
   # - UNIT_TEST=y
   # - DIR=main    TEST=wiring/api        PLATFORM=photon COMPILE_LTO=n

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: required
+language: bash
+
 services:
   - docker
+
 install:
   - scripts/docker-hub-login
   - scripts/fetch-buildpack

--- a/build/module.mk
+++ b/build/module.mk
@@ -222,14 +222,14 @@ $(TARGET_BASE).elf : build_dependencies $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)
 	$(call echo,'Building target: $@')
 	$(call echo,'Invoking: ARM GCC C++ Linker')
 	$(VERBOSE)$(MKDIR) $(dir $@)
-	$(VERBOSE)$(CPP) $(CFLAGS) $(ALLOBJ) --output $@ $(LDFLAGS)
+	$(VERBOSE)$(CCACHE) $(CPP) $(CFLAGS) $(ALLOBJ) --output $@ $(LDFLAGS)
 	$(call echo,)
 
 $(TARGET_BASE)$(EXECUTABLE_EXTENSION) : build_dependencies $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)
 	$(call echo,'Building target: $@')
 	$(call echo,'Invoking: GCC C++ Linker')
 	$(VERBOSE)$(MKDIR) $(dir $@)
-	$(VERBOSE)$(CPP) $(CFLAGS) $(ALLOBJ) --output $@ $(LDFLAGS)
+	$(VERBOSE)$(CCACHE) $(CPP) $(CFLAGS) $(ALLOBJ) --output $@ $(LDFLAGS)
 	$(call echo,)
 
 
@@ -238,14 +238,14 @@ $(TARGET_BASE).a : $(ALLOBJ)
 	$(call echo,'Building target: $@')
 	$(call echo,'Invoking: ARM GCC Archiver')
 	$(VERBOSE)$(MKDIR) $(dir $@)
-	$(VERBOSE)$(AR) -cr $@ $^
+	$(VERBOSE)$(CCACHE) $(AR) -cr $@ $^
 	$(call echo,)
 
 define build_C_file
 	$(call echo,'Building c file: $<')
 	$(call echo,'Invoking: ARM GCC C Compiler')
 	$(VERBOSE)$(MKDIR) $(dir $@)
-	$(VERBOSE)$(CC) $(CFLAGS) $(CONLYFLAGS) -c -o $@ $<
+	$(VERBOSE)$(CCACHE) $(CC) $(CFLAGS) $(CONLYFLAGS) -c -o $@ $<
 	$(call echo,)
 endef
 
@@ -253,7 +253,7 @@ define build_CPP_file
 	$(call echo,'Building cpp file: $<')
 	$(call echo,'Invoking: ARM GCC CPP Compiler')
 	$(VERBOSE)$(MKDIR) $(dir $@)
-	$(VERBOSE)$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+	$(VERBOSE)$(CCACHE) $(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 	$(call echo,)
 endef
 
@@ -283,7 +283,7 @@ $(BUILD_PATH)/%.o : $(COMMON_BUILD)/arm/%.S
 	$(call echo,'Building file: $<')
 	$(call echo,'Invoking: ARM GCC Assembler')
 	$(VERBOSE)$(MKDIR) $(dir $@)
-	$(VERBOSE)$(CC) $(ASFLAGS) -c -o $@ $<
+	$(VERBOSE)$(CCACHE) $(CC) $(ASFLAGS) -c -o $@ $<
 	$(call echo,)
 
 

--- a/ci/enumerate_build_matrix.sh
+++ b/ci/enumerate_build_matrix.sh
@@ -33,6 +33,9 @@ filterPlatform PLATFORM
 filterPlatform MODULAR_PLATFORM 
 filterPlatform PLATFORM_BOOTLOADER
 
+echo "runing matrix PLATFORM=$PLATFORM MODULAR_PLATFORM=$MODULAR_PLATFORM PLATFORM_BOOTLOADER=$PLATFORM_BOOTLOADER"
+
+
 # set current working dir
 cd main
 

--- a/ci/enumerate_build_matrix.sh
+++ b/ci/enumerate_build_matrix.sh
@@ -12,7 +12,7 @@ set -x # be noisy + log everything that is happening in the script
 
 function runmake()
 {
-	make -s  all $*
+	make -s clean all $*
 }
 
 MAKE=runmake
@@ -134,3 +134,5 @@ echo '-----------------------------------------------------------------------'
 $MAKE  PLATFORM="photon" COMPILE_LTO="n" MINIMAL=y
 	testcase
 fi
+
+checkFailures || exit 1

--- a/ci/enumerate_build_matrix.sh
+++ b/ci/enumerate_build_matrix.sh
@@ -6,17 +6,16 @@
 # Stops executing and returns exit 1 if any of them fail
 ############
 
+. ./ci/functions.sh
+
 set -x # be noisy + log everything that is happening in the script
 
 function runmake()
 {
-	make -s clean all $*
+	make -s  all $*
 }
 
 MAKE=runmake
-GREEN="\033[32m"
-RED="\033[31m"
-NO_COLOR="\033[0m"
 
 # define build matrix dimensions
 # "" means execute execute the $MAKE command without that var specified
@@ -25,39 +24,35 @@ PLATFORM=( core photon P1 electron )
 # P1 bootloader built with gcc 4.8.4 doesn't fit flash, disabling for now
 PLATFORM_BOOTLOADER=( core photon electron )
 SPARK_CLOUD=( y n )
-# TODO: Once FIRM-161 is fixed, change APP to this: APP=( "" tinker product_id_and_version )
-APP=( "" tinker )
+APP=( "" tinker product_id_and_version)
 TEST=( wiring/api wiring/no_fixture )
 
 MODULAR_PLATFORM=( photon P1 electron)
+
+filterPlatform PLATFORM 
+filterPlatform MODULAR_PLATFORM 
+filterPlatform PLATFORM_BOOTLOADER
 
 # set current working dir
 cd main
 
 # Newhal Build
+if platform newhal; then
 echo
 echo '-----------------------------------------------------------------------'
 $MAKE  PLATFORM="newhal" COMPILE_LTO="n"
 HAS_NO_SECTIONS=`echo $? | grep 'has no sections'`;
-if [[ ! -z HAS_NO_SECTIONS || "$?" -eq 0 ]]; then
-  echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-else
-  echo -e "$RED ✗ FAILED $NO_COLOR"
-  exit 1
+[[ ! -z HAS_NO_SECTIONS || "$?" -eq 0 ]]; 
+testcase
 fi
 
 # GCC Build
+if platform gcc; then
 echo
 echo '-----------------------------------------------------------------------'
 $MAKE  PLATFORM=gcc
-if [[ "$?" -eq 0 ]]; then
-  echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-else
-  echo -e "$RED ✗ FAILED $NO_COLOR"
-  exit 1
+testcase
 fi
-
-
 
 
 # COMPILE_LTO required on the Core for wiring/no_fixture to fit
@@ -68,12 +63,7 @@ do
     echo
     echo '-----------------------------------------------------------------------'
     $MAKE  PLATFORM="$p" COMPILE_LTO="n" TEST="$t"
-    if [[ "$?" -eq 0 ]]; then
-      echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-    else
-      echo -e "$RED ✗ FAILED $NO_COLOR"
-      exit 1
-    fi
+	testcase
   done
 done
 
@@ -93,30 +83,19 @@ do
         c=n
         if [[ "$p" = "core" ]]; then
            c=y
-           # skip debug build since it overflows
+	   # core debug build overflows at present
            if [[ "$db" = "y" ]]; then
                continue
-           fi
+        fi
         fi
         echo
         echo '-----------------------------------------------------------------------'
         if [[ "$app" = "" ]]; then
           $MAKE  DEBUG_BUILD="$db" PLATFORM="$p" COMPILE_LTO="$c" SPARK_CLOUD="$sc"
-          if [[ "$?" -eq 0 ]]; then
-            echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-          else
-            echo -e "$RED ✗ FAILED $NO_COLOR"
-            exit 1
-          fi
         else
           $MAKE  DEBUG_BUILD="$db" PLATFORM="$p" COMPILE_LTO="$c" SPARK_CLOUD="$sc" APP="$app"
-          if [[ "$?" -eq 0 ]]; then
-            echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-          else
-            echo -e "$RED ✗ FAILED $NO_COLOR"
-            exit 1
           fi
-        fi
+		testcase
       done
     done
   done
@@ -128,12 +107,7 @@ do
   echo
   echo '-----------------------------------------------------------------------'
   $MAKE PLATFORM="$p"
-  if [[ "$?" -eq 0 ]]; then
-      echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-    else
-      echo -e "$RED ✗ FAILED $NO_COLOR"
-      exit 1
-  fi
+  testcase
 done
 
 cd ../modules
@@ -146,22 +120,14 @@ do
     echo
     echo '-----------------------------------------------------------------------'
     $MAKE  DEBUG_BUILD="$db" PLATFORM="$p" COMPILE_LTO="n"
-    if [[ "$?" -eq 0 ]]; then
-      echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-    else
-      echo -e "$RED ✗ FAILED $NO_COLOR"
-      exit 1
-    fi
+	testcase
   done
 done
 
 # Photon minimal build
+if platform photon; then
 echo
 echo '-----------------------------------------------------------------------'
 $MAKE  PLATFORM="photon" COMPILE_LTO="n" MINIMAL=y
-if [[ "$?" -eq 0 ]]; then
-  echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
-else
-  echo -e "$RED ✗ FAILED $NO_COLOR"
-  exit 1
+	testcase
 fi

--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -3,12 +3,21 @@ GREEN="\033[32m"
 RED="\033[31m"
 NO_COLOR="\033[0m"
 
+function checkFailures {
+if [[ $HAS_FAILURES == 1 ]]; then
+   echo "Ruh roh. Failed tests."
+   return 1
+fi
+return 0
+}
+
 function testcase {
 	if [ $? -eq 0 ]; then
 	  echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
 	  return 0
 	else
 	  echo -e "$RED ✗ FAILED $NO_COLOR"
+	  export HAS_FAILURES=1
 	  return 1
 	fi
 }

--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -1,11 +1,59 @@
 
-function die() {
-   [[ -z "$1" ]] || echo "Error: $1"    
+GREEN="\033[32m"
+RED="\033[31m"
+NO_COLOR="\033[0m"
+
+function testcase {
+	if [ $? -eq 0 ]; then
+	  echo -e "$GREEN ✓ SUCCESS $NO_COLOR"
+	  return 0
+	else
+	  echo -e "$RED ✗ FAILED $NO_COLOR"
+	  return 1
+	fi
+}
+
+
+function contains {
+	loop=($1)
+	for i in "${loop[@]}"
+	do 
+		if [[ "$i" == "$2" ]] ; then
+       		return 0
+		fi
+	done
+	return 1
+}
+
+
+function emptyOrContains {
+  [[ "" == "$1" ]] || contains "$1" "$2"
+}
+
+function platform {
+	emptyOrContains "${BUILD_PLATFORM[*]}" "$1"
+}
+
+function filterPlatform {
+	eval 'array=${'${1}'[@]}'
+	eval "array=( $array )"
+	result=""
+	for i in "${array[@]}"; do
+		if platform $i; then			
+		    result="$result $i"
+		fi
+	done
+	# remove leading space
+	eval "$1=( ${result} )"
+}
+
+function die {
+   [[ -z "$1" ]] || echo "Error: $1"
    exit 1
 }
 
 # executes script in this shell passed as stdin
-function executeScript() {
+function executeScript {
    while read line; do
       eval $line
    done

--- a/ci/install_boost.sh
+++ b/ci/install_boost.sh
@@ -2,14 +2,10 @@ BOOST_VERSION=1_59_0
 
 # this was previously hardcoded to 1.59.0 in the path, replacing with a fast source
 #test -f boost_$BOOST_VERSION.tar.gz || wget --quiet http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_$BOOST_VERSION.tar.gz
-test -f boost_$BOOST_VERSION.tar.gz || wget --quiet https://s3.amazonaws.com/spark-assets/boost_1_59_0.tar.gz
 export BOOST_HOME=$HOME/.ci/boost
 export BOOST_ROOT=$BOOST_HOME/boost_$BOOST_VERSION
-mkdir -p $BOOST_HOME
-test -d $BOOST_ROOT || (
-   tar zxf boost_$BOOST_VERSION.tar.gz
-   mv boost_$BOOST_VERSION  $BOOST_HOME
-)
+mkdir -p $BOOST_ROOT
 test -d $BOOST_ROOT || ( echo "boost root $BOOST_ROOT not created." && exit 1)
+test -f $BOOST_ROOT/INSTALL || wget --quiet https://s3.amazonaws.com/spark-assets/boost_${BOOST_VERSION}.tar.gz -O - | tar -xz -C $BOOST_ROOT --strip-components 1 
 export DYLD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$DYLD_LIBRARY_PATH"
 export LD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$LD_LIBRARY_PATH"

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
+# ensure we are in the root
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
-source ./ci/install_boost.sh
-./ci/build_boost.sh &&
-./ci/unit_tests.sh &&
+
+. ./ci/functions.sh
+
+cmd=""
+
+if contains "${BUILD_PLATFORM[*]}" unit-test; then
+	( source ./ci/install_boost.sh
+	./ci/build_boost.sh &&
+	./ci/unit_tests.sh ) || die
+fi
+
 ./ci/enumerate_build_matrix.sh

--- a/scripts/docker-hub-login
+++ b/scripts/docker-hub-login
@@ -1,0 +1,1 @@
+if [ ! -z "$DOCKER_HUB_EMAIL" ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD; fi

--- a/scripts/fetch-buildpack
+++ b/scripts/fetch-buildpack
@@ -1,0 +1,1 @@
+mkdir buildpack && wget https://api.github.com/repos/spark/firmware-buildpack-builder/tarball/feature/go_faster_stripes -O - | tar -xz -C buildpack --strip-components 1

--- a/system/inc/system_power.h
+++ b/system/inc/system_power.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "system_tick_hal.h"
 #include "spark_wiring_diagnostics.h"
 
 namespace particle { namespace power {

--- a/user/applications/product_id_and_version/application.cpp
+++ b/user/applications/product_id_and_version/application.cpp
@@ -1,3 +1,5 @@
+#include "Particle.h"
+
 // To verify product creator macros work correctly.
 // These values get sent to the cloud on connection and help dashboard.particle.io do the right thing
 //


### PR DESCRIPTION
### Problem

The CI build is slower than a herd of snails travelling though peanut butter, taking around 50 minutes to complete.

### Solution

- Build multiple platforms in parallel
- Report all failed tests (not stop at the first, reducing the number of failed repeat builds)
- use Ccache ompiler
- cache the built Boost binaries

NB: For tagged builds, each individual platform docker image will be uploaded when the build for that platform succeeds, even when some of the others fail. This will be addressed in another PR. 

### Completeness


- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
