### PR TITLE
fuelgauge: removes lower 20%-0% state of charge mapping

### DIFF
--- a/wiring/src/spark_wiring_fuel.cpp
+++ b/wiring/src/spark_wiring_fuel.cpp
@@ -98,7 +98,7 @@ float FuelGauge::getNormalizedSoC() {
 
     const float magicError = 0.05f;
     const float maxCharge = (1.0f - (reference100PercentV - referenceMaxV)) - magicError;
-    const float minCharge = 0.2f; // 20%
+    const float minCharge = 0.0f; // 0%
 
     float normalized = (soc - minCharge) * (1.0f / (maxCharge - minCharge)) + 0.0f;
     // Clamp at [0.0, 1.0]


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

`FuelGauge.getNormalizedSoC()` currently maps 20% of physical state of charge to 0%. This artificial clamping should be removed for now to avoid any confusion when interpreting diagnostics information.

### References

- [CH9697]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
